### PR TITLE
WIP: Use Wasm struct to metadata to pass as argument to the j.l.Class

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,72 @@
+name: CI
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  test-suite-js:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        suffix: [2_13]
+        esVersion: [ES5_1, ES2021]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-java@v4
+        with:
+          distribution: 'temurin'
+          java-version: '21'
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+      - name: npm install
+        run: npm install
+      - name: helloworld${{ matrix.suffix }}/run
+        run: sbt 'set scalaJSLinkerConfig in testSuite.v${{ matrix.suffix }} ~= (_.withESFeatures(_.withESVersion(ESVersion.${{ matrix.esVersion }}))) ' \
+            helloworld${{ matrix.suffix }}/run
+      - name: testSuite${{ matrix.suffix }}/test
+        run: sbt 'set scalaJSLinkerConfig in testSuite.v${{ matrix.suffix }} ~= (_.withESFeatures(_.withESVersion(ESVersion.${{ matrix.esVersion }}))) ' \
+            testSuite${{ matrix.suffix }}/test
+      - name: testSuiteEx${{ matrix.suffix }}/test
+        run: sbt 'set scalaJSLinkerConfig in testSuite.v${{ matrix.suffix }} ~= (_.withESFeatures(_.withESVersion(ESVersion.${{ matrix.esVersion }}))) ' \
+            testSuiteEx${{ matrix.suffix }}/test
+
+  test-suite-webassembly:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        suffix: [2_12, 2_13]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-java@v4
+        with:
+          distribution: 'temurin'
+          java-version: '21'
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+      - name: npm install
+        run: npm install
+      - name: helloworld${{ matrix.suffix }}/run
+        run: sbt 'set Global/enableWasmEverywhere := true' helloworld${{ matrix.suffix }}/run
+      - name: testSuite${{ matrix.suffix }}/test
+        run: sbt 'set Global/enableWasmEverywhere := true' testSuite${{ matrix.suffix }}/test
+      - name: testSuiteEx${{ matrix.suffix }}/test
+        run: sbt 'set Global/enableWasmEverywhere := true' testSuiteEx${{ matrix.suffix }}/test
+  style:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-java@v4
+        with:
+          distribution: 'temurin'
+          java-version: '21'
+      - name: scalastyleCheck
+        run: sbt scalastyleCheck

