### PR TITLE
Integer.parseInt without JS asInt

### DIFF
--- a/examples/test-suite-wasi/src/main/scala/test-suites-wasi/JavalibLangTest.scala
+++ b/examples/test-suite-wasi/src/main/scala/test-suites-wasi/JavalibLangTest.scala
@@ -224,14 +224,13 @@ object JavalibLangTest {
       compareToInteger()
       compareTo()
 
-      // TODO: JSBinaryOp 8: asInt (number2dynamic)
-      // parseString()
-      // parseStringInvalidThrows()
-      // parseUnsignedInt()
-      // parseUnsignedIntInvalidThrows()
-      // parseStringBase16()
-      // decodeStringBase8()
-      // decodeStringInvalidThrows()
+      parseString()
+      parseStringInvalidThrows()
+      parseUnsignedInt()
+      parseUnsignedIntInvalidThrows()
+      parseStringBase16()
+      decodeStringBase8()
+      decodeStringInvalidThrows()
 
       highestOneBit()
       lowestOneBit()
@@ -243,10 +242,9 @@ object JavalibLangTest {
       // TODO: JSMethodApply toString (enableJSNumberOps)
       // toStringRadix()
 
-      // TODO: JSMethodApply (asInt)
-      // parseUnsignedIntRadix()
-      // parseUnsignedIntRadixInvalidThrows()
-      // parseUnsignedIntBase16()
+      parseUnsignedIntRadix()
+      parseUnsignedIntRadixInvalidThrows()
+      parseUnsignedIntBase16()
 
       // JSBinaryOp 13 Utils.scala toUint
       // compareUnsigned()

--- a/javalib/src/main/scala/java/lang/Integer.scala
+++ b/javalib/src/main/scala/java/lang/Integer.scala
@@ -97,31 +97,53 @@ object Integer {
     val firstChar = s.charAt(0)
     val negative = signed && firstChar == '-'
 
-    val maxAbsValue: scala.Double = {
-      if (!signed) 0xffffffffL.toDouble
-      else if (negative) 0x80000000L.toDouble
-      else 0x7fffffffL.toDouble
-    }
-
     var i = if (negative || firstChar == '+') 1 else 0
 
     // We need at least one digit
     if (i >= s.length)
       fail()
 
-    var result: scala.Double = 0.0
-    while (i != len) {
-      val digit = Character.digitWithValidRadix(s.charAt(i), radix)
-      result = result * radix + digit
-      if (digit == -1 || result > maxAbsValue)
-        fail()
-      i += 1
-    }
+    if (LinkingInfo.targetPureWasm) {
+      val maxAbsValue: scala.Long = {
+        if (!signed) 0xffffffffL
+        else if (negative) 0x80000000L
+        else 0x7fffffffL
+      }
 
-    if (negative)
-      asInt(-result)
-    else
-      asInt(result)
+      var result: scala.Long = 0L
+      while (i != len) {
+        val digit = Character.digitWithValidRadix(s.charAt(i), radix)
+        result = result * radix + digit
+        if (digit == -1 || result > maxAbsValue)
+          fail()
+        i += 1
+      }
+
+      if (negative)
+        -result.toInt
+      else
+        result.toInt
+    } else {
+      val maxAbsValue: scala.Double = {
+        if (!signed) 0xffffffffL.toDouble
+        else if (negative) 0x80000000L.toDouble
+        else 0x7fffffffL.toDouble
+      }
+
+      var result: scala.Double = 0.0
+      while (i != len) {
+        val digit = Character.digitWithValidRadix(s.charAt(i), radix)
+        result = result * radix + digit
+        if (digit == -1 || result > maxAbsValue)
+          fail()
+        i += 1
+      }
+
+      if (negative)
+        asInt(-result)
+      else
+        asInt(result)
+      }
   }
 
   @inline def toString(i: scala.Int): String = "" + i


### PR DESCRIPTION
We use Double instead of Long for accumulating the result value prpobably because in JS backend runtime long is more expensive than double (?). On the other hand, in Wasm backend, we have native i64 and accumulating in long would be cheaper.