### PR TITLE
Emit a different loader file for targetPureWasm.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -92,10 +92,7 @@ jobs:
         run: npm install
       - name: testSuiteWASI${{ matrix.suffix }}/fastLinkJS
         run: |
-          sbt "set Seq(Global/enableWasmEverywhere := true, testSuiteWASI.v${{ matrix.suffix }}/scalaJSLinkerConfig ~= (_.withWasmFeatures(_.withExceptionHandling(${{ matrix.eh-support }}))))" testSuiteWASI${{ matrix.suffix }}/fastLinkJS
-          VERSION=$(echo "${{ matrix.suffix }}" | sed 's/2_/2./')
-          node ${{ matrix.eh-support && '--experimental-wasm-exnref' || '--no-experimental-wasm-exnref' }} ./index.mjs ./examples/test-suite-wasi/.$VERSION/target/scala-$VERSION/test-suite-wasi-fastopt/main.wasm
-          echo "test success"
+          sbt "set Seq(Global/enableWasmEverywhere := true, testSuiteWASI.v${{ matrix.suffix }}/scalaJSLinkerConfig ~= (_.withWasmFeatures(_.withExceptionHandling(${{ matrix.eh-support }}))))" testSuiteWASI${{ matrix.suffix }}/run
 
   test-suite-component:
     runs-on: ubuntu-latest

--- a/linker/shared/src/main/scala/org/scalajs/linker/backend/wasmemitter/Emitter.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/backend/wasmemitter/Emitter.scala
@@ -59,7 +59,9 @@ final class Emitter(config: Emitter.Config) {
 
   def emit(module: ModuleSet.Module, globalInfo: LinkedGlobalInfo, logger: Logger): Result = {
     val (wasmModule, jsFileContentInfo) = emitWasmModule(module, globalInfo)
-    val loaderContent = LoaderContent.bytesContent
+    val loaderContent =
+      if (coreSpec.wasmFeatures.targetPureWasm) LoaderContent.pureWasmBytesContent
+      else LoaderContent.bytesContent
     val jsFileContent = buildJSFileContent(module, jsFileContentInfo)
 
     new Result(wasmModule, loaderContent, jsFileContent)


### PR DESCRIPTION
This loader file does not expose any of the JS interop features. This way, we can use the standard `run` (and later `test`) sbt commands, while verifying that are indeed not touching any JS.

Moreover, the build sets up the most limited flags for Node.js based on the linker config, so we also don't have to take care of that while testing.