--- a/examples/helloworld/src/main/scala/helloworld/HelloWorld.scala
+++ b/examples/helloworld/src/main/scala/helloworld/HelloWorld.scala
@@ -13,7 +13,18 @@ object HelloWorld {
   def main(args: Array[String]): Unit = {
     import js.DynamicImplicits.truthValue
 
-    ()
+    val name = "a".getClass().getName()
+    val isPrimitive = 1.getClass().isPrimitive()
+    val isArray = Array(1, 2).getClass().isArray()
+    val isInterface = 1.getClass().isPrimitive()
+    val isInstance = "a".getClass().isInstance(1)
+    val isAssignableFrom = classOf[CharSequence].isAssignableFrom(classOf[String])
+    println(name)
+    println(isPrimitive)
+    println(isArray)
+    println(isInterface)
+    println(isInstance)
+    println(isAssignableFrom)
 
     // if (linkingInfo.targetIsPureWasm) {
     //   println("WASI!")

--- a/examples/helloworld/src/main/scala/helloworld/HelloWorld.scala
+++ b/examples/helloworld/src/main/scala/helloworld/HelloWorld.scala
@@ -7,21 +7,30 @@ package helloworld
 
 import scala.scalajs.js
 import js.annotation._
+import scala.scalajs.runtime.linkingInfo
 
 object HelloWorld {
   def main(args: Array[String]): Unit = {
     import js.DynamicImplicits.truthValue
 
-    if (js.typeOf(js.Dynamic.global.document) != "undefined" &&
-        js.Dynamic.global.document &&
-        js.Dynamic.global.document.getElementById("playground")) {
-      sayHelloFromDOM()
-      sayHelloFromTypedDOM()
-      sayHelloFromJQuery()
-      sayHelloFromTypedJQuery()
-    } else {
-      println("Hello world!")
-    }
+    ()
+
+    // if (linkingInfo.targetIsPureWasm) {
+    //   println("WASI!")
+    // } else {
+    //   println("Wasm!")
+    // }
+
+    // if (js.typeOf(js.Dynamic.global.document) != "undefined" &&
+    //     js.Dynamic.global.document &&
+    //     js.Dynamic.global.document.getElementById("playground")) {
+    //   sayHelloFromDOM()
+    //   sayHelloFromTypedDOM()
+    //   sayHelloFromJQuery()
+    //   sayHelloFromTypedJQuery()
+    // } else {
+    //   println("Hello world!")
+    // }
   }
 
   def sayHelloFromDOM(): Unit = {

--- a/library/src/main/scala/scala/scalajs/LinkingInfo.scala
+++ b/library/src/main/scala/scala/scalajs/LinkingInfo.scala
@@ -258,6 +258,10 @@ object LinkingInfo {
   def isWebAssembly: Boolean =
     linkingInfo.isWebAssembly
 
+  @inline
+  def targetIsPureWasm: Boolean =
+    linkingInfo.targetIsPureWasm
+
   /** Constants for the value of `esVersion`. */
   object ESVersion {
     /** ECMAScrîpt 5.1. */

--- a/library/src/main/scala/scala/scalajs/runtime/LinkingInfo.scala
+++ b/library/src/main/scala/scala/scalajs/runtime/LinkingInfo.scala
@@ -43,6 +43,15 @@ sealed trait LinkingInfo extends js.Object {
    */
   val isWebAssembly: Boolean
 
+  /** Whether we are linking to pure WebAssembly.
+   *
+   *  When this property is `true`, the generated Wasm module should not
+   *  contain JavaScript interoperation.
+   *
+   *  TODO: maybe we should have an information whether we are linking to wasi preview 1 or 2?
+   */
+  val targetIsPureWasm: Boolean
+
   /** Whether we are linking in production mode. */
   val productionMode: Boolean
 

--- a/linker-interface/shared/src/main/scala/org/scalajs/linker/interface/StandardConfig.scala
+++ b/linker-interface/shared/src/main/scala/org/scalajs/linker/interface/StandardConfig.scala
@@ -86,7 +86,15 @@ final class StandardConfig private (
     /** The maximum number of (file) writes executed concurrently. */
     val maxConcurrentWrites: Int,
     /** If true, use the experimental WebAssembly backend. */
-    val experimentalUseWebAssembly: Boolean
+    val experimentalUseWebAssembly: Boolean,
+
+    /** Runtime target to use when compiling to WebAssembly.
+     *
+     *  When `experimentalUseWebAssembly` is `false`, this setting will be ignored.
+     *
+     *  TODO: Maybe we should include this property into something like `WasmFeatures`?
+     */
+    val wasmRuntimeTarget: WasmRuntimeTarget,
 ) {
   private def this() = {
     this(
@@ -106,7 +114,8 @@ final class StandardConfig private (
         prettyPrint = false,
         batchMode = false,
         maxConcurrentWrites = 50,
-        experimentalUseWebAssembly = false
+        experimentalUseWebAssembly = false,
+        wasmRuntimeTarget = WasmRuntimeTarget.JS
     )
   }
 
@@ -220,6 +229,9 @@ final class StandardConfig private (
   def withExperimentalUseWebAssembly(experimentalUseWebAssembly: Boolean): StandardConfig =
     copy(experimentalUseWebAssembly = experimentalUseWebAssembly)
 
+  def withWasmRuntimeTarget(wasmRuntimeTarget: WasmRuntimeTarget): StandardConfig =
+    copy(wasmRuntimeTarget = wasmRuntimeTarget)
+
   override def toString(): String = {
     s"""StandardConfig(
        |  semantics                  = $semantics,
@@ -239,6 +251,7 @@ final class StandardConfig private (
        |  batchMode                  = $batchMode,
        |  maxConcurrentWrites        = $maxConcurrentWrites,
        |  experimentalUseWebAssembly = $experimentalUseWebAssembly,
+       |  wasmRuntimeTarget          = $wasmRuntimeTarget,
        |)""".stripMargin
   }
 
@@ -259,7 +272,8 @@ final class StandardConfig private (
       prettyPrint: Boolean = prettyPrint,
       batchMode: Boolean = batchMode,
       maxConcurrentWrites: Int = maxConcurrentWrites,
-      experimentalUseWebAssembly: Boolean = experimentalUseWebAssembly
+      experimentalUseWebAssembly: Boolean = experimentalUseWebAssembly,
+      wasmRuntimeTarget: WasmRuntimeTarget = wasmRuntimeTarget
   ): StandardConfig = {
     new StandardConfig(
         semantics,
@@ -278,7 +292,8 @@ final class StandardConfig private (
         prettyPrint,
         batchMode,
         maxConcurrentWrites,
-        experimentalUseWebAssembly
+        experimentalUseWebAssembly,
+        wasmRuntimeTarget
     )
   }
 }
@@ -310,6 +325,7 @@ object StandardConfig {
         .addField("batchMode", config.batchMode)
         .addField("maxConcurrentWrites", config.maxConcurrentWrites)
         .addField("experimentalUseWebAssembly", config.experimentalUseWebAssembly)
+        .addField("wasmRuntimeTarget", config.wasmRuntimeTarget)
         .build()
     }
   }
@@ -338,6 +354,7 @@ object StandardConfig {
    *  - `batchMode`: `false`
    *  - `maxConcurrentWrites`: `50`
    *  - `experimentalUseWebAssembly`: `false`
+   *  - `wasmRuntimeTarget`: [[WasmRuntimeTarget.JS]]
    */
   def apply(): StandardConfig = new StandardConfig()
 

--- a/linker-interface/shared/src/main/scala/org/scalajs/linker/interface/WasmRuntimeTarget.scala
+++ b/linker-interface/shared/src/main/scala/org/scalajs/linker/interface/WasmRuntimeTarget.scala
@@ -1,0 +1,42 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
+package org.scalajs.linker.interface
+
+import Fingerprint.FingerprintBuilder
+
+final class WasmRuntimeTarget private (val name: String) {
+
+  override def equals(that: Any): Boolean = that match {
+    case target: WasmRuntimeTarget => this.name == target.name
+    case _ => false
+  }
+
+  override def hashCode(): Int = name.##
+
+  override def toString(): String = name
+}
+
+object WasmRuntimeTarget {
+  val JS: WasmRuntimeTarget = new WasmRuntimeTarget("js")
+  val WASIP1: WasmRuntimeTarget = new WasmRuntimeTarget("wasi_snapshot_preview1")
+
+  private[interface] implicit object WasmRuntimeTargetFingerprint
+      extends Fingerprint[WasmRuntimeTarget] {
+
+    override def fingerprint(target: WasmRuntimeTarget): String = {
+      new FingerprintBuilder("WasmRuntimeTarget")
+        .addField("name", target.name)
+        .build()
+    }
+  }
+}

--- a/linker-interface/shared/src/main/scala/org/scalajs/linker/interface/WasmRuntimeTarget.scala
+++ b/linker-interface/shared/src/main/scala/org/scalajs/linker/interface/WasmRuntimeTarget.scala
@@ -21,6 +21,8 @@ final class WasmRuntimeTarget private (val name: String) {
     case _ => false
   }
 
+  val isJS: Boolean = this == WasmRuntimeTarget.JS
+
   override def hashCode(): Int = name.##
 
   override def toString(): String = name

--- a/linker/shared/src/main/scala/org/scalajs/linker/backend/emitter/CoreJSLib.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/backend/emitter/CoreJSLib.scala
@@ -164,6 +164,7 @@ private[emitter] object CoreJSLib {
           str("esVersion") -> int(esVersion.edition),
           str("assumingES6") -> bool(useECMAScript2015Semantics), // different name for historical reasons
           str("isWebAssembly") -> bool(false),
+          str("targetIsPureWasm") -> bool(false),
           str("productionMode") -> bool(productionMode),
           str("linkerVersion") -> str(ScalaJSVersions.current),
           str("fileLevelThis") -> This()

--- a/linker/shared/src/main/scala/org/scalajs/linker/backend/wasmemitter/LoaderContent.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/backend/wasmemitter/LoaderContent.scala
@@ -84,6 +84,7 @@ const linkingInfo = Object.freeze({
   "esVersion": 6,
   "assumingES6": true,
   "isWebAssembly": true,
+  "targetPureWasm": false,
   "productionMode": false,
   "linkerVersion": "${ScalaJSVersions.current}",
   "fileLevelThis": this

--- a/linker/shared/src/main/scala/org/scalajs/linker/backend/wasmemitter/VarGen.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/backend/wasmemitter/VarGen.scala
@@ -292,6 +292,19 @@ object VarGen {
       case object funcRef extends FieldID
     }
 
+    object classData {
+      case object typeData extends FieldID
+      case object name extends FieldID
+      case object isPrimitive extends FieldID
+      case object isArrayClass extends FieldID
+      case object isInterface extends FieldID
+      case object isInstance extends FieldID
+      case object isAssignableFrom extends FieldID
+      case object checkCast extends FieldID
+      case object getComponentType extends FieldID
+      case object newArrayOfThisClass extends FieldID
+    }
+
     /** Fields of the typeData structs. */
     object typeData {
 
@@ -414,6 +427,7 @@ object VarGen {
 
     case object typeData extends TypeID
     case object reflectiveProxy extends TypeID
+    case object classData extends TypeID
 
     // Array types -- they extend j.l.Object
     case object BooleanArray extends TypeID
@@ -477,6 +491,13 @@ object VarGen {
 
     case object cloneFunctionType extends TypeID
     case object isJSClassInstanceFuncType extends TypeID
+
+    // pure wasm
+    case object isInstance extends TypeID
+    case object isAssignableFrom extends TypeID
+    case object checkCast extends TypeID
+    case object getComponentType extends TypeID
+    case object newArrayOfThisClass extends TypeID
   }
 
   object genTagID {

--- a/linker/shared/src/main/scala/org/scalajs/linker/frontend/optimizer/OptimizerCore.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/frontend/optimizer/OptimizerCore.scala
@@ -5056,6 +5056,9 @@ private[optimizer] abstract class OptimizerCore(
       case (JSLinkingInfo(), StringLiteral("isWebAssembly")) =>
         BooleanLiteral(isWasm)
 
+      case (JSLinkingInfo(), StringLiteral("targetIsPureWasm")) =>
+        BooleanLiteral(isWasm && config.coreSpec.wasmRuntimeTarget != WasmRuntimeTarget.JS)
+
       case (JSLinkingInfo(), StringLiteral("version")) =>
         StringLiteral(ScalaJSVersions.current)
 

--- a/linker/shared/src/main/scala/org/scalajs/linker/standard/CoreSpec.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/standard/CoreSpec.scala
@@ -23,7 +23,9 @@ final class CoreSpec private (
     /** ECMAScript features to use. */
     val esFeatures: ESFeatures,
     /** Whether we are compiling to WebAssembly. */
-    val targetIsWebAssembly: Boolean
+    val targetIsWebAssembly: Boolean,
+    /** Runtime target to use when compiling to WebAssembly. */
+    val wasmRuntimeTarget: WasmRuntimeTarget
 ) {
   import CoreSpec._
 
@@ -32,7 +34,8 @@ final class CoreSpec private (
       semantics = Semantics.Defaults,
       moduleKind = ModuleKind.NoModule,
       esFeatures = ESFeatures.Defaults,
-      targetIsWebAssembly = false
+      targetIsWebAssembly = false,
+      wasmRuntimeTarget = WasmRuntimeTarget.JS
     )
   }
 
@@ -54,12 +57,16 @@ final class CoreSpec private (
   def withTargetIsWebAssembly(targetIsWebAssembly: Boolean): CoreSpec =
     copy(targetIsWebAssembly = targetIsWebAssembly)
 
+  def withWasmRuntimeTarget(wasmRuntimeTarget: WasmRuntimeTarget): CoreSpec =
+    copy(wasmRuntimeTarget = wasmRuntimeTarget)
+
   override def equals(that: Any): Boolean = that match {
     case that: CoreSpec =>
       this.semantics == that.semantics &&
       this.moduleKind == that.moduleKind &&
       this.esFeatures == that.esFeatures &&
-      this.targetIsWebAssembly == that.targetIsWebAssembly
+      this.targetIsWebAssembly == that.targetIsWebAssembly &&
+      this.wasmRuntimeTarget == that.wasmRuntimeTarget
     case _ =>
       false
   }
@@ -70,7 +77,8 @@ final class CoreSpec private (
     acc = mix(acc, semantics.##)
     acc = mix(acc, moduleKind.##)
     acc = mix(acc, esFeatures.##)
-    acc = mixLast(acc, targetIsWebAssembly.##)
+    acc = mix(acc, targetIsWebAssembly.##)
+    acc = mixLast(acc, wasmRuntimeTarget.##)
     finalizeHash(acc, 4)
   }
 
@@ -80,6 +88,7 @@ final class CoreSpec private (
        |  moduleKind = $moduleKind,
        |  esFeatures = $esFeatures,
        |  targetIsWebAssembly = $targetIsWebAssembly
+       |  wasmRuntimeTarget = $wasmRuntimeTarget
        |)""".stripMargin
   }
 
@@ -87,13 +96,15 @@ final class CoreSpec private (
       semantics: Semantics = semantics,
       moduleKind: ModuleKind = moduleKind,
       esFeatures: ESFeatures = esFeatures,
-      targetIsWebAssembly: Boolean = targetIsWebAssembly
+      targetIsWebAssembly: Boolean = targetIsWebAssembly,
+      wasmRuntimeTarget: WasmRuntimeTarget = wasmRuntimeTarget
   ): CoreSpec = {
     new CoreSpec(
       semantics,
       moduleKind,
       esFeatures,
-      targetIsWebAssembly
+      targetIsWebAssembly,
+      wasmRuntimeTarget
     )
   }
 }
@@ -109,7 +120,8 @@ private[linker] object CoreSpec {
       config.semantics,
       config.moduleKind,
       config.esFeatures,
-      config.experimentalUseWebAssembly
+      config.experimentalUseWebAssembly,
+      config.wasmRuntimeTarget
     )
   }
 }

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -2015,7 +2015,10 @@ object Build {
       exampleSettings,
       name := "Hello World - Scala.js example",
       moduleName := "helloworld",
-      scalaJSUseMainModuleInitializer := true
+      scalaJSUseMainModuleInitializer := true,
+      scalaJSLinkerConfig ~= {
+        _.withPrettyPrint(true).withWasmRuntimeTarget(WasmRuntimeTarget.WASIP1)
+      }
   ).withScalaJSCompiler.dependsOnLibrary
 
   lazy val reversi: MultiScalaProject = MultiScalaProject(


### PR DESCRIPTION
https://github.com/scala-wasm/scala-wasm/commit/8b20a984174ac9564218b9d331a8c232598d6190

The `j.l.Class` constructor receives a JS object containing metadata, and the methods in `j.l.Class` depend on that metadata.
This commit attempts to remove the dependency on the JS object for metadata by representing it using a WasmGC struct.

When calling methods (`ApplyStatically`) on `j.l.Class`, the function calls will be replaced by implementations that rely on the metadata represented in the WasmGC struct.
One issue is that we cannot replace the function call for `j.l.Class#cast` because it's inlined by the optimizer.

Do you think this is the right approach, and is there a workaround?

---

Alternative approaches

(1) Modify the `j.l.Class` method implementations to avoid accessing the JS object containing metadata,
and instead access the WasmGC struct. I'm unsure how to access the metadata at the library level; perhaps some new IR nodes are needed?

(2) Compile `JSSelect`/`JSMethodApply` on the `ScalaJSClassData` to field access on the WasmGC struct that contains the metadata.
I'm not sure how to determine if the qualifier of `JSSelect` is `ScalaJSClassData`, as `qualifier.tpe` on `JSSelect` returns `AnyType` in this case.
Also, I don't think this is the correct approach to removing JS interop. I believe the right way to avoid JS interop involving `js.Object` is to avoid accessing the `js.Object` altogether, and `JSSelect`/`JSMethodApply` shouldn’t appear at link-time under pure-WASM.