### PR TITLE
Draft: Add support for some "essential" external features in targetPureWasm.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -92,10 +92,7 @@ jobs:
         run: npm install
       - name: testSuiteWASI${{ matrix.suffix }}/fastLinkJS
         run: |
-          sbt "set Seq(Global/enableWasmEverywhere := true, testSuiteWASI.v${{ matrix.suffix }}/scalaJSLinkerConfig ~= (_.withWasmFeatures(_.withExceptionHandling(${{ matrix.eh-support }}))))" testSuiteWASI${{ matrix.suffix }}/fastLinkJS
-          VERSION=$(echo "${{ matrix.suffix }}" | sed 's/2_/2./')
-          node ${{ matrix.eh-support && '--experimental-wasm-exnref' || '--no-experimental-wasm-exnref' }} ./index.mjs ./examples/test-suite-wasi/.$VERSION/target/scala-$VERSION/test-suite-wasi-fastopt/main.wasm
-          echo "test success"
+          sbt "set Seq(Global/enableWasmEverywhere := true, testSuiteWASI.v${{ matrix.suffix }}/scalaJSLinkerConfig ~= (_.withWasmFeatures(_.withExceptionHandling(${{ matrix.eh-support }}))))" testSuiteWASI${{ matrix.suffix }}/run
 
   test-suite-component:
     runs-on: ubuntu-latest

--- a/examples/test-suite-wasi/src/main/scala/test-suites-wasi/Run.scala
+++ b/examples/test-suite-wasi/src/main/scala/test-suites-wasi/Run.scala
@@ -6,5 +6,7 @@ object Run {
     JavalibLangTest.run()
     JavalibUtilTest.run()
     LibraryTest.run()
+
+    println("Test suite completed")
   }
 }

