### PR TITLE
Optimize string concatenation with new data structure

### DIFF
--- a/examples/test-suite-wasi/src/main/scala/test-suites-wasi/JavalibLangTest.scala
+++ b/examples/test-suite-wasi/src/main/scala/test-suites-wasi/JavalibLangTest.scala
@@ -536,9 +536,8 @@ object JavalibLangTest {
 
       trim()
 
-      // TODO: it takes too long to concat strings
-      // createFromLargeCharArray_Issue2553()
-      // createFromLargeCodePointArray_Issue2553()
+      createFromLargeCharArray_Issue2553()
+      createFromLargeCodePointArray_Issue2553()
 
       stringCaseInsensitiveOrdering()
     }

--- a/linker/shared/src/main/scala/org/scalajs/linker/backend/wasmemitter/ClassEmitter.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/backend/wasmemitter/ClassEmitter.scala
@@ -224,7 +224,7 @@ class ClassEmitter(coreSpec: CoreSpec) {
     val nameValue =
       if (targetPureWasm)
         ctx.stringPool.getConstantStringDataInstr(nameStr) :+
-            wa.RefNull(watpe.HeapType(genTypeID.i16Array))
+            wa.RefNull(watpe.HeapType(genTypeID.wasmString))
       else ctx.stringPool.getConstantStringDataInstr(nameStr)
 
     val kind = className match {

--- a/linker/shared/src/main/scala/org/scalajs/linker/backend/wasmemitter/SWasmGen.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/backend/wasmemitter/SWasmGen.scala
@@ -19,6 +19,8 @@ import org.scalajs.linker.backend.webassembly._
 import org.scalajs.linker.backend.webassembly.Instructions._
 
 import VarGen._
+import org.scalajs.linker.backend.webassembly.Types.HeapType
+import org.scalajs.linker.backend.webassembly.Identitities.LocalID
 
 /** Scala.js-specific Wasm generators that are used across the board. */
 object SWasmGen {
@@ -43,7 +45,7 @@ object SWasmGen {
         I32Const(0)
       case ClassType(BoxedStringClass, true) =>
         if (ctx.coreSpec.wasmFeatures.targetPureWasm)
-          RefNull(Types.HeapType(genTypeID.i16Array))
+          RefNull(HeapType(genTypeID.wasmString))
         else
           RefNull(Types.HeapType.NoExtern)
 
@@ -131,6 +133,21 @@ object SWasmGen {
         fb += Return
       }
     }
+  }
+
+  def genWasmStringFromCharCode(fb: FunctionBuilder): Unit = {
+    fb += ArrayNewFixed(genTypeID.i16Array, 1)
+    fb += I32Const(1)
+    fb += RefNull(HeapType(genTypeID.wasmString))
+    fb += StructNew(genTypeID.wasmString)
+  }
+
+  def genWasmStringFromArray(fb: FunctionBuilder, array: LocalID): Unit = {
+    fb += LocalGet(array)
+    fb += LocalGet(array)
+    fb += ArrayLen
+    fb += RefNull(HeapType(genTypeID.wasmString))
+    fb += StructNew(genTypeID.wasmString)
   }
 
 }

--- a/linker/shared/src/main/scala/org/scalajs/linker/backend/wasmemitter/TypeTransformer.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/backend/wasmemitter/TypeTransformer.scala
@@ -114,7 +114,7 @@ object TypeTransformer {
       case Some(info) =>
         if (className == BoxedStringClass) {
           if (ctx.coreSpec.wasmFeatures.targetPureWasm)
-            watpe.HeapType(genTypeID.i16Array)
+            watpe.HeapType(genTypeID.wasmString)
           else
             watpe.HeapType.Extern // for all the JS string builtin functions
         }
@@ -148,8 +148,10 @@ object TypeTransformer {
       case FloatType   => watpe.Float32
       case DoubleType  => watpe.Float64
       case StringType  =>
-        if (ctx.coreSpec.wasmFeatures.targetPureWasm) watpe.RefType(genTypeID.i16Array)
-        else watpe.RefType.extern
+        if (ctx.coreSpec.wasmFeatures.targetPureWasm)
+          watpe.RefType(genTypeID.wasmString)
+        else
+          watpe.RefType.extern
       case NullType    => watpe.RefType.nullref
 
       case VoidType | NothingType =>

--- a/linker/shared/src/main/scala/org/scalajs/linker/backend/wasmemitter/canonicalabi/ScalaJSToCABI.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/backend/wasmemitter/canonicalabi/ScalaJSToCABI.scala
@@ -59,7 +59,7 @@ object ScalaJSToCABI {
         val offset = fb.addLocal(NoOriginalName, watpe.Int32)
         val units = fb.addLocal(NoOriginalName, watpe.Int32)
 
-        fb += wa.RefCast(watpe.RefType.nullable(genTypeID.i16Array))
+        fb += wa.RefCast(watpe.RefType.nullable(genTypeID.wasmString))
         fb += wa.Call(genFunctionID.cabiStoreString)
         // now we have [i32(string offset), i32(string units)] on stack
         fb += wa.LocalSet(units)
@@ -231,7 +231,7 @@ object ScalaJSToCABI {
         val offset = fb.addLocal(NoOriginalName, watpe.Int32)
         val units = fb.addLocal(NoOriginalName, watpe.Int32)
 
-        fb += wa.RefCast(watpe.RefType.nullable(genTypeID.i16Array))
+        fb += wa.RefCast(watpe.RefType.nullable(genTypeID.wasmString))
         fb += wa.Call(genFunctionID.cabiStoreString) // baseAddr, units
 
         fb += wa.LocalSet(units)

--- a/linker/shared/src/main/scala/org/scalajs/linker/frontend/optimizer/OptimizerCore.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/frontend/optimizer/OptimizerCore.scala
@@ -6623,6 +6623,9 @@ private[optimizer] object OptimizerCore {
         ClassName("java.lang.Character$") -> List(
             m("toString", List(I), StringClassRef) -> CharacterCodePointToString
         ),
+        ClassName("java.lang.String") -> List(
+            m("codePointAt", List(I), I) -> StringCodePointAt
+        ),
     )
 
     private val wasmIntrinsics: List[(ClassName, List[(MethodName, Int)])] = List(
@@ -6651,9 +6654,6 @@ private[optimizer] object OptimizerCore {
         ClassName("java.lang.Double$") -> List(
             m("doubleToLongBits", List(D), J) -> DoubleToLongBits,
             m("longBitsToDouble", List(J), D) -> LongBitsToDouble
-        ),
-        ClassName("java.lang.String") -> List(
-            m("codePointAt", List(I), I) -> StringCodePointAt
         ),
         ClassName("java.lang.Math$") -> List(
             m("abs", List(F), F) -> MathAbsFloat,


### PR DESCRIPTION
Fix https://github.com/scala-wasm/scala-wasm/issues/14

The previous implementation of string concatenation suffered from performance issues.
Each `stringConcat` operation immediately allocated a new character array (`i16Array`) and copied the character data from both operands.
This approach resulted in significant overhead, especially in scenarios with multiple concatenations.
In fact, test cases such as `createFromLargeCharArray_Issue2553()` and `createFromLargeCodePointArray_Issue2553()` in `org.scalajs.testsuite.javalib.lang.StringTest` didn't finish in a reasonable time.

This commit introduces a new data structure that avoids immediate full array allocation and copying, and defers allocation of the full string contents until it's actually needed by an operation such as `String_charAt'.

The new structure represents concatenated prefix strings as a chain, the `$wasmString' has 3 fields:
- `left: (ref null $wasmString)`: A reference to the left operand string in a concatenation.
- `length: i32`: The total length of the final concatenated string (precomputed).
- chars: (ref (array i16))`: Holds character data.

When concatenating strings `A` and `B`, the resulting `wasmString` object `S` is stored:
- A reference to `A` in `left`.
- The combined length (`A.length + B.length`) in `length`.
- Only the character data of the right operand `B` directly in `chars`.

This creates a linked-list-like structure, starting from the rightmost string segment and working backwards.

The complete, contiguous character array for the entire concatenated string is only constructed (i.e., collapsed) when an operation requires access to the entire sequence (e.g., `string_charAt' and `stringEquals').
This is handled by the `collapseString` function, it collects all concatenated characters into a newly allocated i16Array, and mutates the object's `chars` field to the new one, and also mutates `left` to `null`, meaning that the string is no longer concatenated.