### PR TITLE
Make the payload of exceptions an `anyref` in pure Wasm.

### DIFF
--- a/linker/shared/src/main/scala/org/scalajs/linker/backend/wasmemitter/CoreWasmLib.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/backend/wasmemitter/CoreWasmLib.scala
@@ -138,7 +138,7 @@ final class CoreWasmLib(coreSpec: CoreSpec, globalInfo: LinkedGlobalInfo) {
     if (!targetPureWasm) genImports()
     else {
       if (coreSpec.wasmFeatures.exceptionHandling) {
-        val exceptionSig = FunctionType(List(RefType(genTypeID.forClass(ThrowableClass))), Nil)
+        val exceptionSig = FunctionType(List(RefType.anyref), Nil)
         val typeID = ctx.moduleBuilder.functionTypeToTypeID(exceptionSig)
         ctx.moduleBuilder.addTag(
           Tag(

--- a/linker/shared/src/main/scala/org/scalajs/linker/backend/wasmemitter/FunctionEmitter.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/backend/wasmemitter/FunctionEmitter.scala
@@ -1707,7 +1707,6 @@ private class FunctionEmitter private (
       case Throw =>
         if (ctx.coreSpec.wasmFeatures.exceptionHandling) {
           if (!targetPureWasm) fb += wa.ExternConvertAny
-          else fb += wa.RefCast(watpe.RefType(genTypeID.ThrowableStruct))
           fb += wa.Throw(genTagID.exception)
         } else {
           fb += wa.Drop
@@ -2759,7 +2758,7 @@ private class FunctionEmitter private (
     markPosition(tree)
 
     val exceptionType =
-      if (targetPureWasm) watpe.RefType.nullable(genTypeID.ThrowableStruct)
+      if (targetPureWasm) watpe.RefType.anyref
       else watpe.RefType.externref
 
     fb.block(resultType) { doneLabel =>


### PR DESCRIPTION
Even though we don't have JS interop, the semantics of `Throw` and `TryCatch` in the IR are that they accept `AnyType`, not just `jl.Throwable`s.