### PR TITLE
Report JS tree in targetPureWasm=true in Analyzer

### DIFF
--- a/javalib/src/main/scala/java/lang/Character.scala
+++ b/javalib/src/main/scala/java/lang/Character.scala
@@ -128,7 +128,7 @@ object Character {
     if (!isValidCodePoint(codePoint))
       throw new IllegalArgumentException()
 
-    if (LinkingInfo.targetPureWasm) {
+    LinkingInfo.linkTimeIf (LinkingInfo.targetPureWasm) {
       if (isBmpCodePoint(codePoint)) {
         Character.toString(codePoint.toChar)
       } else {
@@ -136,7 +136,8 @@ object Character {
         toSurrogate(codePoint, dst, 0)
         new String(dst)
       }
-    } else if (LinkingInfo.esVersion >= ESVersion.ES2015) {
+    } {
+    if (LinkingInfo.esVersion >= ESVersion.ES2015) {
       js.Dynamic.global.String.fromCodePoint(codePoint).asInstanceOf[String]
     } else {
       if (codePoint < MIN_SUPPLEMENTARY_CODE_POINT) {
@@ -148,7 +149,7 @@ object Character {
           .fromCharCode(highSurrogate(codePoint).toInt, lowSurrogate(codePoint).toInt)
           .asInstanceOf[String]
       }
-    }
+    }}
   }
 
   // Low-level code point and code unit manipulations -------------------------
@@ -706,10 +707,10 @@ object Character {
       case _ =>
         // In WASI implementation, we cannot use String#toUpperCase
         // since it uses Character#toUpperCase.
-        if (LinkingInfo.targetPureWasm) {
+        LinkingInfo.linkTimeIf(LinkingInfo.targetPureWasm) {
           import CaseUtil._
           toCase(codePoint, a, z, lowerBeta, lowerRanges, lowerDeltas, lowerSteps)
-        } else {
+        } {
           val upperChars = toString(codePoint).toUpperCase()
           upperChars.length match {
             case 1 =>
@@ -735,12 +736,12 @@ object Character {
       case 0x0130 =>
         0x0069 // İ => i
       case _ =>
-        if (LinkingInfo.targetPureWasm) {
+        LinkingInfo.linkTimeIf(LinkingInfo.targetPureWasm) {
           // in pure Wasm implementation, we cannot use String#toLowerCase
           // since it uses Character$toLowerCase
           import CaseUtil._
           toCase(codePoint, A, Z, upperMu, upperRanges, upperDeltas, upperSteps)
-        } else {
+        } {
           val lowerChars = toString(codePoint).toLowerCase()
           lowerChars.length match {
             case 1 =>

--- a/javalib/src/main/scala/java/lang/Double.scala
+++ b/javalib/src/main/scala/java/lang/Double.scala
@@ -16,6 +16,7 @@ import java.lang.constant.{Constable, ConstantDesc}
 
 import scala.scalajs.js
 import scala.scalajs.LinkingInfo
+import scala.scalajs.LinkingInfo.linkTimeIf
 
 import Utils._
 
@@ -380,10 +381,11 @@ object Double {
    *  The two implementations compute the same results.
    */
   @inline def hashCode(value: scala.Double): Int = {
-    if (LinkingInfo.isWebAssembly)
+    linkTimeIf(LinkingInfo.isWebAssembly) {
       hashCodeForWasm(value)
-    else
+    } {
       hashCodeForJS(value)
+    }
   }
 
   @inline

--- a/javalib/src/main/scala/java/lang/System.scala
+++ b/javalib/src/main/scala/java/lang/System.scala
@@ -68,8 +68,11 @@ object System {
 
   @inline
   def currentTimeMillis(): scala.Long =
-    if (LinkingInfo.targetPureWasm) WasmSystem.currentTimeMillis()
-    else js.Date.now().toLong
+    LinkingInfo.linkTimeIf(LinkingInfo.targetPureWasm) {
+      WasmSystem.currentTimeMillis()
+    } {
+      js.Date.now().toLong
+    }
 
   private object NanoTime {
     val getHighPrecisionTime: js.Function0[scala.Double] = {
@@ -91,8 +94,11 @@ object System {
 
   @inline
   def nanoTime(): scala.Long =
-    if (LinkingInfo.targetPureWasm) WasmSystem.nanoTime()
-    else (NanoTime.getHighPrecisionTime() * 1000000).toLong
+    LinkingInfo.linkTimeIf(LinkingInfo.targetPureWasm) {
+      WasmSystem.nanoTime()
+    } {
+      (NanoTime.getHighPrecisionTime() * 1000000).toLong
+    }
 
   // arraycopy ----------------------------------------------------------------
 
@@ -385,9 +391,9 @@ private final class JSConsoleBasedPrintStream(isErr: scala.Boolean)
   override def close(): Unit = ()
 
   private def doWriteLine(line: String): Unit = {
-    if (LinkingInfo.targetPureWasm) {
+    LinkingInfo.linkTimeIf (LinkingInfo.targetPureWasm) {
       WasmSystem.print(line)
-    } else {
+    } {
       import js.DynamicImplicits.truthValue
 
       if (js.typeOf(global.console) != "undefined") {

--- a/junit-runtime/src/main/scala/org/junit/Assert.scala
+++ b/junit-runtime/src/main/scala/org/junit/Assert.scala
@@ -407,12 +407,12 @@ object Assert {
             actualThrown)
     }
 
-    if (LinkingInfo.targetPureWasm) {
+    LinkingInfo.linkTimeIf(LinkingInfo.targetPureWasm) {
       throw new AssertionError(
           buildPrefix +
           "expecte " + formatClass(expectedThrowable) + " to be thrown, but nothing was thrown"
       )
-    } else {
+    } {
     throw new AssertionError(
         buildPrefix +
         String.format("expected %s to be thrown, but nothing was thrown", formatClass(expectedThrowable)))

--- a/library/src/main/scala/scala/scalajs/LinkingInfo.scala
+++ b/library/src/main/scala/scala/scalajs/LinkingInfo.scala
@@ -258,7 +258,7 @@ object LinkingInfo {
   def isWebAssembly: Boolean =
     linkTimePropertyBoolean("core/isWebAssembly")
 
-  @inline
+  @inline @linkTimeProperty("core/targetPureWasm")
   def targetPureWasm: Boolean =
     linkTimePropertyBoolean("core/targetPureWasm")
 

--- a/linker/shared/src/main/scala/org/scalajs/linker/analyzer/Analysis.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/analyzer/Analysis.scala
@@ -227,6 +227,8 @@ object Analysis {
     from: From
   ) extends Error
 
+  final case class JSInteropInPureWasm(from: From) extends Error
+
   sealed trait From
   final case class FromMethod(methodInfo: MethodInfo) extends From
   final case class FromDispatch(classInfo: ClassInfo, methodName: MethodName) extends From
@@ -291,6 +293,8 @@ object Analysis {
         "Uses an orphan await (outside of an async block) without targeting WebAssembly"
       case InvalidLinkTimeProperty(name, tpe, _) =>
         s"Uses invalid link-time property ${name} of type ${tpe}"
+      case JSInteropInPureWasm(_) =>
+        s"Uses JS interop with targetPureWasm = true"
     }
 
     logger.log(level, headMsg)

--- a/linker/shared/src/main/scala/org/scalajs/linker/analyzer/InfoLoader.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/analyzer/InfoLoader.scala
@@ -30,9 +30,10 @@ import org.scalajs.linker.CollectionsCompat.MutableMapCompatOps
 import Platform.emptyThreadSafeMap
 
 private[analyzer] final class InfoLoader(irLoader: IRLoader,
-    checkIRFor: Option[CheckingPhase], linkTimeProperties: LinkTimeProperties) {
+    checkIRFor: Option[CheckingPhase], linkTimeProperties: LinkTimeProperties,
+    targetPureWasm: Boolean) {
 
-  private val generator = new Infos.InfoGenerator(linkTimeProperties)
+  private val generator = new Infos.InfoGenerator(linkTimeProperties, targetPureWasm)
   private var logger: Logger = _
   private val cache = emptyThreadSafeMap[ClassName, InfoLoader.ClassInfoCache]
 

--- a/scalalib/overrides-2.12/scala/collection/mutable/ArrayBuilder.scala
+++ b/scalalib/overrides-2.12/scala/collection/mutable/ArrayBuilder.scala
@@ -15,6 +15,7 @@ import scala.runtime.BoxedUnit
 
 import scala.scalajs.js
 import scala.scalajs.LinkingInfo
+import scala.scalajs.LinkingInfo.linkTimeIf
 
 /** A builder class for arrays.
  *
@@ -37,8 +38,11 @@ object ArrayBuilder {
    */
   @inline
   def make[T: ClassTag](): ArrayBuilder[T] =
-    if (LinkingInfo.isWebAssembly) makeForWasm()
-    else makeForJS()
+    linkTimeIf(LinkingInfo.isWebAssembly) {
+      makeForWasm()
+    } {
+      makeForJS()
+    }
 
   /** Implementation of `make` for JS. */
   @inline

--- a/scalalib/overrides-2.13/scala/collection/mutable/ArrayBuilder.scala
+++ b/scalalib/overrides-2.13/scala/collection/mutable/ArrayBuilder.scala
@@ -18,6 +18,7 @@ import scala.runtime.BoxedUnit
 
 import scala.scalajs.js
 import scala.scalajs.LinkingInfo
+import scala.scalajs.LinkingInfo.linkTimeIf
 
 /** A builder class for arrays.
  *
@@ -90,8 +91,11 @@ object ArrayBuilder {
    */
   @inline
   def make[T: ClassTag]: ArrayBuilder[T] =
-    if (LinkingInfo.isWebAssembly) makeForWasm
-    else makeForJS
+    linkTimeIf(LinkingInfo.isWebAssembly) {
+      makeForWasm
+    } {
+      makeForJS
+    }
 
   /** Implementation of `make` for JS. */
   @inline

--- a/scalalib/overrides/scala/runtime/BoxesRunTime.scala
+++ b/scalalib/overrides/scala/runtime/BoxesRunTime.scala
@@ -2,6 +2,9 @@ package scala.runtime
 
 import scala.math.ScalaNumber
 
+import scala.scalajs.LinkingInfo
+import scala.scalajs.LinkingInfo.linkTimeIf
+
 /* The declaration of the class is only to make the JVM back-end happy when
  * compiling the scalalib.
  */
@@ -49,9 +52,10 @@ object BoxesRunTime {
   def unboxToDouble(d: Any): Double = d.asInstanceOf[Double]
 
   def equals(x: Object, y: Object): Boolean =
-    if (scala.scalajs.LinkingInfo.targetPureWasm) {
-      equals2(x, y)
-    } else {
+    linkTimeIf(LinkingInfo.targetPureWasm) {
+      if (x eq y) true
+      else equals2(x, y)
+    } {
       if (scala.scalajs.js.special.strictEquals(x, y)) true
       else equals2(x, y)
     }


### PR DESCRIPTION
~cherry-picking  https://github.com/scala-js/scala-js/pull/5110/commits/95d74bf8204b01d89aa3c05c99760a0b2c3e4539~

Previously, when `targetPureWasm = true`, JS-related trees
would lead to link failure at `FunctionEmitter` with an exception.
However, this report only indicated which location contained the JS interop, and not the call path leading to it.
This made it difficult to tell how the JS interop code was reached.

This commit introduces a new `JSInteropInPureWasm` error that specifically flags JS-related trees discovered within a reachable code path when `targetPureWasm` is enabled.

Now, if the Analyzer detects JS interop under these conditions, it reports not just the location but also the sequence of calls that led to that point, that improves the debugging experience for pure Wasm targets.

```
[error] Uses JS interop with targetPureWasm = true
[error]   dispatched from scala.collection.mutable.ArrayBuilder$.scala$collection$mutable$ArrayBuilder$$genericArrayBuilderResult(java.lang.Class,scala.scalajs.js.Array)java.lang.Object
[error]   called from scala.collection.mutable.ArrayBuilder$generic.result()java.lang.Object
[error]   dispatched from scala.collection.mutable.Builder.result()java.lang.Object
[error]   called from scala.collection.generic.GenericCompanion.apply(scala.collection.Seq)scala.collection.GenTraversable
[error]   dispatched from scala.collection.immutable.Set$.apply(scala.collection.Seq)scala.collection.GenTraversable
[error]   called from org.scalajs.testsuite.javalib.lang.ThrowablesTest.suppression()void
[error]   called from testSuiteWASI.JavalibLangTest$.run()void
[error]   called from testSuiteWASI.Run$.main([java.lang.String)void
[error]   called from static testSuiteWASI.Run.main([java.lang.String)void
[error]   called from core module module initializers
[error] involving instantiated classes:
[error]   scala.collection.mutable.ArrayBuilder$generic
[error]   scala.collection.mutable.HashSet$
[error]   scala.collection.Seq$
[error]   scala.collection.immutable.Set$
[error]   org.scalajs.testsuite.javalib.lang.ThrowablesTest
[error]   testSuiteWASI.JavalibLangTest$
[error]   testSuiteWASI.Run$
```