--- a/javalib/src/main/scala/java/lang/Math.scala
+++ b/javalib/src/main/scala/java/lang/Math.scala
@@ -153,7 +153,9 @@ object Math {
   @inline def atan(a: scala.Double): scala.Double = js.Math.atan(a)
   @inline def atan2(y: scala.Double, x: scala.Double): scala.Double = js.Math.atan2(y, x)
 
-  @inline def random(): scala.Double = js.Math.random()
+  @inline def random(): scala.Double =
+    if (LinkingInfo.targetPureWasm) WasmSystem.random()
+    else js.Math.random()
 
   @inline def toDegrees(a: scala.Double): scala.Double = a * 180.0 / PI
   @inline def toRadians(a: scala.Double): scala.Double = a / 180.0 * PI

--- a/javalib/src/main/scala/java/lang/System.scala
+++ b/javalib/src/main/scala/java/lang/System.scala
@@ -68,7 +68,8 @@ object System {
 
   @inline
   def currentTimeMillis(): scala.Long =
-    (new js.Date).getTime().toLong
+    if (LinkingInfo.targetPureWasm) WasmSystem.currentTimeMillis()
+    else js.Date.now().toLong
 
   private object NanoTime {
     val getHighPrecisionTime: js.Function0[scala.Double] = {
@@ -90,7 +91,8 @@ object System {
 
   @inline
   def nanoTime(): scala.Long =
-    (NanoTime.getHighPrecisionTime() * 1000000).toLong
+    if (LinkingInfo.targetPureWasm) WasmSystem.nanoTime()
+    else (NanoTime.getHighPrecisionTime() * 1000000).toLong
 
   // arraycopy ----------------------------------------------------------------
 
@@ -384,8 +386,7 @@ private final class JSConsoleBasedPrintStream(isErr: scala.Boolean)
 
   private def doWriteLine(line: String): Unit = {
     if (LinkingInfo.targetPureWasm) { // isWASI
-      // TODO
-
+      WasmSystem.print(line)
     } else {
       import js.DynamicImplicits.truthValue
 

--- a/javalib/src/main/scala/java/lang/WasmSystem.scala
+++ b/javalib/src/main/scala/java/lang/WasmSystem.scala
@@ -1,0 +1,15 @@
+package java.lang
+
+protected[lang] object WasmSystem {
+  @noinline
+  def print(s: String): Unit = ()
+
+  @noinline
+  def nanoTime(): scala.Long = 0L
+
+  @noinline
+  def currentTimeMillis(): scala.Long = 0L
+
+  @noinline
+  def random(): scala.Double = 0.0
+}

--- a/javalib/src/main/scala/java/util/Date.scala
+++ b/javalib/src/main/scala/java/util/Date.scala
@@ -27,7 +27,7 @@ class Date(private var millis: Long) extends Object
     /* No need to check for overflow. If SJS lives that long (~year 275760),
      * it's OK to have a bug ;-)
      */
-    this(js.Date.now().toLong)
+    this(System.currentTimeMillis())
   }
 
   @Deprecated

--- a/javalib/src/main/scala/java/util/Random.scala
+++ b/javalib/src/main/scala/java/util/Random.scala
@@ -215,6 +215,6 @@ object Random {
     (randomInt().toLong << 32) | (randomInt().toLong & 0xffffffffL)
 
   private def randomInt(): Int =
-    (Math.floor(js.Math.random() * 4294967296.0) - 2147483648.0).toInt
+    (Math.floor(Math.random() * 4294967296.0) - 2147483648.0).toInt
 
 }

--- a/linker/shared/src/main/scala/org/scalajs/linker/backend/wasmemitter/ClassEmitter.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/backend/wasmemitter/ClassEmitter.scala
@@ -1410,17 +1410,30 @@ class ClassEmitter(coreSpec: CoreSpec) {
     val body = method.body.getOrElse(throw new Exception("abstract method cannot be transformed"))
 
     // Emit the function
-    FunctionEmitter.emitFunction(
-      functionID,
-      originalName,
-      Some(className),
-      captureParamDefs = None,
-      receiverType,
-      method.args,
-      restParam = None,
-      body,
-      method.resultType
-    )
+    if (className == SpecialNames.WasmSystemClass &&
+        namespace == MemberNamespace.Public && !methodName.isReflectiveProxy) {
+      emitSpecialMethod(
+        functionID,
+        originalName,
+        className,
+        methodName,
+        receiverType.get,
+        method.args,
+        method.resultType
+      )
+    } else {
+      FunctionEmitter.emitFunction(
+        functionID,
+        originalName,
+        Some(className),
+        captureParamDefs = None,
+        receiverType,
+        method.args,
+        restParam = None,
+        body,
+        method.resultType
+      )
+    }
 
     if (namespace == MemberNamespace.Public && !isHijackedClass) {
       /* Also generate the bridge that is stored in the table entries. In table
@@ -1464,6 +1477,48 @@ class ClassEmitter(coreSpec: CoreSpec) {
 
       fb.buildAndAddToModule()
     }
+  }
+
+  private def emitSpecialMethod(
+      functionID: wanme.FunctionID,
+      originalName: OriginalName,
+      enclosingClassName: ClassName,
+      methodName: MethodName,
+      receiverType: watpe.Type,
+      paramDefs: List[ParamDef],
+      resultType: Type
+  )(implicit ctx: WasmContext, pos: Position): Unit = {
+    val fb = new FunctionBuilder(ctx.moduleBuilder, functionID, originalName, pos)
+    val receiverParam = fb.addParam("this", receiverType)
+    val paramLocals = paramDefs.map { paramDef =>
+      fb.addParam(paramDef.originalName.orElse(paramDef.name.name),
+          transformParamType(paramDef.ptpe))
+    }
+    fb.setResultTypes(transformResultType(resultType))
+
+    methodName.simpleName.nameString match {
+      case "print" =>
+        fb += wa.LocalGet(paramLocals(0))
+        fb += wa.RefAsNonNull
+        fb += wa.Call(genFunctionID.wasmString.getWholeChars)
+        fb += wa.Call(genFunctionID.wasmEssentials.print)
+
+      case "nanoTime" =>
+        fb += wa.Call(genFunctionID.wasmEssentials.nanoTime)
+        fb += wa.I64TruncSatF64S
+
+      case "currentTimeMillis" =>
+        fb += wa.Call(genFunctionID.wasmEssentials.currentTimeMillis)
+        fb += wa.I64TruncSatF64S
+
+      case "random" =>
+        fb += wa.Call(genFunctionID.wasmEssentials.random)
+
+      case _ =>
+        throw new AssertionError(s"Unknown WasmSystem method ${methodName.nameString}")
+    }
+
+    fb.buildAndAddToModule()
   }
 
   private def makeDebugName(namespace: UTF8String, exportedName: String): OriginalName =

--- a/linker/shared/src/main/scala/org/scalajs/linker/backend/wasmemitter/CoreWasmLib.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/backend/wasmemitter/CoreWasmLib.scala
@@ -174,6 +174,8 @@ final class CoreWasmLib(coreSpec: CoreSpec, globalInfo: LinkedGlobalInfo) {
 
     if (!targetPureWasm) genImports()
     else {
+      genWasmEssentialsImports()
+
       if (coreSpec.wasmFeatures.exceptionHandling) {
         val exceptionSig = FunctionType(List(RefType.anyref), Nil)
         val typeID = ctx.moduleBuilder.functionTypeToTypeID(exceptionSig)
@@ -715,6 +717,26 @@ final class CoreWasmLib(coreSpec: CoreSpec, globalInfo: LinkedGlobalInfo) {
       List(anyref, anyref, anyref, anyref),
       Nil
     )
+  }
+
+  private def genWasmEssentialsImports()(implicit ctx: WasmContext): Unit = {
+    def addEssentialImport(id: genFunctionID.JSHelperFunctionID,
+        params: List[Type], results: List[Type]): Unit = {
+      val sig = FunctionType(params, results)
+      val typeID = ctx.moduleBuilder.functionTypeToTypeID(sig)
+      ctx.moduleBuilder.addImport(
+        Import(
+          EssentialExternsModule,
+          id.toString(), // import name, guaranteed by JSHelperFunctionID
+          ImportDesc.Func(id, OriginalName(id.toString()), typeID)
+        )
+      )
+    }
+
+    addEssentialImport(genFunctionID.wasmEssentials.print, List(RefType(genTypeID.i16Array)), Nil)
+    addEssentialImport(genFunctionID.wasmEssentials.nanoTime, Nil, List(Float64))
+    addEssentialImport(genFunctionID.wasmEssentials.currentTimeMillis, Nil, List(Float64))
+    addEssentialImport(genFunctionID.wasmEssentials.random, Nil, List(Float64))
   }
 
   // --- Global definitions ---

--- a/linker/shared/src/main/scala/org/scalajs/linker/backend/wasmemitter/EmbeddedConstants.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/backend/wasmemitter/EmbeddedConstants.scala
@@ -40,6 +40,9 @@ object EmbeddedConstants {
   /** Imported modules for WTF-16 strings, which cannot use the JS string builtins. */
   final val WTF16StringConstantsModule = "wtf16Strings"
 
+  /** Module for the essential externs for testing without the component model, defined by hand in `LoaderContent`. */
+  final val EssentialExternsModule = "essentialExterns"
+
   /* Values returned by the `jsValueType` helper.
    *
    * 0: false

--- a/linker/shared/src/main/scala/org/scalajs/linker/backend/wasmemitter/Emitter.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/backend/wasmemitter/Emitter.scala
@@ -225,8 +225,14 @@ final class Emitter(config: Emitter.Config) {
       fb += wa.Return
       fb += wa.End
 
-      // TODO Print *something* useful, somehow.
-      // For now at least we fail the execution.
+      // TODO Print the toString() of the exception, if possible
+      val message = "Uncaught exception"
+      for (c <- message)
+        fb += wa.I32Const(c.toInt)
+      fb += wa.ArrayNewFixed(genTypeID.i16Array, message.length())
+      fb += wa.Call(genFunctionID.wasmEssentials.print)
+
+      // In any case, fail the execution
       fb += wa.Unreachable
     }
 

--- a/linker/shared/src/main/scala/org/scalajs/linker/backend/wasmemitter/Emitter.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/backend/wasmemitter/Emitter.scala
@@ -59,7 +59,9 @@ final class Emitter(config: Emitter.Config) {
 
   def emit(module: ModuleSet.Module, globalInfo: LinkedGlobalInfo, logger: Logger): Result = {
     val (wasmModule, jsFileContentInfo) = emitWasmModule(module, globalInfo)
-    val loaderContent = LoaderContent.bytesContent
+    val loaderContent =
+      if (coreSpec.wasmFeatures.targetPureWasm) LoaderContent.pureWasmBytesContent
+      else LoaderContent.bytesContent
     val jsFileContent = buildJSFileContent(module, jsFileContentInfo)
 
     new Result(wasmModule, loaderContent, jsFileContent)

--- a/linker/shared/src/main/scala/org/scalajs/linker/backend/wasmemitter/SpecialNames.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/backend/wasmemitter/SpecialNames.scala
@@ -50,6 +50,9 @@ object SpecialNames {
   val WasmRuntimeClass =
     ClassName("org.scalajs.linker.runtime.WasmRuntime")
 
+  val WasmSystemClass =
+    ClassName("java.lang.WasmSystem$")
+
   // Field names
 
   val valueFieldSimpleName = SimpleFieldName("value")

--- a/linker/shared/src/main/scala/org/scalajs/linker/backend/wasmemitter/VarGen.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/backend/wasmemitter/VarGen.scala
@@ -119,6 +119,7 @@ object VarGen {
     final case object f32Fmod extends FunctionID
     final case object f64Fmod extends FunctionID
     final case object itoa extends FunctionID
+    final case object hijackedValueToString extends FunctionID
     final case object stringLiteral extends FunctionID
 
     final case object malloc extends FunctionID

--- a/linker/shared/src/main/scala/org/scalajs/linker/backend/wasmemitter/VarGen.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/backend/wasmemitter/VarGen.scala
@@ -270,6 +270,16 @@ object VarGen {
       case object charCodeAt extends FunctionID
     }
     case object scalaValueType extends FunctionID
+
+    // Wasm essentials
+
+    object wasmEssentials {
+      // Extend JSHelperFunctionID although these have nothing to do with JS
+      case object print extends JSHelperFunctionID
+      case object nanoTime extends JSHelperFunctionID
+      case object currentTimeMillis extends JSHelperFunctionID
+      case object random extends JSHelperFunctionID
+    }
   }
 
   object genFieldID {


### PR DESCRIPTION
Namely: `print`, `nanoTime`, `currentTimeMillis` and `random`.

TODO: This won't work in the component model, as it requires four
dedicated imports. Needs fixing before it can be merged.

Draft PR for getting the CI to run on the rest.