### PR TITLE
Implement exception handling by hand when Wasm doesn't have EH support.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,6 +76,7 @@ jobs:
       fail-fast: false
       matrix:
         suffix: [2_12] # TODO: test with 2_13 too
+        eh-support: [true, false]
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-java@v4
@@ -91,9 +92,9 @@ jobs:
         run: npm install
       - name: testSuiteWASI${{ matrix.suffix }}/fastLinkJS
         run: |
-          sbt 'set Global/enableWasmEverywhere := true' testSuiteWASI${{ matrix.suffix }}/fastLinkJS
+          sbt "set Seq(Global/enableWasmEverywhere := true, testSuiteWASI.v${{ matrix.suffix }}/scalaJSLinkerConfig ~= (_.withWasmFeatures(_.withExceptionHandling(${{ matrix.eh-support }}))))" testSuiteWASI${{ matrix.suffix }}/fastLinkJS
           VERSION=$(echo "${{ matrix.suffix }}" | sed 's/2_/2./')
-          node --experimental-wasm-exnref ./index.mjs ./examples/test-suite-wasi/.$VERSION/target/scala-$VERSION/test-suite-wasi-fastopt/main.wasm
+          node ${{ matrix.eh-support && '--experimental-wasm-exnref' || '--no-experimental-wasm-exnref' }} ./index.mjs ./examples/test-suite-wasi/.$VERSION/target/scala-$VERSION/test-suite-wasi-fastopt/main.wasm
           echo "test success"
 
   test-suite-component:

--- a/linker/shared/src/main/scala/org/scalajs/linker/backend/wasmemitter/VarGen.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/backend/wasmemitter/VarGen.scala
@@ -53,6 +53,8 @@ object VarGen {
     case object bZeroFloat extends GlobalID
     case object bZeroDouble extends GlobalID
     case object emptyStringArray extends GlobalID
+    case object thrownException extends GlobalID
+    case object isThrowing extends GlobalID
     // component model
     case object stackPointer extends GlobalID
     case object savedStackPointer extends GlobalID


### PR DESCRIPTION
Previously, when targeting Wasm without exception handling support, we were trapping instead of throwing, and discarded attempts at catching exceptions.

Now, we properly implement exception handling on top of lower-level primitives. The overall strategy is the following:

We have two globals to store the "throwing state": `thrownException: anyref` and `isThrowing: bool`. While code is executing normally, they are `null` and `false` (0), respectively.

When we `Throw`, we store the exception insde `thrownException`, and set `isThrowing` to `true`. We then branch to the closest handler within the function.

The handler of a `TryCatch` stores the `thrownException` in the `errVar`, then resets the two globals. The handler of a `TryFinally` stores the two values in locals, for safekeeping, during the execution of the `finally` block.

When there is no enclosing handler in the function, we jump to an implicit handler that we install around the body of every function. That handler does *not* reset the throwing state. Instead, it materializes a fake result value of the value, then returns.

Upon returning from basically every function, we check the value of `isThrowing`. If it is `true`, we branch to the closest handler, or the implicit handler of the function, as if we just did a `throw`.

This strategy correctly implements all the semantics of exception handling, at the cost of the additional check after every function call. It's not pretty, but while we wait for Wasm engines to catch up to the EH support, it is better to have that than to have no exception handling at all. Proper semantics for exception handling are necessary to set up the full test suite.