### PR TITLE
Fix string concat with `Any` that happens to be a hijacked value.

### DIFF
--- a/linker/shared/src/main/scala/org/scalajs/linker/backend/wasmemitter/VarGen.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/backend/wasmemitter/VarGen.scala
@@ -119,6 +119,7 @@ object VarGen {
     final case object f32Fmod extends FunctionID
     final case object f64Fmod extends FunctionID
     final case object itoa extends FunctionID
+    final case object hijackedValueToString extends FunctionID
     final case object stringLiteral extends FunctionID
 
     final case object malloc extends FunctionID


### PR DESCRIPTION
Like in an explicit `toString()` call dispatch, we must handle hijacked values in string concatenation with something that is an ancestor of hijacked classes.