### PR TITLE
Various fix in Wasm Component Model API

### DIFF
--- a/compiler/src/main/scala/org/scalajs/nscplugin/GenJSCode.scala
+++ b/compiler/src/main/scala/org/scalajs/nscplugin/GenJSCode.scala
@@ -62,7 +62,8 @@ import org.scalajs.ir.Types.ArrayType
  */
 abstract class GenJSCode[G <: Global with Singleton](val global: G)
     extends plugins.PluginComponent with TypeConversions[G] with JSEncoding[G]
-    with GenJSExports[G] with GenJSFiles[G] with CompatComponent {
+    with GenJSExports[G] with GenJSFiles[G] with CompatComponent
+    with GenWasmComponentModelInterop[G] {
 
   import GenJSCode._
 
@@ -162,7 +163,8 @@ abstract class GenJSCode[G <: Global with Singleton](val global: G)
       val paramSyms: List[Symbol])
       extends EnclosingLabelDefInfo
 
-  class JSCodePhase(prev: Phase) extends StdPhase(prev) with JSExportsPhase {
+  class JSCodePhase(prev: Phase) extends StdPhase(prev) with JSExportsPhase
+      with WasmComponentModelInteropPhase {
 
     override def name: String = phaseName
     override def description: String = GenJSCode.this.description
@@ -489,18 +491,9 @@ abstract class GenJSCode[G <: Global with Singleton](val global: G)
                 }
               } else if (isWasmComponentRecordClass(sym)) {
                 genClass(cd)
-              } else if (isWasmComponentInterfaceClass(sym)) {
-                if (sym.hasAnnotation(ComponentImportAnnotation))
-                  genImportWasmComponentInterfaceClassData(cd)
-                else if (sym.hasAnnotation(ComponentExportAnnotation)) {
-                  genExportWasmComponentInterfaceClassData(cd)
-                } else
-                  throw new AssertionError(s"component.interface must annotated either of @ComponentImport or @ComponentExport")
               } else if (isWasmComponentResourceType(sym)) {
-                if (sym.hasAnnotation(ComponentNativeAnnotation))
-                  genWasmComponentResourceClassData(cd)
-                else
-                  throw new AssertionError(s"non native resource type isn't yet supported: $sym")
+                genWasmComponentResourceClassData(cd)
+                // TODO: export resource?
               } else if (sym.isTraitOrInterface) {
                 genInterface(cd)
               } else {
@@ -685,23 +678,33 @@ abstract class GenJSCode[G <: Global with Singleton](val global: G)
       val methodsBuilder = List.newBuilder[js.MethodDef]
       val jsNativeMembersBuilder = List.newBuilder[js.JSNativeMemberDef]
       val componentNativeMembersBuilder = List.newBuilder[js.ComponentNativeMemberDef]
-
-      val componentModuleOpt = sym.getAnnotation(ComponentImportAnnotation).orElse {
-        sym.companionClass.getAnnotation(ComponentImportAnnotation)
-      }.flatMap(_.stringArg(0))
+      val wasmComponentExportDefsBuilder = List.newBuilder[js.WasmComponentExportDef]
 
       for (dd <- collectDefDefs(cd.impl)) {
-        if (dd.symbol.hasAnnotation(ComponentNativeAnnotation)) {
-          componentModuleOpt match {
-            case Some(module) =>
-              componentNativeMembersBuilder += genComponentNativeMemberDef(dd, module)
-            case None =>
-              throw new AssertionError("Cannot define component native member for non @ComponentImport annotated class.")
-          }
-        } else if (dd.symbol.hasAnnotation(JSNativeAnnotation))
+        if (dd.symbol.hasAnnotation(ComponentImportAnnotation)) {
+          val annot = dd.symbol.getAnnotation(ComponentImportAnnotation).get
+          val moduleName = annot.stringArg(0).get
+          val functionName = annot.stringArg(1).get
+          val flags = js.MemberFlags.empty.withNamespace(js.MemberNamespace.PublicStatic)
+          componentNativeMembersBuilder +=
+            genComponentNativeMemberDef(flags, dd, moduleName,
+                js.WasmComponentFunctionName.Function(functionName))
+        } else if (isWasmComponentResourceStaticMethod(dd.symbol)) {
+          componentNativeMembersBuilder ++= genComponentResourceStaticMethodDef(dd)
+        } else if (isWasmComponentResourceConstructor(dd.symbol)) {
+          componentNativeMembersBuilder ++= genComponentResourceConstructor(dd)
+        } else if (dd.symbol.hasAnnotation(JSNativeAnnotation)) {
           jsNativeMembersBuilder += genJSNativeMemberDef(dd)
-        else
+        } else if (dd.symbol.hasAnnotation(ComponentExportAnnotation)) {
+          for {
+            method <- genMethod(dd)
+            info <- jsInterop.wasmComponentExportOf(dd.symbol)
+          } {
+            wasmComponentExportDefsBuilder += genWasmComponentExportDef(info, method)
+          }
+        } else {
           methodsBuilder ++= genMethod(dd)
+        }
       }
 
       val fields = if (!isHijacked) genClassFields(cd) else Nil
@@ -829,7 +832,7 @@ abstract class GenJSCode[G <: Global with Singleton](val global: G)
           memberExports,
           jsNativeMembers,
           componentNativeMembers = componentNativeMembersBuilder.result(),
-          topLevelExportDefs)(
+          topLevelExportDefs ++ wasmComponentExportDefsBuilder.result())(
           optimizerHints)
     }
 
@@ -1165,93 +1168,6 @@ abstract class GenJSCode[G <: Global with Singleton](val global: G)
       val closure = js.Closure(js.ClosureFlags.arrow, jsClassCaptures, Nil, None, jstpe.AnyType,
           js.Block(inlinedCtorStats, selfRef), jsSuperClassValue :: args)
       js.JSFunctionApply(closure, Nil)
-    }
-
-    private def genImportWasmComponentInterfaceClassData(cd: ClassDef): js.ClassDef = {
-      val sym = cd.symbol
-      implicit val pos = sym.pos
-
-      val annotOpt = sym.annotations.find(_.symbol == ComponentImportAnnotation)
-      val annot = annotOpt.get
-
-      val module = annot.stringArg(0).get
-
-      val classIdent = encodeClassNameIdent(sym)
-      val kind = {
-        ClassKind.NativeWasmComponentInterfaceClass
-      }
-
-      val componentNativeMembersBuilder = List.newBuilder[js.ComponentNativeMemberDef]
-      for (dd <- collectDefDefs(cd.impl)) {
-        if (!dd.symbol.isConstructor) {
-          componentNativeMembersBuilder += genComponentNativeMemberDef(dd, module)
-        }
-      }
-      js.ClassDef(classIdent, originalNameOfClass(sym), kind, None, superClass= None,
-          genClassInterfaces(sym, false), None, None,
-          Nil, Nil, None, Nil, Nil, componentNativeMembersBuilder.result(), Nil)(
-          OptimizerHints.empty)
-    }
-
-    private def genExportWasmComponentInterfaceClassData(cd: ClassDef): js.ClassDef = {
-      val sym = cd.symbol
-      implicit val pos = sym.pos
-
-      val annotOpt = sym.annotations.find(_.symbol == ComponentExportAnnotation)
-      val annot = annotOpt.get
-
-      val module = annot.stringArg(0).get
-
-      val classIdent = encodeClassNameIdent(sym)
-      val kind = {
-        ClassKind.NativeWasmComponentInterfaceClass
-      }
-
-      val wasmComponentExportDefsBuilder = List.newBuilder[js.WasmComponentExportDef]
-      for (dd <- collectDefDefs(cd.impl)) {
-        if (!dd.symbol.isConstructor && !dd.symbol.isAbstract)
-          wasmComponentExportDefsBuilder += genWasmComponentExport(dd)
-      }
-      js.ClassDef(classIdent, originalNameOfClass(sym), kind, None, superClass= None,
-          genClassInterfaces(sym, false), None, None,
-          Nil, Nil, None, Nil, Nil, Nil, wasmComponentExportDefsBuilder.result())(
-          OptimizerHints.empty)
-    }
-
-    def genWasmComponentResourceClassData(cd: ClassDef): js.ClassDef = {
-      val sym = cd.symbol
-      implicit val pos = sym.pos
-
-      val classIdent = encodeClassNameIdent(sym)
-      val kind = {
-        ClassKind.NativeWasmComponentResourceClass
-      }
-
-      val annotOpt = sym.annotations.find(_.symbol == ComponentImportAnnotation)
-      val annot = annotOpt.get
-      val module = annot.stringArg(0).get
-
-      val componentNativeMembersBuilder = List.newBuilder[js.ComponentNativeMemberDef]
-      for (dd <- collectDefDefs(cd.impl)) {
-        if (!dd.symbol.isConstructor) {
-          componentNativeMembersBuilder += genComponentNativeMemberDef(dd, module)
-        }
-      }
-
-      val resourceName = sym.rawname.encoded.replaceAll("([a-z])([A-Z])", "$1-$2").toLowerCase()
-      componentNativeMembersBuilder +=
-        js.ComponentNativeMemberDef(
-          js.MemberFlags.empty.withNamespace(js.MemberNamespace.Public),
-          js.MethodIdent(MethodName("close", Nil, jstpe.VoidRef)),
-          module,
-          s"[resource-drop]$resourceName",
-          wit.FuncType(List(wit.ResourceType(classIdent.name)), None)
-        )(ir.Position.NoPosition)
-
-      js.ClassDef(classIdent, originalNameOfClass(sym), kind, None, superClass= None,
-          genClassInterfaces(sym, false), None, None,
-          Nil, Nil, None, Nil, Nil, componentNativeMembersBuilder.result(), Nil)(
-          OptimizerHints.empty)
     }
 
     // Generate the class data of a JS class -----------------------------------
@@ -2387,162 +2303,6 @@ abstract class GenJSCode[G <: Global with Singleton](val global: G)
       val methodName = encodeMethodSym(sym)
       val jsNativeLoadSpec = jsInterop.jsNativeLoadSpecOf(sym)
       js.JSNativeMemberDef(flags, methodName, jsNativeLoadSpec)
-    }
-
-    private def genComponentNativeMemberDef(tree: DefDef, module: String): js.ComponentNativeMemberDef = {
-      implicit val pos = tree.pos
-      val sym = tree.symbol
-      val flags = js.MemberFlags.empty.withNamespace(js.MemberNamespace.PublicStatic)
-      val methodName = sym.encodedName.replaceAll("([a-z])([A-Z])", "$1-$2").toLowerCase()
-      withNewLocalNameScope {
-        val funcType = jsInterop.componentFunctionTypeOf(sym)
-        val baseParams = funcType.params.map { p => toWIT(p) }
-        val (params, name) =
-          if (isWasmComponentResourceType(sym.owner)) {
-            val params = wit.ResourceType(encodeClassName(sym.owner)) +: baseParams
-            val resourceName = sym.owner.rawname.encoded.replaceAll("([a-z])([A-Z])", "$1-$2").toLowerCase()
-            val name = s"[method]$resourceName.$methodName"
-            (params, name)
-          } else if (sym.owner.isModuleClass && isWasmComponentResourceType(sym.owner.companionClass)) {
-            // companion object of the component.Resource class
-            val resourceName = sym.owner.companionClass.rawname.encoded.replaceAll("([a-z])([A-Z])", "$1-$2").toLowerCase()
-            val name =
-              if (sym.name == nme.apply) s"[constructor]$resourceName"
-              else s"[static]$resourceName.$methodName"
-            (baseParams, name)
-          } else {
-            (baseParams, methodName)
-          }
-
-        val ft = wit.FuncType(
-          params,
-          toResultWIT(funcType.resultType)
-        )
-        js.ComponentNativeMemberDef(flags, encodeMethodSym(sym), module, name, ft)
-      }
-    }
-
-    lazy val primitiveIRWIT: Map[jstpe.Type, wit.ValType] = Map(
-      jstpe.VoidType -> wit.VoidType,
-      jstpe.BooleanType -> wit.BoolType,
-      jstpe.ByteType -> wit.S8Type,
-      jstpe.ShortType -> wit.S16Type,
-      jstpe.IntType -> wit.S32Type,
-      jstpe.LongType -> wit.S64Type,
-      jstpe.FloatType -> wit.F32Type,
-      jstpe.DoubleType -> wit.F64Type,
-      jstpe.CharType -> wit.CharType,
-      jstpe.StringType -> wit.StringType,
-      jstpe.ClassType(ClassName("java.lang.String"), true) -> wit.StringType
-    )
-
-    lazy val unsigned2WIT: Map[Symbol, wit.ValType] = Map(
-      ComponentUnsigned_UByte -> wit.U8Type,
-      ComponentUnsigned_UShort -> wit.U16Type,
-      ComponentUnsigned_UInt -> wit.U32Type,
-      ComponentUnsigned_ULong -> wit.U64Type
-    )
-
-    def toResultWIT(tpe: Type): Option[wit.ValType] = {
-      if (toIRType(tpe) == jstpe.VoidType) None
-      else Some(toWIT(tpe))
-    }
-
-
-    def toWIT(tpe: Type): wit.ValType = {
-      def toFlagTypeOpt(tpe: Type): Option[wit.FlagsType] = {
-        for {
-          ann <- tpe.typeSymbolDirect.getAnnotation(ComponentFlagsAnnotation)
-          numFlags <- ann.intArg(0)
-          if toIRType(tpe) == jstpe.IntType
-        } yield wit.FlagsType(numFlags)
-      }
-
-      toFlagTypeOpt(tpe).orElse {
-        unsigned2WIT.get(tpe.typeSymbolDirect)
-      }.orElse {
-        toWITMaybeArray(tpe.dealiasWiden)
-      }.orElse {
-        primitiveIRWIT.get(toIRType(tpe.dealiasWiden))
-      }.getOrElse {
-        tpe.dealiasWiden.typeSymbol match {
-          case tsym if tsym.fullName.startsWith("scala.Tuple") =>
-            wit.TupleType(tpe.typeArgs.map(toWIT(_)))
-
-          case tsym if isWasmComponentRecordClass(tsym) =>
-            // TODO: it needs to be sorted by the order of record in wit definition
-            val className = encodeClassName(tsym)
-            val fields: List[wit.FieldType] = tsym.info.decls.collect {
-              case f if f.isField =>
-                val label = encodeFieldSym(f)(f.pos).name
-                val fieldType = jsInterop.componentVariantValueTypeOf(f)
-                val valueType = toWIT(fieldType)
-                wit.FieldType(label, valueType)
-            }.toList
-            wit.RecordType(className, fields)
-
-          case tsym if tsym.isSubClass(ComponentResourceClass) =>
-            wit.ResourceType(encodeClassName(tsym))
-
-          case tsym if tsym.isSubClass(ComponentResultClass) && tsym.isSealed =>
-            val List(ok, err) = tpe.typeArgs
-            wit.ResultType(toWIT(ok), toWIT(err))
-
-          case tsym if tsym.fullName == "java.util.Optional" =>
-            val List(t) = tpe.dealiasWiden.typeArgs
-            wit.OptionType(toWIT(t))
-
-          case tsym if tsym.isSubClass(ComponentVariantClass) && tsym.isSealed =>
-            // Sort by declaration order, we need to know which index
-            // corresponds to which type.
-            // Make sure code generator declare children by index order.
-            // assert(tsym.isClass)
-            val cases = tsym.sealedChildren.toList.sortBy(_.pos.line) map { child =>
-              // assert(child.isFinal)
-              // assert(child.isClass)
-              val valueType = jsInterop.componentVariantValueTypeOf(child)
-              wit.CaseType(
-                encodeClassName(child),
-                toWIT(valueType)
-              )
-            }
-            wit.VariantType(
-              encodeClassName(tsym),
-              cases
-            )
-          case _ => throw new AssertionError(s"invalid tpe: $tpe")
-        }
-      }
-    }
-
-    private def toWITMaybeArray(tpe: Type): Option[wit.ValType] = {
-      tpe match {
-        case TypeRef(_, sym, targs) =>
-          sym match {
-            case ArrayClass =>
-              Some(wit.ListType(toWIT(targs.head), None))
-            case _ => None
-          }
-        case _ => None
-      }
-    }
-
-    def genWasmComponentExport(method: DefDef): js.WasmComponentExportDef = {
-      val sym = method.symbol
-      val info = jsInterop.wasmComponentExportOf(sym)
-      withNewLocalNameScope {
-        val methodDef = genMethod(method).get
-        val signature = wit.FuncType(
-          info.signature.params.map(toWIT(_)),
-          toResultWIT(info.signature.resultType)
-        )
-        js.WasmComponentExportDef(
-          DefaultModuleID,
-          info.name,
-          methodDef,
-          signature
-        )(method.pos)
-      }
     }
 
     /** Generates the MethodDef of a (non-constructor) method
@@ -3849,12 +3609,13 @@ abstract class GenJSCode[G <: Global with Singleton](val global: G)
           genApplyJSClassMethod(genExpr(receiver), sym, genActualArgs(sym, args))
       } else if (sym.hasAnnotation(JSNativeAnnotation)) {
         genJSNativeMemberCall(tree, isStat)
-      } else if (sym.hasAnnotation(ComponentNativeAnnotation)) {
-        genComponentNativeMemberCall(sym, tree, None, isStat)
-      } else if (isWasmComponentResourceType(receiver.tpe) &&
-          receiver.tpe.typeSymbol.hasAnnotation(ComponentNativeAnnotation)) {
+      // Wasm Component Model
+      } else if (sym.hasAnnotation(ComponentResourceMethodAnnotation) ||
+          sym.hasAnnotation(ComponentResourceDropAnnotation)) {
         genComponentNativeMemberCall(sym, tree, Some(receiver), isStat)
-      } else if (sym.owner.hasAnnotation(ComponentImportAnnotation)) {
+      } else if (sym.hasAnnotation(ComponentImportAnnotation) ||
+          sym.hasAnnotation(ComponentResourceStaticMethodAnnotation) ||
+          sym.hasAnnotation(ComponentResourceConstructorAnnotation)) {
         genComponentNativeMemberCall(sym, tree, None, isStat)
       } else if (compileAsStaticMethod(sym)) {
         if (sym.isMixinConstructor) {
@@ -5939,28 +5700,6 @@ abstract class GenJSCode[G <: Global with Singleton](val global: G)
       genJSCallGeneric(sym, receiver, args, isStat)
     }
 
-    private def genComponentNativeMemberCall(method: Symbol, tree: Apply,
-        receiver: Option[Tree], isStat: Boolean): js.Tree = {
-      val sym = tree.symbol
-      val Apply(Select(qual, _), args) = tree
-
-      implicit val pos = tree.pos
-
-      val methodIdent = encodeMethodSym(method)
-
-      // Not using encodeClassName(method.owner)
-      // The method.owner of `close` methods will be `component.Resource` instead of the specific resource class that extends the Resource trait.
-      // `component.Resource` defines a `final def close`, preventing users from overriding the close implementation.
-      // However, the actual `close` methods to be called are automatically generated for all resource classes.
-      val className = encodeClassName(qual.symbol.tpe.typeSymbol)
-      js.ComponentFunctionApply(
-        receiver.map(genExpr(_)),
-        className,
-        methodIdent,
-        genActualArgs(sym, args)
-      )(toIRType(tree.tpe))
-    }
-
     /** Gen JS code for a call to a native JS def or val. */
     private def genJSNativeMemberCall(tree: Apply, isStat: Boolean): js.Tree = {
       val sym = tree.symbol
@@ -7462,12 +7201,6 @@ abstract class GenJSCode[G <: Global with Singleton](val global: G)
   private lazy val hasNewCollections =
     !scala.util.Properties.versionNumberString.startsWith("2.12.")
 
-  def isWasmComponentResourceType(tpe: Type): Boolean =
-    isWasmComponentResourceType(tpe.typeSymbol)
-
-  def isWasmComponentResourceType(sym: Symbol): Boolean =
-    sym.isNonBottomSubClass(ComponentResourceClass) && sym != ComponentResourceClass
-
   /** Tests whether the given type represents a JavaScript type,
    *  i.e., whether it extends scala.scalajs.js.Any.
    */
@@ -7521,17 +7254,6 @@ abstract class GenJSCode[G <: Global with Singleton](val global: G)
     sym.superClass == JSFunctionClass &&
     sym.info.decl(nme.apply).filter(JSCallingConvention.isCall(_)).exists
   }
-
-  private def isWasmComponentRecordClass(sym: Symbol): Boolean =
-    sym.hasAnnotation(ComponentRecordAnnotation) && sym.isFinal
-
-  private def isWasmComponentFlags(sym: Symbol): Boolean =
-    sym.hasAnnotation(ComponentFlagsAnnotation)
-
-  private def isWasmComponentInterfaceClass(sym: Symbol): Boolean =
-    sym.tpe.typeSymbol.isNonBottomSubClass(ComponentInterfaceClass) &&
-    sym.tpe.typeSymbol != ComponentInterfaceClass &&
-    sym.isModuleClass
 
   private def hasDefaultCtorArgsAndJSModule(classSym: Symbol): Boolean = {
     /* Get the companion module class.

--- a/compiler/src/main/scala/org/scalajs/nscplugin/GenWasmComponentModelInterop.scala
+++ b/compiler/src/main/scala/org/scalajs/nscplugin/GenWasmComponentModelInterop.scala
@@ -1,0 +1,322 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
+package org.scalajs.nscplugin
+
+import scala.tools.nsc._
+
+import scala.collection.mutable
+
+import org.scalajs.ir.{
+  Names,
+  Trees => js,
+  Types => jstpe,
+  WasmInterfaceTypes => wit,
+  ClassKind,
+  Position,
+}
+
+trait GenWasmComponentModelInterop[G <: Global with Singleton] extends SubComponent {
+  this: GenJSCode[G] =>
+
+  import global._
+  import definitions._
+  import jsAddons._
+  import jsDefinitions._
+
+  // - annotated with @ComponentResourceMethod
+  // - owner is a companion object of @ComponentResourceImport annotated trait
+  def isWasmComponentResourceStaticMethod(sym: Symbol): Boolean =
+    sym.hasAnnotation(ComponentResourceStaticMethodAnnotation) &&
+        sym.owner.isModuleClass &&
+        sym.owner.companionClass.hasAnnotation(ComponentResourceImportAnnotation)
+
+  def isWasmComponentResourceConstructor(sym: Symbol): Boolean =
+    sym.hasAnnotation(ComponentResourceConstructorAnnotation) &&
+        sym.owner.isModuleClass &&
+        sym.owner.companionClass.hasAnnotation(ComponentResourceImportAnnotation)
+
+  def isWasmComponentRecordClass(sym: Symbol): Boolean =
+    sym.hasAnnotation(ComponentRecordAnnotation) && sym.isFinal
+
+  def isWasmComponentFlags(sym: Symbol): Boolean =
+    sym.hasAnnotation(ComponentFlagsAnnotation)
+
+  def isWasmComponentResourceType(tpe: Type): Boolean =
+    isWasmComponentResourceType(tpe.typeSymbol)
+
+  def isWasmComponentResourceType(sym: Symbol): Boolean =
+    sym.hasAnnotation(ComponentResourceImportAnnotation)
+
+  trait WasmComponentModelInteropPhase { this: JSCodePhase =>
+
+    def genComponentNativeMemberCall(method: Symbol, tree: Apply,
+        receiver: Option[Tree], isStat: Boolean): js.Tree = {
+      val sym = tree.symbol
+      val Apply(Select(qual, _), args) = tree
+      implicit val pos = tree.pos
+      val methodIdent = encodeMethodSym(method)
+
+      // Not using encodeClassName(method.owner)
+      // The method.owner of `close` methods will be `component.Resource` instead of the specific resource class that extends the Resource trait.
+      // `component.Resource` defines a `final def close`, preventing users from overriding the close implementation.
+      // However, the actual `close` methods to be called are automatically generated for all resource classes.
+      // val className = encodeClassName(qual.symbol.tpe.typeSymbol)
+
+      val className = encodeClassName(method.owner)
+      js.ComponentFunctionApply(
+        receiver.map(genExpr(_)),
+        className,
+        methodIdent,
+        args.map(genExpr(_)) // genActualArgs?
+      )(toIRType(tree.tpe))
+    }
+
+    def genWasmComponentResourceClassData(cd: ClassDef): js.ClassDef = {
+      val sym = cd.symbol
+      implicit val pos = sym.pos
+
+      val classIdent = encodeClassNameIdent(sym)
+      val kind = ClassKind.NativeWasmComponentResourceClass
+
+      val annot = sym.getAnnotation(ComponentResourceImportAnnotation).get
+      val moduleName = annot.stringArg(0).get
+      val resourceName = annot.stringArg(1).get
+
+      val flags = js.MemberFlags.empty.withNamespace(js.MemberNamespace.Public)
+      val componentNativeMembersBuilder = List.newBuilder[js.ComponentNativeMemberDef]
+      for (stat <- cd.impl.body) {
+        stat match {
+          case dd: DefDef if dd.symbol.hasAnnotation(ComponentResourceMethodAnnotation) =>
+            for {
+              annot <- dd.symbol.getAnnotation(ComponentResourceMethodAnnotation)
+              functionName <- annot.stringArg(0)
+            } {
+              componentNativeMembersBuilder +=
+                genComponentNativeMemberDef(flags, dd, moduleName,
+                    js.WasmComponentFunctionName.ResourceMethod(functionName, resourceName))
+            }
+
+          case dd: DefDef if dd.symbol.hasAnnotation(ComponentResourceDropAnnotation) =>
+            for {
+              annot <- dd.symbol.getAnnotation(ComponentResourceDropAnnotation)
+            } {
+              componentNativeMembersBuilder +=
+                genComponentNativeMemberDef(flags, dd, moduleName,
+                    js.WasmComponentFunctionName.ResourceDrop(resourceName))
+            }
+          case _ =>
+        }
+      }
+      js.ClassDef(classIdent, originalNameOfClass(sym), kind, None, superClass= None,
+          interfaces = Nil, None, None,
+          Nil, Nil, None, Nil, Nil, componentNativeMembersBuilder.result(), Nil)(
+          js.OptimizerHints.empty)
+    }
+  }
+
+  def genComponentNativeMemberDef(flags: js.MemberFlags, tree: DefDef, moduleName: String,
+      name: js.WasmComponentFunctionName): js.ComponentNativeMemberDef = {
+    implicit val pos = tree.pos
+    val sym = tree.symbol
+    withNewLocalNameScope {
+      val funcType = jsInterop.componentFunctionTypeOf(sym)
+      val baseParams = funcType.params.map(toWIT(_))
+      val params = name match {
+        case _:js.WasmComponentFunctionName.Function |
+             _:js.WasmComponentFunctionName.ResourceConstructor |
+             _:js.WasmComponentFunctionName.ResourceStaticMethod => baseParams
+        case _:js.WasmComponentFunctionName.ResourceMethod |
+             _:js.WasmComponentFunctionName.ResourceDrop =>
+          wit.ResourceType(encodeClassName(sym.owner)) +: baseParams
+      }
+      val witFuncType = wit.FuncType(
+        params,
+        toResultWIT(funcType.resultType)
+      )
+      js.ComponentNativeMemberDef(flags, moduleName, name,
+          encodeMethodSym(sym), witFuncType)
+    }
+  }
+
+  def genComponentResourceStaticMethodDef(tree: DefDef): Option[js.ComponentNativeMemberDef] = {
+    implicit val pos = tree.pos
+    val sym = tree.symbol
+
+    val flags = js.MemberFlags.empty.withNamespace(js.MemberNamespace.PublicStatic)
+    val funcType = jsInterop.componentFunctionTypeOf(sym)
+
+    for {
+      methodAnnot <- sym.getAnnotation(ComponentResourceStaticMethodAnnotation)
+      resourceAnnot <- sym.owner.companionClass.getAnnotation(ComponentResourceImportAnnotation)
+      methodName <- methodAnnot.stringArg(0)
+      moduleName <- resourceAnnot.stringArg(0)
+      resourceName <- resourceAnnot.stringArg(1)
+    } yield {
+      println(methodName)
+      val name = js.WasmComponentFunctionName.ResourceStaticMethod(
+          func = methodName, resource = resourceName)
+      withNewLocalNameScope {
+        val params = funcType.params.map { p => toWIT(p) }
+        val ft = wit.FuncType(params, toResultWIT(funcType.resultType))
+        js.ComponentNativeMemberDef(flags, moduleName, name, encodeMethodSym(sym), ft)
+      }
+    }
+  }
+
+  def genComponentResourceConstructor(tree: DefDef): Option[js.ComponentNativeMemberDef] = {
+    implicit val pos = tree.pos
+    val sym = tree.symbol
+
+    val flags = js.MemberFlags.empty.withNamespace(js.MemberNamespace.PublicStatic)
+    val funcType = jsInterop.componentFunctionTypeOf(sym)
+
+    for {
+      methodAnnot <- sym.getAnnotation(ComponentResourceConstructorAnnotation)
+      resourceAnnot <- sym.owner.companionClass.getAnnotation(ComponentResourceImportAnnotation)
+      moduleName <- resourceAnnot.stringArg(0)
+      resourceName <- resourceAnnot.stringArg(1)
+    } yield {
+      val name = js.WasmComponentFunctionName.ResourceConstructor(resourceName)
+      withNewLocalNameScope {
+        val params = funcType.params.map { p => toWIT(p) }
+        val ft = wit.FuncType(params, toResultWIT(funcType.resultType))
+        js.ComponentNativeMemberDef(flags, moduleName, name, encodeMethodSym(sym), ft)
+      }
+    }
+  }
+
+
+  def genWasmComponentExportDef(info: jsInterop.WasmComponentExportInfo,
+      methodDef: js.MethodDef): js.WasmComponentExportDef = {
+    withNewLocalNameScope {
+      val signature = wit.FuncType(
+        info.signature.params.map(toWIT(_)),
+        toResultWIT(info.signature.resultType)
+      )
+      js.WasmComponentExportDef(
+        info.moduleName,
+        js.WasmComponentFunctionName.Function(info.name),
+        methodDef,
+        signature
+      )(methodDef.pos)
+    }
+  }
+
+  private def toFlagTypeOpt(tpe: Type): Option[wit.FlagsType] = {
+    for {
+      ann <- tpe.typeSymbolDirect.getAnnotation(ComponentFlagsAnnotation)
+      numFlags <- ann.intArg(0)
+      if toIRType(tpe) == jstpe.IntType
+    } yield wit.FlagsType(numFlags)
+  }
+
+  private def toWIT(tpe: Type): wit.ValType = {
+    toFlagTypeOpt(tpe).orElse {
+      unsigned2WIT.get(tpe.typeSymbolDirect)
+    }.orElse {
+      toWITMaybeArray(tpe.dealiasWiden)
+    }.orElse {
+      primitiveIRWIT.get(toIRType(tpe.dealiasWiden))
+    }.getOrElse {
+      tpe.dealiasWiden.typeSymbol match {
+        case tsym if tsym.fullName.startsWith("scala.Tuple") =>
+          wit.TupleType(tpe.typeArgs.map(toWIT(_)))
+
+        case tsym if isWasmComponentRecordClass(tsym) =>
+          // TODO: it needs to be sorted by the order of record in wit definition
+          val className = encodeClassName(tsym)
+          val fields: List[wit.FieldType] = tsym.info.decls.collect {
+            case f if f.isField =>
+              val label = encodeFieldSym(f)(f.pos).name
+              val fieldType = jsInterop.componentVariantValueTypeOf(f)
+              val valueType = toWIT(fieldType)
+              wit.FieldType(label, valueType)
+          }.toList
+          wit.RecordType(className, fields)
+
+        case tsym if isWasmComponentResourceType(tsym) =>
+          wit.ResourceType(encodeClassName(tsym))
+
+        case tsym if tsym.isSubClass(ComponentResultClass) && tsym.isSealed =>
+          val List(ok, err) = tpe.typeArgs
+          wit.ResultType(toWIT(ok), toWIT(err))
+
+        case tsym if tsym.fullName == "java.util.Optional" =>
+          val List(t) = tpe.dealiasWiden.typeArgs
+          wit.OptionType(toWIT(t))
+
+        case tsym if tsym.isSubClass(ComponentVariantClass) && tsym.isSealed =>
+          // Sort by declaration order, we need to know which index
+          // corresponds to which type.
+          // Make sure code generator declare children by index order.
+          // assert(tsym.isClass)
+          val cases = tsym.sealedChildren.toList.sortBy(_.pos.line) map { child =>
+            // assert(child.isFinal)
+            // assert(child.isClass)
+            val valueType = jsInterop.componentVariantValueTypeOf(child)
+            wit.CaseType(
+              encodeClassName(child),
+              toWIT(valueType)
+            )
+          }
+          wit.VariantType(
+            encodeClassName(tsym),
+            cases
+          )
+        case _ => throw new AssertionError(s"invalid tpe: $tpe")
+      }
+    }
+  }
+
+  private def toResultWIT(tpe: Type): Option[wit.ValType] = {
+    if (toIRType(tpe) == jstpe.VoidType) None
+    else Some(toWIT(tpe))
+  }
+
+  private def toWITMaybeArray(tpe: Type): Option[wit.ValType] = {
+    tpe match {
+      case TypeRef(_, ArrayClass, targs) =>
+        Some(wit.ListType(toWIT(targs.head), None))
+      case _ => None
+    }
+  }
+
+  private lazy val ScalaJSComponentUnsignedPackageModule = rootMirror.getPackageObject("scala.scalajs.component.unsigned")
+    private lazy val ComponentUnsigned_UByte = getTypeMember(ScalaJSComponentUnsignedPackageModule, newTermName("UByte"))
+    private lazy val ComponentUnsigned_UShort = getTypeMember(ScalaJSComponentUnsignedPackageModule, newTermName("UShort"))
+    private lazy val ComponentUnsigned_UInt = getTypeMember(ScalaJSComponentUnsignedPackageModule, newTermName("UInt"))
+    private lazy val ComponentUnsigned_ULong = getTypeMember(ScalaJSComponentUnsignedPackageModule, newTermName("ULong"))
+
+  private lazy val unsigned2WIT: Map[Symbol, wit.ValType] = Map(
+    ComponentUnsigned_UByte  -> wit.U8Type,
+    ComponentUnsigned_UShort -> wit.U16Type,
+    ComponentUnsigned_UInt   -> wit.U32Type,
+    ComponentUnsigned_ULong  -> wit.U64Type
+  )
+
+  private lazy val primitiveIRWIT: Map[jstpe.Type, wit.ValType] = Map(
+    jstpe.VoidType -> wit.VoidType,
+    jstpe.BooleanType -> wit.BoolType,
+    jstpe.ByteType -> wit.S8Type,
+    jstpe.ShortType -> wit.S16Type,
+    jstpe.IntType -> wit.S32Type,
+    jstpe.LongType -> wit.S64Type,
+    jstpe.FloatType -> wit.F32Type,
+    jstpe.DoubleType -> wit.F64Type,
+    jstpe.CharType -> wit.CharType,
+    jstpe.StringType -> wit.StringType,
+    jstpe.ClassType(Names.ClassName("java.lang.String"), true) ->
+        wit.StringType
+  )
+
+}

--- a/compiler/src/main/scala/org/scalajs/nscplugin/JSDefinitions.scala
+++ b/compiler/src/main/scala/org/scalajs/nscplugin/JSDefinitions.scala
@@ -78,17 +78,21 @@ trait JSDefinitions {
 
     lazy val ScalaJSComponentPackageModule = getPackageObject("scala.scalajs.component")
       lazy val ComponentPackage_native = getMemberMethod(ScalaJSComponentPackageModule, newTermName("native"))
-    lazy val ComponentNativeAnnotation = getRequiredClass("scala.scalajs.component.native")
     lazy val ComponentImportAnnotation = getRequiredClass("scala.scalajs.component.annotation.ComponentImport")
     lazy val ComponentExportAnnotation = getRequiredClass("scala.scalajs.component.annotation.ComponentExport")
     lazy val ComponentRecordAnnotation = getRequiredClass("scala.scalajs.component.annotation.ComponentRecord")
     lazy val ComponentFlagsAnnotation  = getRequiredClass("scala.scalajs.component.annotation.ComponentFlags")
+
+    lazy val ComponentResourceImportAnnotation = getRequiredClass("scala.scalajs.component.annotation.ComponentResourceImport")
+    lazy val ComponentResourceMethodAnnotation = getRequiredClass("scala.scalajs.component.annotation.ComponentResourceMethod")
+    lazy val ComponentResourceStaticMethodAnnotation = getRequiredClass("scala.scalajs.component.annotation.ComponentResourceStaticMethod")
+    lazy val ComponentResourceConstructorAnnotation = getRequiredClass("scala.scalajs.component.annotation.ComponentResourceConstructor")
+    lazy val ComponentResourceDropAnnotation = getRequiredClass("scala.scalajs.component.annotation.ComponentResourceDrop")
+
     lazy val ComponentResultClass      = getRequiredClass("scala.scalajs.component.Result")
     lazy val ComponentResultOkClass    = getRequiredClass("scala.scalajs.component.Ok")
     lazy val ComponentResultErrClass   = getRequiredClass("scala.scalajs.component.Err")
     lazy val ComponentVariantClass     = getRequiredClass("scala.scalajs.component.Variant")
-    lazy val ComponentResourceClass    = getRequiredClass("scala.scalajs.component.Resource")
-    lazy val ComponentInterfaceClass   = getRequiredClass("scala.scalajs.component.Interface")
 
     lazy val ScalaJSComponentUnsignedPackageModule = getPackageObject("scala.scalajs.component.unsigned")
       lazy val ComponentUnsigned_UByte = getTypeMember(ScalaJSComponentUnsignedPackageModule, newTermName("UByte"))

--- a/compiler/src/main/scala/org/scalajs/nscplugin/JSGlobalAddons.scala
+++ b/compiler/src/main/scala/org/scalajs/nscplugin/JSGlobalAddons.scala
@@ -125,7 +125,8 @@ trait JSGlobalAddons extends JSDefinitions
         val pos: Position) extends ExportInfo
     case class StaticExportInfo(jsName: String)(val pos: Position)
         extends ExportInfo
-    case class WasmComponentExportInfo(name: String, signature: ComponentFunctionType)(
+    case class WasmComponentExportInfo(moduleName: String, name: String,
+        signature: ComponentFunctionType)(
         val pos: Position) extends ExportInfo
     case class ComponentFunctionType(
       params: List[Type],
@@ -290,13 +291,11 @@ trait JSGlobalAddons extends JSDefinitions
       staticExports.put(sym, infos)
     }
 
-    def wasmComponentExportOf(sym: Symbol): WasmComponentExportInfo = {
-      wasmComponentExports(sym)
-    }
+    def wasmComponentExportOf(sym: Symbol): Option[WasmComponentExportInfo] =
+      wasmComponentExports.get(sym)
 
     def registerWasmComponentExport(sym: Symbol, info: WasmComponentExportInfo): Unit = {
       assert(!wasmComponentExports.contains(sym), s"symbol exported twice: $sym")
-      // assert(sym.isMethod)
       wasmComponentExports.put(sym, info)
     }
 

--- a/compiler/src/main/scala/org/scalajs/nscplugin/TypeConversions.scala
+++ b/compiler/src/main/scala/org/scalajs/nscplugin/TypeConversions.scala
@@ -73,12 +73,6 @@ trait TypeConversions[G <: Global with Singleton] extends SubComponent {
       makeArrayTypeRef(base, arrayDepth)
   }
 
-  def toWIT(tpe: Type): Option[wit.ValType] = {
-    unsigned2WIT.get(tpe.typeSymbolDirect).orElse {
-      primitiveIRWIT.get(toIRType(tpe))
-    }
-  }
-
   private lazy val primitiveIRWIT: Map[Types.Type, wit.ValType] = Map(
     Types.VoidType -> wit.VoidType,
     Types.BooleanType -> wit.BoolType,

--- a/examples/test-component-model/rust-exports/src/lib.rs
+++ b/examples/test-component-model/rust-exports/src/lib.rs
@@ -79,7 +79,6 @@ impl Countable for Component {
 
 #[allow(unused_variables)]
 impl Tests for Component {
-  fn roundtrip_basics0(a: (u32, i32)) -> (u32, i32) { a }
   fn roundtrip_basics1(a: (u8, i8, u16, i16, u32, i32, f32, f64, char)) -> (u8, i8, u16, i16, u32, i32, f32, f64, char) { a }
   fn roundtrip_list_u16(a: Vec<u16>) -> Vec<u16> { a }
   fn roundtrip_list_point(a: Vec<Point>) -> Vec<Point> { a }

--- a/examples/test-component-model/src/main/scala/componentmodel/Exports.scala
+++ b/examples/test-component-model/src/main/scala/componentmodel/Exports.scala
@@ -3,48 +3,77 @@ package componentmodel
 import scala.scalajs.js
 import scala.scalajs.{component => cm}
 import scala.scalajs.component._
-import cm.annotation._
-import cm.unsigned._
+import scala.scalajs.component.annotation._
+import scala.scalajs.component.unsigned._
 
 import java.util.Optional
 
-@ComponentExport("component:testing/tests")
-object TestsExport extends cm.Interface {
-  def roundtripBasics0(a: (UInt, Int)):
-    (UInt, Int) = a
+object TestsExport {
+  @ComponentExport("component:testing/tests", "roundtrip-basics1")
   def roundtripBasics1(a: (UByte, Byte, UShort, Short, UInt, Int, Float, Double, Char)):
-    (UByte, Byte, UShort, Short, UInt, Int, Float, Double, Char) = a
+      (UByte, Byte, UShort, Short, UInt, Int, Float, Double, Char) = a
 
+  @ComponentExport("component:testing/tests", "roundtrip-list-u16")
   def roundtripListU16(a: Array[UShort]): Array[UShort] = a
+
+  @ComponentExport("component:testing/tests", "roundtrip-list-point")
   def roundtripListPoint(a: Array[Point]): Array[Point] = a
+
+  @ComponentExport("component:testing/tests", "roundtrip-list-variant")
   def roundtripListVariant(a: Array[C1]): Array[C1] = a
 
+  @ComponentExport("component:testing/tests", "roundtrip-string")
   def roundtripString(a: String): String = a
+
+  @ComponentExport("component:testing/tests", "roundtrip-point")
   def roundtripPoint(a: Point): Point = a
 
+  @ComponentExport("component:testing/tests", "roundtrip-c1")
   def roundtripC1(a: C1): C1 = a
+
+  @ComponentExport("component:testing/tests", "roundtrip-z1")
   def roundtripZ1(a: Z1): Z1 = a
+
+  @ComponentExport("component:testing/tests", "test-c1")
   def testC1(a: C1): Unit = {}
 
+  @ComponentExport("component:testing/tests", "roundtrip-enum")
   def roundtripEnum(a: E1): E1 = a
+
+  @ComponentExport("component:testing/tests", "roundtrip-tuple")
   def roundtripTuple(a: (C1, Z1)): (C1, Z1) = a
 
+  @ComponentExport("component:testing/tests", "roundtrip-option")
   def roundtripOption(a: Optional[String]): Optional[String] = a
+
+  @ComponentExport("component:testing/tests", "roundtrip-double-option")
   def roundtripDoubleOption(a: Optional[Optional[String]]): Optional[Optional[String]] = a
 
+  @ComponentExport("component:testing/tests", "roundtrip-result")
   def roundtripResult(a: cm.Result[Unit, Unit]): cm.Result[Unit, Unit] = a
+
+  @ComponentExport("component:testing/tests", "roundtrip-string-error")
   def roundtripStringError(a: cm.Result[Float, String]): cm.Result[Float, String] = a
+
+  @ComponentExport("component:testing/tests", "roundtrip-enum-error")
   def roundtripEnumError(a: cm.Result[C1, E1]): cm.Result[C1, E1] = a
 
   import TestImportsHelper._
+  @ComponentExport("component:testing/tests", "roundtrip-f8")
   def roundtripF8(a: F1): F1 = a
+
+  @ComponentExport("component:testing/tests", "roundtrip-f16")
   def roundtripF16(a: F2): F2 = a
+
+  @ComponentExport("component:testing/tests", "roundtrip-f32")
   def roundtripF32(a: F3): F3 = a
+
+  @ComponentExport("component:testing/tests", "roundtrip-flags")
   def roundtripFlags(a: (F1, F1)): (F1, F1) = a
 }
 
-@ComponentExport("component:testing/test-imports")
-object TestImports extends cm.Interface {
+object TestImports {
+  @ComponentExport("component:testing/test-imports", "run")
   def run(): Unit = {
     import Basics._
     import Tests._
@@ -68,39 +97,13 @@ object TestImports extends cm.Interface {
       roundtripBasics1((127, 127, 32767, 32767, 532423, 2147483647, 0.0f, 0.0, 'x'))
     )
 
-
-    // new Array goes like:
-    // that contains Assign(JSArraySelect(...), ...)
-    // why it's "JS"ArraySelect?
-    // def apply(x: Short, xs: Short*): Array[Short] = {
-    //   val array = new Array[Short](xs.length + 1)
-    //   ...
-    //   for (x <- xs.iterator) { array(i) = x; i += 1 }
-    //   array
-    // }
-    val arr = {
-      val arr = new Array[UShort](3)
-      arr(0) = 0
-      arr(1) = 1
-      arr(2) = 2
-      arr
-    }
+    val arr = Array[UShort](0, 1, 2)
     assert(arr.sameElements(roundtripListU16(arr)))
 
-    val arr2 = {
-      val arr = new Array[Point](2)
-      arr(0) = Point(0, 0)
-      arr(1) = Point(3, 0)
-      arr
-    }
+    val arr2 = Array[Point](Point(0, 0), Point(3, 0))
     assert(arr2.sameElements(roundtripListPoint(arr2)))
 
-    val arr3 = {
-      val arr = new Array[C1](2)
-      arr(0) = C1.A(0)
-      arr(1) = C1.B(3)
-      arr
-    }
+    val arr3 = Array[C1](C1.A(0), C1.B(3))
     assert(arr3.sameElements(roundtripListVariant(arr3)))
 
     assert("foo" == roundtripString("foo"))
@@ -128,17 +131,17 @@ object TestImports extends cm.Interface {
     assert(Optional.of(Optional.of("foo")) == roundtripDoubleOption(Optional.of(Optional.of("foo"))))
     assert(Optional.of(Optional.empty) == roundtripDoubleOption(Optional.of(Optional.empty[String])))
     assert(Optional.empty == roundtripDoubleOption(Optional.empty[Optional[String]]))
-    assert(cm.Err("aaa") != cm.Err("bbb"))
+    // assert(new cm.Err("aaa") != new cm.Err("bbb"))
 
-    assert(cm.Ok(()) == roundtripResult(cm.Ok(())))
-    assert(cm.Err(()) == roundtripResult(cm.Err(())))
-    // assert(cm.Ok(3.0f) == roundtripStringError(cm.Ok(3.0f)))
-    assert(cm.Err("err") == roundtripStringError(cm.Err("err")))
-    assert(cm.Ok(C1.A(432)) == roundtripEnumError(cm.Ok(C1.A(432))))
-    assert(cm.Ok(C1.B(0.0f)) == roundtripEnumError(cm.Ok(C1.B(0.0f))))
-    assert(cm.Err(E1.A) == roundtripEnumError(cm.Err(E1.A)))
-    assert(cm.Err(E1.B) == roundtripEnumError(cm.Err(E1.B)))
-    assert(cm.Err(E1.C) == roundtripEnumError(cm.Err(E1.C)))
+    // assert(new cm.Ok(()) == roundtripResult(new cm.Ok(())))
+    // assert(new cm.Err(()) == roundtripResult(new cm.Err(())))
+    // assert(new cm.Ok(3.0f) == roundtripStringError(new cm.Ok(3.0f)))
+    // assert(new cm.Err("err") == roundtripStringError(new cm.Err("err")))
+    // assert(new cm.Ok(C1.A(432)) == roundtripEnumError(new cm.Ok(C1.A(432))))
+    // assert(new cm.Ok(C1.B(0.0f)) == roundtripEnumError(new cm.Ok(C1.B(0.0f))))
+    // assert(new cm.Err(E1.A) == roundtripEnumError(new cm.Err(E1.A)))
+    // assert(new cm.Err(E1.B) == roundtripEnumError(new cm.Err(E1.B)))
+    // assert(new cm.Err(E1.C) == roundtripEnumError(new cm.Err(E1.C)))
 
     import TestImportsHelper._
     assert((F1.b3 | F1.b6 | F1.b7) == roundtripF8(F1.b3 | F1.b6 | F1.b7))
@@ -157,9 +160,14 @@ object TestImports extends cm.Interface {
       c2.down()
       assert(99 == c2.valueOf())
 
-      val s = Counter.sum(c1, c2)
-      assert(100 == s.valueOf())
-      // assert(100 == Counter.sum(c1, c2).valueOf())
+      // val s1 = Counter.sum(c1, c2)
+      // val s2 = Counter.sum(c1, c2)
+      // assert(s1.valueOf() == s2.valueOf())
+      // assert(100 == s.valueOf())
+
+      // use c1 multiple times fails with
+      // unknown handle index 1 (?)
+      assert(100 == Counter.sum(c1, c2).valueOf())
     }
   }
 }

--- a/examples/test-component-model/src/main/scala/componentmodel/Test.scala
+++ b/examples/test-component-model/src/main/scala/componentmodel/Test.scala
@@ -1,63 +1,125 @@
 package componentmodel
 
 import scala.scalajs.{component => cm}
-import cm.annotation._
-import cm.unsigned._
+import scala.scalajs.component.annotation._
+import scala.scalajs.component.unsigned._
 
 import java.util.Optional
 
-@ComponentImport("component:testing/basics")
-object Basics extends cm.Interface {
-  def roundtripU8(a: UByte): UByte = cm.native
+object Basics {
+ @ComponentImport("component:testing/basics", "roundtrip-u8")
+ def roundtripU8(a: UByte): UByte = cm.native
+
+  @ComponentImport("component:testing/basics", "roundtrip-s8")
   def roundtripS8(a: Byte): Byte = cm.native
+
+  @ComponentImport("component:testing/basics", "roundtrip-u16")
   def roundtripU16(a: UShort): UShort = cm.native
+
+  @ComponentImport("component:testing/basics", "roundtrip-s16")
   def roundtripS16(a: Short): Short = cm.native
+
+  @ComponentImport("component:testing/basics", "roundtrip-u32")
   def roundtripU32(a: UInt): UInt = cm.native
+
+  @ComponentImport("component:testing/basics", "roundtrip-s32")
   def roundtripS32(a: Int): Int = cm.native
+
+  @ComponentImport("component:testing/basics", "roundtrip-u64")
   def roundtripU64(a: ULong): ULong = cm.native
+
+  @ComponentImport("component:testing/basics", "roundtrip-s64")
   def roundtripS64(a: Long): Long = cm.native
+
+  @ComponentImport("component:testing/basics", "roundtrip-f32")
   def roundtripF32(a: Float): Float = cm.native
+
+  @ComponentImport("component:testing/basics", "roundtrip-f64")
   def roundtripF64(a: Double): Double = cm.native
+
+  @ComponentImport("component:testing/basics", "roundtrip-char")
   def roundtripChar(a: Char): Char = cm.native
 }
 
+
 object Countable {
-  @cm.native
-  @ComponentImport("component:testing/countable")
-  trait Counter extends cm.Resource {
+  @ComponentResourceImport("component:testing/countable", "counter")
+  trait Counter {
+    @ComponentResourceMethod("up")
     def up(): Unit = cm.native
+
+    @ComponentResourceMethod("down")
     def down(): Unit = cm.native
+
+    @ComponentResourceMethod("value-of")
     def valueOf(): Int = cm.native
+
+    @ComponentResourceDrop
+    def close(): Unit = cm.native
   }
   object Counter {
-    @cm.native
+    @ComponentResourceConstructor
     def apply(i: Int): Counter = cm.native
 
-    @cm.native
+    @ComponentResourceStaticMethod("sum")
     def sum(a: Counter, b: Counter): Counter = cm.native
   }
 }
 
 import TestImportsHelper._
-@ComponentImport("component:testing/tests")
-object Tests extends cm.Interface {
+object Tests {
+  @ComponentImport("component:testing/tests", "roundtrip-basics1")
   def roundtripBasics1(a: (UByte, Byte, UShort, Short, UInt, Int, Float, Double, Char)):
-    (UByte, Byte, UShort, Short, UInt, Int, Float, Double, Char) = cm.native
+      (UByte, Byte, UShort, Short, UInt, Int, Float, Double, Char) = cm.native
+
+  @ComponentImport("component:testing/tests", "roundtrip-list-u16")
   def roundtripListU16(a: Array[UShort]): Array[UShort] = cm.native
+
+  @ComponentImport("component:testing/tests", "roundtrip-list-point")
   def roundtripListPoint(a: Array[Point]): Array[Point] = cm.native
+
+  @ComponentImport("component:testing/tests", "roundtrip-list-variant")
   def roundtripListVariant(a: Array[C1]): Array[C1] = cm.native
+
+  @ComponentImport("component:testing/tests", "roundtrip-string")
   def roundtripString(a: String): String = cm.native
+
+  @ComponentImport("component:testing/tests", "roundtrip-point")
   def roundtripPoint(a: Point): Point = cm.native
+
+  @ComponentImport("component:testing/tests", "test-c1")
   def testC1(a: C1): Unit = cm.native
+
+  @ComponentImport("component:testing/tests", "roundtrip-c1")
   def roundtripC1(a: C1): C1 = cm.native
+
+  @ComponentImport("component:testing/tests", "roundtrip-z1")
   def roundtripZ1(a: Z1): Z1 = cm.native
+
+  @ComponentImport("component:testing/tests", "roundtrip-enum")
   def roundtripEnum(a: E1): E1 = cm.native
+
+  @ComponentImport("component:testing/tests", "roundtrip-tuple")
   def roundtripTuple(a: (C1, Z1)): (C1, Z1) = cm.native
+
+  @ComponentImport("component:testing/tests", "roundtrip-option")
   def roundtripOption(a: Optional[String]): Optional[String] = cm.native
+
+  @ComponentImport("component:testing/tests", "roundtrip-double-option")
   def roundtripDoubleOption(a: Optional[Optional[String]]): Optional[Optional[String]] = cm.native
+
+  @ComponentImport("component:testing/tests", "roundtrip-result")
   def roundtripResult(a: cm.Result[Unit, Unit]): cm.Result[Unit, Unit] = cm.native
+
+  @ComponentImport("component:testing/tests", "roundtrip-string-error")
   def roundtripStringError(a: cm.Result[Float, String]): cm.Result[Float, String] = cm.native
+
+  @ComponentImport("component:testing/tests", "roundtrip-enum-error")
   def roundtripEnumError(a: cm.Result[C1, E1]): cm.Result[C1, E1] = cm.native
+
+  @ComponentImport("component:testing/tests", "roundtrip-f8")
   def roundtripF8(a: F1): F1 = cm.native
+
+  @ComponentImport("component:testing/tests", "roundtrip-flags")
   def roundtripFlags(a: (F1, F1)): (F1, F1) = cm.native
 }

--- a/examples/test-component-model/wit/deps/wasi-clocks-0.2.0/package.wit
+++ b/examples/test-component-model/wit/deps/wasi-clocks-0.2.0/package.wit
@@ -1,29 +1,90 @@
 package wasi:clocks@0.2.0;
 
+/// WASI Monotonic Clock is a clock API intended to let users measure elapsed
+/// time.
+///
+/// It is intended to be portable at least between Unix-family platforms and
+/// Windows.
+///
+/// A monotonic clock is a clock which has an unspecified initial value, and
+/// successive reads of the clock will produce non-decreasing values.
+///
+/// It is intended for measuring elapsed time.
 interface monotonic-clock {
   use wasi:io/poll@0.2.0.{pollable};
 
+  /// An instant in time, in nanoseconds. An instant is relative to an
+  /// unspecified initial value, and can only be compared to instances from
+  /// the same monotonic-clock.
   type instant = u64;
 
+  /// A duration of time, in nanoseconds.
   type duration = u64;
 
+  /// Read the current value of the clock.
+  ///
+  /// The clock is monotonic, therefore calling this function repeatedly will
+  /// produce a sequence of non-decreasing values.
   now: func() -> instant;
 
+  /// Query the resolution of the clock. Returns the duration of time
+  /// corresponding to a clock tick.
   resolution: func() -> duration;
 
+  /// Create a `pollable` which will resolve once the specified instant
+  /// occured.
   subscribe-instant: func(when: instant) -> pollable;
 
+  /// Create a `pollable` which will resolve once the given duration has
+  /// elapsed, starting at the time at which this function was called.
+  /// occured.
   subscribe-duration: func(when: duration) -> pollable;
 }
 
+/// WASI Wall Clock is a clock API intended to let users query the current
+/// time. The name "wall" makes an analogy to a "clock on the wall", which
+/// is not necessarily monotonic as it may be reset.
+///
+/// It is intended to be portable at least between Unix-family platforms and
+/// Windows.
+///
+/// A wall clock is a clock which measures the date and time according to
+/// some external reference.
+///
+/// External references may be reset, so this clock is not necessarily
+/// monotonic, making it unsuitable for measuring elapsed time.
+///
+/// It is intended for reporting the current date and time for humans.
 interface wall-clock {
+  /// A time and date in seconds plus nanoseconds.
   record datetime {
     seconds: u64,
     nanoseconds: u32,
   }
 
+  /// Read the current value of the clock.
+  ///
+  /// This clock is not monotonic, therefore calling this function repeatedly
+  /// will not necessarily produce a sequence of non-decreasing values.
+  ///
+  /// The returned timestamps represent the number of seconds since
+  /// 1970-01-01T00:00:00Z, also known as [POSIX's Seconds Since the Epoch],
+  /// also known as [Unix Time].
+  ///
+  /// The nanoseconds field of the output is always less than 1000000000.
+  ///
+  /// [POSIX's Seconds Since the Epoch]: https://pubs.opengroup.org/onlinepubs/9699919799/xrat/V4_xbd_chap04.html#tag_21_04_16
+  /// [Unix Time]: https://en.wikipedia.org/wiki/Unix_time
   now: func() -> datetime;
 
+  /// Query the resolution of the clock.
+  ///
+  /// The nanoseconds field of the output is always less than 1000000000.
   resolution: func() -> datetime;
 }
 
+world imports {
+  import wasi:io/poll@0.2.0;
+  import monotonic-clock;
+  import wall-clock;
+}

--- a/examples/test-component-model/wit/deps/wasi-io-0.2.0/package.wit
+++ b/examples/test-component-model/wit/deps/wasi-io-0.2.0/package.wit
@@ -1,48 +1,292 @@
 package wasi:io@0.2.0;
 
 interface error {
+  /// A resource which represents some error information.
+  ///
+  /// The only method provided by this resource is `to-debug-string`,
+  /// which provides some human-readable information about the error.
+  ///
+  /// In the `wasi:io` package, this resource is returned through the
+  /// `wasi:io/streams/stream-error` type.
+  ///
+  /// To provide more specific error information, other interfaces may
+  /// provide functions to further "downcast" this error into more specific
+  /// error information. For example, `error`s returned in streams derived
+  /// from filesystem types to be described using the filesystem's own
+  /// error-code type, using the function
+  /// `wasi:filesystem/types/filesystem-error-code`, which takes a parameter
+  /// `borrow<error>` and returns
+  /// `option<wasi:filesystem/types/error-code>`.
+  ///
+  /// The set of functions which can "downcast" an `error` into a more
+  /// concrete type is open.
   resource error {
+    /// Returns a string that is suitable to assist humans in debugging
+    /// this error.
+    ///
+    /// WARNING: The returned string should not be consumed mechanically!
+    /// It may change across platforms, hosts, or other implementation
+    /// details. Parsing this string is a major platform-compatibility
+    /// hazard.
     to-debug-string: func() -> string;
   }
 }
 
+/// A poll API intended to let users wait for I/O events on multiple handles
+/// at once.
 interface poll {
+  /// `pollable` represents a single I/O event which may be ready, or not.
   resource pollable {
+    /// Return the readiness of a pollable. This function never blocks.
+    ///
+    /// Returns `true` when the pollable is ready, and `false` otherwise.
     ready: func() -> bool;
+    /// `block` returns immediately if the pollable is ready, and otherwise
+    /// blocks until ready.
+    ///
+    /// This function is equivalent to calling `poll.poll` on a list
+    /// containing only this pollable.
     block: func();
   }
 
+  /// Poll for completion on a set of pollables.
+  ///
+  /// This function takes a list of pollables, which identify I/O sources of
+  /// interest, and waits until one or more of the events is ready for I/O.
+  ///
+  /// The result `list<u32>` contains one or more indices of handles in the
+  /// argument list that is ready for I/O.
+  ///
+  /// If the list contains more elements than can be indexed with a `u32`
+  /// value, this function traps.
+  ///
+  /// A timeout can be implemented by adding a pollable from the
+  /// wasi-clocks API to the list.
+  ///
+  /// This function does not return a `result`; polling in itself does not
+  /// do any I/O so it doesn't fail. If any of the I/O sources identified by
+  /// the pollables has an error, it is indicated by marking the source as
+  /// being reaedy for I/O.
   poll: func(in: list<borrow<pollable>>) -> list<u32>;
 }
 
+/// WASI I/O is an I/O abstraction API which is currently focused on providing
+/// stream types.
+///
+/// In the future, the component model is expected to add built-in stream types;
+/// when it does, they are expected to subsume this API.
 interface streams {
   use error.{error};
   use poll.{pollable};
 
+  /// An error for input-stream and output-stream operations.
   variant stream-error {
+    /// The last operation (a write or flush) failed before completion.
+    ///
+    /// More information is available in the `error` payload.
     last-operation-failed(error),
+    /// The stream is closed: no more input will be accepted by the
+    /// stream. A closed output-stream will return this error on all
+    /// future operations.
     closed,
   }
 
+  /// An input bytestream.
+  ///
+  /// `input-stream`s are *non-blocking* to the extent practical on underlying
+  /// platforms. I/O operations always return promptly; if fewer bytes are
+  /// promptly available than requested, they return the number of bytes promptly
+  /// available, which could even be zero. To wait for data to be available,
+  /// use the `subscribe` function to obtain a `pollable` which can be polled
+  /// for using `wasi:io/poll`.
   resource input-stream {
+    /// Perform a non-blocking read from the stream.
+    ///
+    /// When the source of a `read` is binary data, the bytes from the source
+    /// are returned verbatim. When the source of a `read` is known to the
+    /// implementation to be text, bytes containing the UTF-8 encoding of the
+    /// text are returned.
+    ///
+    /// This function returns a list of bytes containing the read data,
+    /// when successful. The returned list will contain up to `len` bytes;
+    /// it may return fewer than requested, but not more. The list is
+    /// empty when no bytes are available for reading at this time. The
+    /// pollable given by `subscribe` will be ready when more bytes are
+    /// available.
+    ///
+    /// This function fails with a `stream-error` when the operation
+    /// encounters an error, giving `last-operation-failed`, or when the
+    /// stream is closed, giving `closed`.
+    ///
+    /// When the caller gives a `len` of 0, it represents a request to
+    /// read 0 bytes. If the stream is still open, this call should
+    /// succeed and return an empty list, or otherwise fail with `closed`.
+    ///
+    /// The `len` parameter is a `u64`, which could represent a list of u8 which
+    /// is not possible to allocate in wasm32, or not desirable to allocate as
+    /// as a return value by the callee. The callee may return a list of bytes
+    /// less than `len` in size while more bytes are available for reading.
     read: func(len: u64) -> result<list<u8>, stream-error>;
+    /// Read bytes from a stream, after blocking until at least one byte can
+    /// be read. Except for blocking, behavior is identical to `read`.
     blocking-read: func(len: u64) -> result<list<u8>, stream-error>;
+    /// Skip bytes from a stream. Returns number of bytes skipped.
+    ///
+    /// Behaves identical to `read`, except instead of returning a list
+    /// of bytes, returns the number of bytes consumed from the stream.
     skip: func(len: u64) -> result<u64, stream-error>;
+    /// Skip bytes from a stream, after blocking until at least one byte
+    /// can be skipped. Except for blocking behavior, identical to `skip`.
     blocking-skip: func(len: u64) -> result<u64, stream-error>;
+    /// Create a `pollable` which will resolve once either the specified stream
+    /// has bytes available to read or the other end of the stream has been
+    /// closed.
+    /// The created `pollable` is a child resource of the `input-stream`.
+    /// Implementations may trap if the `input-stream` is dropped before
+    /// all derived `pollable`s created with this function are dropped.
     subscribe: func() -> pollable;
   }
 
+  /// An output bytestream.
+  ///
+  /// `output-stream`s are *non-blocking* to the extent practical on
+  /// underlying platforms. Except where specified otherwise, I/O operations also
+  /// always return promptly, after the number of bytes that can be written
+  /// promptly, which could even be zero. To wait for the stream to be ready to
+  /// accept data, the `subscribe` function to obtain a `pollable` which can be
+  /// polled for using `wasi:io/poll`.
   resource output-stream {
+    /// Check readiness for writing. This function never blocks.
+    ///
+    /// Returns the number of bytes permitted for the next call to `write`,
+    /// or an error. Calling `write` with more bytes than this function has
+    /// permitted will trap.
+    ///
+    /// When this function returns 0 bytes, the `subscribe` pollable will
+    /// become ready when this function will report at least 1 byte, or an
+    /// error.
     check-write: func() -> result<u64, stream-error>;
+    /// Perform a write. This function never blocks.
+    ///
+    /// When the destination of a `write` is binary data, the bytes from
+    /// `contents` are written verbatim. When the destination of a `write` is
+    /// known to the implementation to be text, the bytes of `contents` are
+    /// transcoded from UTF-8 into the encoding of the destination and then
+    /// written.
+    ///
+    /// Precondition: check-write gave permit of Ok(n) and contents has a
+    /// length of less than or equal to n. Otherwise, this function will trap.
+    ///
+    /// returns Err(closed) without writing if the stream has closed since
+    /// the last call to check-write provided a permit.
     write: func(contents: list<u8>) -> result<_, stream-error>;
+    /// Perform a write of up to 4096 bytes, and then flush the stream. Block
+    /// until all of these operations are complete, or an error occurs.
+    ///
+    /// This is a convenience wrapper around the use of `check-write`,
+    /// `subscribe`, `write`, and `flush`, and is implemented with the
+    /// following pseudo-code:
+    ///
+    /// ```text
+    /// let pollable = this.subscribe();
+    /// while !contents.is_empty() {
+    /// // Wait for the stream to become writable
+    /// pollable.block();
+    /// let Ok(n) = this.check-write(); // eliding error handling
+    /// let len = min(n, contents.len());
+    /// let (chunk, rest) = contents.split_at(len);
+    /// this.write(chunk  );            // eliding error handling
+    /// contents = rest;
+    /// }
+    /// this.flush();
+    /// // Wait for completion of `flush`
+    /// pollable.block();
+    /// // Check for any errors that arose during `flush`
+    /// let _ = this.check-write();         // eliding error handling
+    /// ```
     blocking-write-and-flush: func(contents: list<u8>) -> result<_, stream-error>;
+    /// Request to flush buffered output. This function never blocks.
+    ///
+    /// This tells the output-stream that the caller intends any buffered
+    /// output to be flushed. the output which is expected to be flushed
+    /// is all that has been passed to `write` prior to this call.
+    ///
+    /// Upon calling this function, the `output-stream` will not accept any
+    /// writes (`check-write` will return `ok(0)`) until the flush has
+    /// completed. The `subscribe` pollable will become ready when the
+    /// flush has completed and the stream can accept more writes.
     flush: func() -> result<_, stream-error>;
+    /// Request to flush buffered output, and block until flush completes
+    /// and stream is ready for writing again.
     blocking-flush: func() -> result<_, stream-error>;
+    /// Create a `pollable` which will resolve once the output-stream
+    /// is ready for more writing, or an error has occured. When this
+    /// pollable is ready, `check-write` will return `ok(n)` with n>0, or an
+    /// error.
+    ///
+    /// If the stream is closed, this pollable is always ready immediately.
+    ///
+    /// The created `pollable` is a child resource of the `output-stream`.
+    /// Implementations may trap if the `output-stream` is dropped before
+    /// all derived `pollable`s created with this function are dropped.
     subscribe: func() -> pollable;
+    /// Write zeroes to a stream.
+    ///
+    /// This should be used precisely like `write` with the exact same
+    /// preconditions (must use check-write first), but instead of
+    /// passing a list of bytes, you simply pass the number of zero-bytes
+    /// that should be written.
     write-zeroes: func(len: u64) -> result<_, stream-error>;
+    /// Perform a write of up to 4096 zeroes, and then flush the stream.
+    /// Block until all of these operations are complete, or an error
+    /// occurs.
+    ///
+    /// This is a convenience wrapper around the use of `check-write`,
+    /// `subscribe`, `write-zeroes`, and `flush`, and is implemented with
+    /// the following pseudo-code:
+    ///
+    /// ```text
+    /// let pollable = this.subscribe();
+    /// while num_zeroes != 0 {
+    /// // Wait for the stream to become writable
+    /// pollable.block();
+    /// let Ok(n) = this.check-write(); // eliding error handling
+    /// let len = min(n, num_zeroes);
+    /// this.write-zeroes(len);         // eliding error handling
+    /// num_zeroes -= len;
+    /// }
+    /// this.flush();
+    /// // Wait for completion of `flush`
+    /// pollable.block();
+    /// // Check for any errors that arose during `flush`
+    /// let _ = this.check-write();         // eliding error handling
+    /// ```
     blocking-write-zeroes-and-flush: func(len: u64) -> result<_, stream-error>;
+    /// Read from one stream and write to another.
+    ///
+    /// The behavior of splice is equivelant to:
+    /// 1. calling `check-write` on the `output-stream`
+    /// 2. calling `read` on the `input-stream` with the smaller of the
+    /// `check-write` permitted length and the `len` provided to `splice`
+    /// 3. calling `write` on the `output-stream` with that read data.
+    ///
+    /// Any error reported by the call to `check-write`, `read`, or
+    /// `write` ends the splice and reports that error.
+    ///
+    /// This function returns the number of bytes transferred; it may be less
+    /// than `len`.
     splice: func(src: borrow<input-stream>, len: u64) -> result<u64, stream-error>;
+    /// Read from one stream and write to another, with blocking.
+    ///
+    /// This is similar to `splice`, except that it blocks until the
+    /// `output-stream` is ready for writing, and the `input-stream`
+    /// is ready for reading, before performing the `splice`.
     blocking-splice: func(src: borrow<input-stream>, len: u64) -> result<u64, stream-error>;
   }
 }
 
+world imports {
+  import error;
+  import poll;
+  import streams;
+}

--- a/examples/test-component-model/wit/world.wit
+++ b/examples/test-component-model/wit/world.wit
@@ -1,7 +1,10 @@
 package component:testing;
 
 world scala {
+  import wasi:clocks/wall-clock@0.2.0;
   import wasi:cli/stdout@0.2.0;
+  import wasi:io/streams@0.2.0;
+
   import basics;
   import tests;
   import countable;
@@ -48,8 +51,8 @@ interface countable {
 }
 
 interface tests {
-  roundtrip-basics0: func(a: tuple<u32, s32>)
-    -> tuple<u32, s32>;
+  /// roundtrip-basics0: func(a: tuple<u32, s32>)
+  ///   -> tuple<u32, s32>;
   roundtrip-basics1: func(a: tuple<u8, s8, u16, s16, u32, s32, f32, f64, char>)
     -> tuple<u8, s8, u16, s16, u32, s32, f32, f64, char>;
 

--- a/examples/test-component-model/wkg.lock
+++ b/examples/test-component-model/wkg.lock
@@ -10,3 +10,21 @@ registry = "warg.wa.dev"
 requirement = "=0.2.0"
 version = "0.2.0"
 digest = "sha256:e7e85458e11caf76554b724ebf4f113259decf0f3b1ee2e2930de096f72114a7"
+
+[[packages]]
+name = "wasi:clocks"
+registry = "warg.wa.dev"
+
+[[packages.versions]]
+requirement = "=0.2.0"
+version = "0.2.0"
+digest = "sha256:51911098e929732f65d1d84f8dc393299f18a9e8de632d854714f37142efe97b"
+
+[[packages]]
+name = "wasi:io"
+registry = "warg.wa.dev"
+
+[[packages.versions]]
+requirement = "=0.2.0"
+version = "0.2.0"
+digest = "sha256:c33b1dbf050f64229ff4decbf9a3d3420e0643a86f5f0cea29f81054820020a6"

--- a/ir/shared/src/main/scala/org/scalajs/ir/ClassKind.scala
+++ b/ir/shared/src/main/scala/org/scalajs/ir/ClassKind.scala
@@ -70,7 +70,6 @@ object ClassKind {
   case object NativeJSClass extends ClassKind
   case object NativeJSModuleClass extends ClassKind
   case object NativeWasmComponentResourceClass extends ClassKind
-  case object NativeWasmComponentInterfaceClass extends ClassKind
 
   private[ir] def toByte(kind: ClassKind): Byte = kind match {
     case ClassKind.Class               => 1
@@ -83,7 +82,6 @@ object ClassKind {
     case ClassKind.NativeJSClass       => 8
     case ClassKind.NativeJSModuleClass => 9
     case ClassKind.NativeWasmComponentResourceClass => 10
-    case ClassKind.NativeWasmComponentInterfaceClass => 11
   }
 
   private[ir] def fromByte(b: Byte): ClassKind = (b: @switch) match {
@@ -97,6 +95,5 @@ object ClassKind {
     case 8 => ClassKind.NativeJSClass
     case 9 => ClassKind.NativeJSModuleClass
     case 10 => ClassKind.NativeWasmComponentResourceClass
-    case 11 => ClassKind.NativeWasmComponentInterfaceClass
   }
 }

--- a/ir/shared/src/main/scala/org/scalajs/ir/Hashers.scala
+++ b/ir/shared/src/main/scala/org/scalajs/ir/Hashers.scala
@@ -114,8 +114,8 @@ object Hashers {
     case TopLevelMethodExportDef(moduleID, methodDef) =>
       TopLevelMethodExportDef(moduleID, hashJSMethodDef(methodDef))(tle.pos)
 
-    case WasmComponentExportDef(moduleID, exportName, methodDef, signature) =>
-      WasmComponentExportDef(moduleID, exportName, hashMethodDef(methodDef), signature)(tle.pos)
+    case WasmComponentExportDef(moduleID, name, methodDef, signature) =>
+      WasmComponentExportDef(moduleID, name, hashMethodDef(methodDef), signature)(tle.pos)
 
     case _:TopLevelFieldExportDef | _:TopLevelModuleExportDef |
         _:TopLevelJSClassExportDef =>

--- a/ir/shared/src/main/scala/org/scalajs/ir/Printers.scala
+++ b/ir/shared/src/main/scala/org/scalajs/ir/Printers.scala
@@ -956,7 +956,11 @@ object Printers {
           print(")")
 
         case ComponentFunctionApply(receiver, className, method, args) =>
-          print(className)
+          print("<component-function-apply>")
+          receiver match {
+            case Some(receiver) => print(receiver)
+            case None => print(className)
+          }
           print(".")
           print(method)
           printArgs(args)
@@ -994,7 +998,6 @@ object Printers {
         case ClassKind.NativeJSClass       => print("native js class ")
         case ClassKind.NativeJSModuleClass => print("native js module class ")
         case ClassKind.NativeWasmComponentResourceClass => print("native wasm resource class ")
-        case ClassKind.NativeWasmComponentInterfaceClass => print("native wasm interface class ")
       }
       print(name)
       print(originalName)
@@ -1108,15 +1111,8 @@ object Printers {
           print(" loadfrom ")
           print(jsNativeLoadSpec)
 
-        case ComponentNativeMemberDef(flags, name, importModule, importName, tpe) =>
-          print(flags.namespace.prefixString)
-          print("component ")
-          print(name)
-          print(" importfrom \"")
-          print(importModule)
-          print("\" \"")
-          print(importName)
-          print("\"")
+        case ComponentNativeMemberDef(flags, module, name,
+            method, tpe) =>
           // TODO
       }
     }
@@ -1147,11 +1143,8 @@ object Printers {
           printEscapeJS(exportName, out)
           print("\"")
 
-        case WasmComponentExportDef(_, exportName, methodDef, signature) =>
-          print("wasm \"")
-          printEscapeJS(exportName, out)
-          print("\" :")
-          // TODO: print signature
+        case WasmComponentExportDef(moduleName, name, methodDef, signature) =>
+          // TODO
           // var first = true
           // for (ty <- paramTypes) {
           //   if (first) first = false
@@ -1163,14 +1156,6 @@ object Printers {
           // print(" = ")
           // print(methodDef)
       }
-    }
-
-    def print(wasmExport: WasmComponentExportDef): Unit = {
-      print("(export \"")
-      print(wasmExport.exportName)
-      print("\" ")
-      print(wasmExport.methodDef)
-      print(")")
     }
 
     def print(typeRef: TypeRef): Unit = typeRef match {

--- a/ir/shared/src/main/scala/org/scalajs/ir/Serializers.scala
+++ b/ir/shared/src/main/scala/org/scalajs/ir/Serializers.scala
@@ -782,12 +782,13 @@ object Serializers {
           writeMethodIdent(name)
           writeJSNativeLoadSpec(Some(jsNativeLoadSpec))
 
-        case ComponentNativeMemberDef(flags, name, importModule, importName, signature) =>
+        case ComponentNativeMemberDef(flags, moduleName, name,
+            method, signature) =>
           writeByte(TagComponentNativeMemberDef)
           writeInt(MemberFlags.toBits(flags))
-          writeMethodIdent(name)
-          writeString(importModule)
-          writeString(importName)
+          writeString(moduleName)
+          writeWasmComponentFunctionName(name)
+          writeMethodIdent(method)
           writeWITType(signature)
       }
     }
@@ -817,10 +818,10 @@ object Serializers {
           writeByte(TagTopLevelFieldExportDef)
           writeString(moduleID); writeString(exportName); writeFieldIdentForEnclosingClass(field)
 
-        case WasmComponentExportDef(moduleID, exportName, methodDef, signature) =>
+        case WasmComponentExportDef(moduleName, name, methodDef, signature) =>
           writeByte(TagWasmComponentExportDef)
-          writeString(moduleID)
-          writeString(exportName)
+          writeString(moduleName)
+          writeWasmComponentFunctionName(name)
           writeMemberDef(methodDef)
           writeWITType(signature)
       }
@@ -1161,6 +1162,29 @@ object Serializers {
     def writeStrings(strings: List[String]): Unit = {
       buffer.writeInt(strings.size)
       strings.foreach(writeString)
+    }
+
+    def writeWasmComponentFunctionName(name: WasmComponentFunctionName): Unit = {
+      import WasmComponentFunctionName._
+      name match {
+        case Function(func) =>
+          buffer.writeByte(TagWasmComponentFunction)
+          writeString(func)
+        case ResourceMethod(func, resource) =>
+          buffer.writeByte(TagWasmComponentResourceMethod)
+          writeString(func)
+          writeString(resource)
+        case ResourceStaticMethod(func, resource) =>
+          buffer.writeByte(TagWasmComponentResourceStaticMethod)
+          writeString(func)
+          writeString(resource)
+        case ResourceConstructor(resource) =>
+          buffer.writeByte(TagWasmComponentResourceConstructor)
+          writeString(resource)
+        case ResourceDrop(resource) =>
+          buffer.writeByte(TagWasmComponentResourceDrop)
+          writeString(resource)
+      }
     }
   }
 
@@ -2461,12 +2485,11 @@ object Serializers {
 
     private def readComponentNativeMemberDef()(implicit pos: Position): ComponentNativeMemberDef = {
       val flags = MemberFlags.fromBits(readInt())
-      val name = readMethodIdent()
-      val importModule = readString()
-      val importName = readString()
+      val moduleName = readString()
+      val name = readWasmComponentFunctionName()
+      val methodIdent = readMethodIdent()
       val signature = readWITFuncType()
-
-      ComponentNativeMemberDef(flags, name, importModule, importName, signature)
+      ComponentNativeMemberDef(flags, moduleName, name, methodIdent, signature)
     }
 
     /* #4442 and #4601: Patch Labeled, If, Match and TryCatch nodes in
@@ -2558,14 +2581,16 @@ object Serializers {
           TopLevelFieldExportDef(readModuleID(), readString(), readFieldIdentForEnclosingClass())
 
         case TagWasmComponentExportDef =>
-          val moduleID = readModuleID()
-          val exportName = readString()
+          val moduleName = readString()
+          val name = readWasmComponentFunctionName()
+          // read methoddef
           val methodPos = readPosition()
           val tag = readByte()
           assert(tag == TagMethodDef, s"unexpected tag $tag")
           val methodDef = readMethodDef(owner, ownerKind)(methodPos)
+
           val signature = readWITFuncType()
-          WasmComponentExportDef(moduleID, exportName, methodDef, signature)
+          WasmComponentExportDef(moduleName, name, methodDef, signature)
       }
     }
 
@@ -3008,6 +3033,23 @@ object Serializers {
       }
 
       res
+    }
+
+    private def readWasmComponentFunctionName(): WasmComponentFunctionName = {
+      import WasmComponentFunctionName._
+      val tag = readByte()
+      (tag: @switch) match {
+        case TagWasmComponentFunction =>
+          Function(readString())
+        case TagWasmComponentResourceMethod =>
+          ResourceMethod(readString(), readString())
+        case TagWasmComponentResourceStaticMethod =>
+          ResourceStaticMethod(readString(), readString())
+        case TagWasmComponentResourceConstructor =>
+          ResourceConstructor(readString())
+        case TagWasmComponentResourceDrop =>
+          ResourceDrop(readString())
+      }
     }
   }
 

--- a/ir/shared/src/main/scala/org/scalajs/ir/Tags.scala
+++ b/ir/shared/src/main/scala/org/scalajs/ir/Tags.scala
@@ -256,4 +256,11 @@ private[ir] object Tags {
   final val TagWITResourceType = TagWITFlagsType + 1
   final val TagWITFuncType = TagWITResourceType + 1
 
+  // Tags for wasm Component Function kind
+
+  final val TagWasmComponentFunction = 0
+  final val TagWasmComponentResourceMethod = TagWasmComponentFunction + 1
+  final val TagWasmComponentResourceStaticMethod = TagWasmComponentResourceMethod + 1
+  final val TagWasmComponentResourceConstructor = TagWasmComponentResourceStaticMethod + 1
+  final val TagWasmComponentResourceDrop = TagWasmComponentResourceConstructor + 1
 }

--- a/javalib/src/main/scala/java/lang/System.scala
+++ b/javalib/src/main/scala/java/lang/System.scala
@@ -385,7 +385,6 @@ private final class JSConsoleBasedPrintStream(isErr: scala.Boolean)
   private def doWriteLine(line: String): Unit = {
     if (LinkingInfo.targetPureWasm) { // isWASI
       // TODO
-
     } else {
       import js.DynamicImplicits.truthValue
 

--- a/library/src/main/scala/scala/scalajs/component/Interface.scala
+++ b/library/src/main/scala/scala/scalajs/component/Interface.scala
@@ -1,3 +1,0 @@
-package scala.scalajs.component
-
-trait Interface

--- a/library/src/main/scala/scala/scalajs/component/Resource.scala
+++ b/library/src/main/scala/scala/scalajs/component/Resource.scala
@@ -1,5 +1,0 @@
-package scala.scalajs.component
-
-trait Resource extends java.io.Closeable {
-  final override def close(): Unit = native
-}

--- a/library/src/main/scala/scala/scalajs/component/Result.scala
+++ b/library/src/main/scala/scala/scalajs/component/Result.scala
@@ -1,12 +1,11 @@
 package scala.scalajs.component
 
 sealed trait Result[+A, +B] extends Variant
-
-final case class Ok[A](val value: A) extends Result[A, Nothing] {
+final class Ok[A](val value: A) extends Result[A, Nothing] {
   type T = A
   val _index: Int = 0
 }
-final case class Err[B](val value: B) extends Result[Nothing, B] {
+final class Err[B](val value: B) extends Result[Nothing, B] {
   type T = B
   val _index: Int = 1
 }

--- a/library/src/main/scala/scala/scalajs/component/annotation/ComponentExport.scala
+++ b/library/src/main/scala/scala/scalajs/component/annotation/ComponentExport.scala
@@ -15,6 +15,6 @@ package scala.scalajs.component.annotation
 import scala.annotation.meta._
 
 @field @getter @setter
-class ComponentImport private () extends scala.annotation.StaticAnnotation {
+class ComponentExport private () extends scala.annotation.StaticAnnotation {
   def this(moduleName: String, name: String) = this()
 }

--- a/library/src/main/scala/scala/scalajs/component/annotation/ComponentFlags.scala
+++ b/library/src/main/scala/scala/scalajs/component/annotation/ComponentFlags.scala
@@ -1,3 +1,15 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package scala.scalajs.component.annotation
 
 import scala.annotation.meta._

--- a/library/src/main/scala/scala/scalajs/component/annotation/ComponentRecord.scala
+++ b/library/src/main/scala/scala/scalajs/component/annotation/ComponentRecord.scala
@@ -1,3 +1,15 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package scala.scalajs.component.annotation
 
 import scala.annotation.meta._

--- a/library/src/main/scala/scala/scalajs/component/annotation/ComponentResourceConstructor.scala
+++ b/library/src/main/scala/scala/scalajs/component/annotation/ComponentResourceConstructor.scala
@@ -15,6 +15,4 @@ package scala.scalajs.component.annotation
 import scala.annotation.meta._
 
 @field @getter @setter
-class ComponentImport private () extends scala.annotation.StaticAnnotation {
-  def this(moduleName: String, name: String) = this()
-}
+class ComponentResourceConstructor() extends scala.annotation.StaticAnnotation

--- a/library/src/main/scala/scala/scalajs/component/annotation/ComponentResourceDrop.scala
+++ b/library/src/main/scala/scala/scalajs/component/annotation/ComponentResourceDrop.scala
@@ -15,6 +15,4 @@ package scala.scalajs.component.annotation
 import scala.annotation.meta._
 
 @field @getter @setter
-class ComponentImport private () extends scala.annotation.StaticAnnotation {
-  def this(moduleName: String, name: String) = this()
-}
+class ComponentResourceDrop() extends scala.annotation.StaticAnnotation

--- a/library/src/main/scala/scala/scalajs/component/annotation/ComponentResourceImport.scala
+++ b/library/src/main/scala/scala/scalajs/component/annotation/ComponentResourceImport.scala
@@ -15,6 +15,6 @@ package scala.scalajs.component.annotation
 import scala.annotation.meta._
 
 @field @getter @setter
-class ComponentImport private () extends scala.annotation.StaticAnnotation {
+class ComponentResourceImport private () extends scala.annotation.StaticAnnotation {
   def this(moduleName: String, name: String) = this()
 }

--- a/library/src/main/scala/scala/scalajs/component/annotation/ComponentResourceMethod.scala
+++ b/library/src/main/scala/scala/scalajs/component/annotation/ComponentResourceMethod.scala
@@ -15,6 +15,6 @@ package scala.scalajs.component.annotation
 import scala.annotation.meta._
 
 @field @getter @setter
-class ComponentImport private () extends scala.annotation.StaticAnnotation {
-  def this(moduleName: String, name: String) = this()
+class ComponentResourceMethod private () extends scala.annotation.StaticAnnotation {
+  def this(name: String) = this()
 }

--- a/library/src/main/scala/scala/scalajs/component/annotation/ComponentResourceStaticMethod.scala
+++ b/library/src/main/scala/scala/scalajs/component/annotation/ComponentResourceStaticMethod.scala
@@ -15,6 +15,6 @@ package scala.scalajs.component.annotation
 import scala.annotation.meta._
 
 @field @getter @setter
-class ComponentImport private () extends scala.annotation.StaticAnnotation {
-  def this(moduleName: String, name: String) = this()
+class ComponentResourceStaticMethod private () extends scala.annotation.StaticAnnotation {
+  def this(name: String) = this()
 }

--- a/library/src/main/scala/scala/scalajs/component/annotation/ComponetExport.scala
+++ b/library/src/main/scala/scala/scalajs/component/annotation/ComponetExport.scala
@@ -1,8 +1,0 @@
-package scala.scalajs.component.annotation
-
-import scala.annotation.meta._
-
-@field @getter @setter
-class ComponentExport private () extends scala.annotation.StaticAnnotation {
-  def this(module: String) = this()
-}

--- a/library/src/main/scala/scala/scalajs/component/package.scala
+++ b/library/src/main/scala/scala/scalajs/component/package.scala
@@ -18,9 +18,6 @@ import scala.annotation.meta._
  */
 package object component {
 
-  @field @getter @setter
-  class native extends scala.annotation.StaticAnnotation
-
   /** Denotes a method body as imported from Wasm Component. For use in facade types:
    *
    *  {{{

--- a/linker-interface/shared/src/main/scala/org/scalajs/linker/interface/WasmFeatures.scala
+++ b/linker-interface/shared/src/main/scala/org/scalajs/linker/interface/WasmFeatures.scala
@@ -4,19 +4,22 @@ import Fingerprint.FingerprintBuilder
 
 final class WasmFeatures private (
   _exceptionHandling: Boolean,
-  _targetPureWasm: Boolean
+  _targetPureWasm: Boolean,
+  _componentModel: Boolean
 ) {
   import WasmFeatures._
 
   private def this() = {
     this(
       _exceptionHandling = true,
-      _targetPureWasm = false
+      _targetPureWasm = false,
+      _componentModel = false
     )
   }
 
   val exceptionHandling = _exceptionHandling
   val targetPureWasm = _targetPureWasm
+  val componentModel = _componentModel
 
   def withExceptionHandling(exceptionHandling: Boolean): WasmFeatures =
     copy(exceptionHandling = exceptionHandling)
@@ -24,10 +27,14 @@ final class WasmFeatures private (
   def withTargetPureWasm(targetPureWasm: Boolean): WasmFeatures =
     copy(targetPureWasm = targetPureWasm)
 
+  def withComponentModel(componentModel: Boolean): WasmFeatures =
+    copy(componentModel = componentModel)
+
   override def equals(that: Any): Boolean = that match {
     case that: WasmFeatures =>
       this.exceptionHandling == that.exceptionHandling &&
-      this.targetPureWasm == that.targetPureWasm
+      this.targetPureWasm == that.targetPureWasm &&
+      this.componentModel == that.componentModel
     case _ =>
       false
   }
@@ -36,24 +43,28 @@ final class WasmFeatures private (
     import scala.util.hashing.MurmurHash3._
     var acc = HashSeed
     acc = mix(acc, exceptionHandling.##)
-    acc = mixLast(acc, targetPureWasm.##)
-    finalizeHash(acc, 2)
+    acc = mix(acc, targetPureWasm.##)
+    acc = mixLast(acc, componentModel.##)
+    finalizeHash(acc, 3)
   }
 
   override def toString(): String = {
     s"""WasmFeatures(
        |  exceptionHandling = $exceptionHandling,
        |  targetPureWasm = $targetPureWasm
+       |  componentModel = $componentModel
        |)""".stripMargin
   }
 
   private def copy(
       exceptionHandling: Boolean = this.exceptionHandling,
-      targetPureWasm: Boolean = this.targetPureWasm
+      targetPureWasm: Boolean = this.targetPureWasm,
+      componentModel: Boolean = this.componentModel
   ): WasmFeatures = {
     new WasmFeatures(
         _exceptionHandling = exceptionHandling,
-        _targetPureWasm = targetPureWasm
+        _targetPureWasm = targetPureWasm,
+        _componentModel = componentModel
     )
   }
 }
@@ -71,6 +82,7 @@ object WasmFeatures {
       new FingerprintBuilder("WasmFeatures")
         .addField("exceptionHandling", wasmFeatures.exceptionHandling)
         .addField("targetPureWasm", wasmFeatures.targetPureWasm)
+        .addField("componentModel", wasmFeatures.componentModel)
         .build()
     }
   }

--- a/linker/shared/src/main/scala/org/scalajs/linker/analyzer/Analyzer.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/analyzer/Analyzer.scala
@@ -603,7 +603,7 @@ private class AnalyzerRun(config: CommonPhaseConfig, initial: Boolean,
             }
           }
 
-        case NativeWasmComponentResourceClass | ClassKind.NativeWasmComponentInterfaceClass =>
+        case NativeWasmComponentResourceClass =>
           assert(superClass.isEmpty)
           None
       }
@@ -616,8 +616,7 @@ private class AnalyzerRun(config: CommonPhaseConfig, initial: Boolean,
         case ClassKind.Class | ClassKind.ModuleClass |
             ClassKind.HijackedClass | ClassKind.Interface =>
           ClassKind.Interface
-        case ClassKind.NativeWasmComponentResourceClass |
-            ClassKind.NativeWasmComponentInterfaceClass =>
+        case ClassKind.NativeWasmComponentResourceClass =>
           ClassKind.Interface
         case ClassKind.JSClass | ClassKind.JSModuleClass |
             ClassKind.NativeJSClass | ClassKind.NativeJSModuleClass |

--- a/linker/shared/src/main/scala/org/scalajs/linker/analyzer/InfoLoader.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/analyzer/InfoLoader.scala
@@ -127,7 +127,7 @@ private[analyzer] object InfoLoader {
         .map(m => m.name.name -> m.jsNativeLoadSpec).toMap
 
       val componentNativeMembers = classDef.componentNativeMembers
-        .map(m => m.name.name -> generator.generateComponentNativeMember(m)).toMap
+        .map(m => m.method.name -> generator.generateComponentNativeMember(m)).toMap
 
       new Infos.ClassInfo(classDef.className, classDef.kind,
           classDef.superClass.map(_.name), classDef.interfaces.map(_.name),

--- a/linker/shared/src/main/scala/org/scalajs/linker/analyzer/Infos.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/analyzer/Infos.scala
@@ -617,7 +617,7 @@ object Infos {
     private var inAsync: Boolean = false
 
     def generateComponentNativeMember(member: ComponentNativeMemberDef): MethodInfo = {
-      val methodName = member.name.name
+      val methodName = member.method.name
       methodName.paramTypeRefs.foreach(builder.maybeAddReferencedClass)
       builder.maybeAddReferencedClass(methodName.resultTypeRef)
       generateForWIT(member.signature)
@@ -858,8 +858,6 @@ object Infos {
               builder.addJSNativeMemberUsed(className, member.name)
 
             case Apply(flags, receiver, method, _) =>
-              // if (receiver.tpe.show.contains("NumValue"))
-              //   println(s"called $receiver.$method")
               builder.addMethodCalled(receiver.tpe, method.name)
             case ApplyStatically(flags, _, className, method, _) =>
               val namespace = MemberNamespace.forNonStaticCall(flags)

--- a/linker/shared/src/main/scala/org/scalajs/linker/backend/wasmemitter/ClassEmitter.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/backend/wasmemitter/ClassEmitter.scala
@@ -78,10 +78,8 @@ class ClassEmitter(coreSpec: CoreSpec) {
         genMethod(clazz, method)
     }
 
-    if (ctx.coreSpec.wasmFeatures.targetPureWasm) {
-      for (member <- clazz.componentNativeMembers) {
-        canonicalabi.InteropEmitter.genComponentNativeInterop(clazz, member)
-      }
+    for (member <- clazz.componentNativeMembers) {
+      canonicalabi.InteropEmitter.genComponentNativeInterop(clazz, member)
     }
 
     // maybe better to Component Interface to be an another ClassKind?
@@ -94,8 +92,7 @@ class ClassEmitter(coreSpec: CoreSpec) {
       case ClassKind.JSClass | ClassKind.JSModuleClass =>
         genJSClass(clazz)
       case ClassKind.HijackedClass | ClassKind.AbstractJSType | ClassKind.NativeJSClass |
-          ClassKind.NativeJSModuleClass | ClassKind.NativeWasmComponentResourceClass |
-          ClassKind.NativeWasmComponentInterfaceClass =>
+          ClassKind.NativeJSModuleClass | ClassKind.NativeWasmComponentResourceClass =>
         () // nothing to do
     }
   }
@@ -248,7 +245,7 @@ class ClassEmitter(coreSpec: CoreSpec) {
             KindClass
           case Interface =>
             KindInterface
-          case NativeWasmComponentResourceClass | NativeWasmComponentInterfaceClass =>
+          case NativeWasmComponentResourceClass =>
             KindClass // TODO
           case JSClass | JSModuleClass | AbstractJSType | NativeJSClass | NativeJSModuleClass =>
             if (clazz.superClass.isDefined)

--- a/linker/shared/src/main/scala/org/scalajs/linker/backend/wasmemitter/Emitter.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/backend/wasmemitter/Emitter.scala
@@ -186,7 +186,7 @@ final class Emitter(config: Emitter.Config) {
            * opposed to the default `undefined` value of the JS `let`).
            */
           fb += wa.GlobalGet(genGlobalID.forStaticField(fieldIdent.name))
-        case WasmComponentExportDef(_, _, _, _) =>
+        case _: WasmComponentExportDef =>
       }
 
       if (!tle.tree.isWasmComponentExport)

--- a/linker/shared/src/main/scala/org/scalajs/linker/backend/wasmemitter/VarGen.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/backend/wasmemitter/VarGen.scala
@@ -18,6 +18,7 @@ import org.scalajs.ir.Types._
 import org.scalajs.ir.WellKnownNames._
 
 import org.scalajs.linker.backend.webassembly.Identitities._
+import org.scalajs.ir.Trees.WasmComponentFunctionName
 
 /** Manages generation of non-local IDs.
  *
@@ -114,7 +115,8 @@ object VarGen {
 
     case object start extends FunctionID
 
-    final case class forComponentFunction(module: String, name: String) extends FunctionID
+    final case class forComponentFunction(module: String,
+        name: WasmComponentFunctionName) extends FunctionID
 
     final case object f32Fmod extends FunctionID
     final case object f64Fmod extends FunctionID

--- a/linker/shared/src/main/scala/org/scalajs/linker/backend/wasmemitter/canonicalabi/ScalaJSToCABI.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/backend/wasmemitter/canonicalabi/ScalaJSToCABI.scala
@@ -105,9 +105,8 @@ object ScalaJSToCABI {
         for ((f, i) <- fields.zipWithIndex) {
           genAlignTo(fb, wit.alignment(f), ptr)
           fb += wa.LocalGet(ptr)
-          val methodName = MethodName(s"_${i + 1}", Nil, ClassRef(ObjectClass))
-
           if (isSpecialized) {
+            val methodName = MethodName(s"_${i + 1}", Nil, ClassRef(ObjectClass))
             genVTableDispatch(fb, className, methodName, tuple)
           } else {
             fb += wa.LocalGet(tuple)
@@ -247,9 +246,8 @@ object ScalaJSToCABI {
         fb += wa.RefCast(watpe.RefType.nullable(genTypeID.forClass(className)))
         fb += wa.LocalSet(tuple)
         for ((f, i) <- fields.zipWithIndex) {
-          val methodName = MethodName(s"_${i + 1}", Nil, ClassRef(ObjectClass))
-
           if (isSpecialized) {
+            val methodName = MethodName(s"_${i + 1}", Nil, ClassRef(ObjectClass))
             genVTableDispatch(fb, className, methodName, tuple)
           } else {
             fb += wa.LocalGet(tuple)

--- a/linker/shared/src/main/scala/org/scalajs/linker/checker/ClassDefChecker.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/checker/ClassDefChecker.scala
@@ -171,7 +171,7 @@ private final class ClassDefChecker(classDef: ClassDef,
         if (classDef.superClass.isDefined)
           reportError("java.lang.Object cannot have a superClass")
 
-      case ClassKind.NativeWasmComponentResourceClass | ClassKind.NativeWasmComponentInterfaceClass =>
+      case ClassKind.NativeWasmComponentResourceClass =>
         if (classDef.superClass.isDefined)
           reportError("Wasm component resource cannot have a superClass")
 
@@ -288,7 +288,7 @@ private final class ClassDefChecker(classDef: ClassDef,
       case ClassKind.Class | ClassKind.HijackedClass =>
         // all namespaces are allowed (except for class initializers as checked above)
 
-      case ClassKind.NativeWasmComponentResourceClass | ClassKind.NativeWasmComponentInterfaceClass =>
+      case ClassKind.NativeWasmComponentResourceClass =>
         // TODO
 
       case ClassKind.Interface =>

--- a/linker/shared/src/main/scala/org/scalajs/linker/checker/IRChecker.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/checker/IRChecker.scala
@@ -75,9 +75,8 @@ private final class IRChecker(linkTimeProperties: LinkTimeProperties,
           implicit val ctx = ErrorContext(methodDef)
           typecheckAny(methodDef.body, Env.empty)
 
-        case WasmComponentExportDef(_, _, methodDef, signature) =>
-          implicit val ctx = ErrorContext(methodDef)
-          // TODO: type check wasm component
+        case WasmComponentExportDef(_, _, methodDef, _) =>
+          // TODO
 
         case _:TopLevelJSClassExportDef | _:TopLevelModuleExportDef |
             _:TopLevelFieldExportDef =>

--- a/linker/shared/src/main/scala/org/scalajs/linker/frontend/BaseLinker.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/frontend/BaseLinker.scala
@@ -169,7 +169,7 @@ private[frontend] object BaseLinker {
       .filter(m => classInfo.jsNativeMembersUsed.contains(m.name.name))
 
     val wasmComponentNativeMembers = classDef.componentNativeMembers
-      .filter(m => classInfo.wasmComponentNativeMembersUsed.contains(m.name.name))
+      .filter(m => classInfo.wasmComponentNativeMembersUsed.contains(m.method.name))
 
     val allMethods = methods ++ syntheticMethodDefs
 

--- a/linker/shared/src/test/scala/org/scalajs/linker/AnalyzerTest.scala
+++ b/linker/shared/src/test/scala/org/scalajs/linker/AnalyzerTest.scala
@@ -182,7 +182,7 @@ class AnalyzerTest {
         case JSClass | JSModuleClass | NativeJSClass | NativeJSModuleClass |
             AbstractJSType =>
           Seq(Class, Interface, AbstractJSType, JSModuleClass)
-        case NativeWasmComponentResourceClass | NativeWasmComponentInterfaceClass =>
+        case NativeWasmComponentResourceClass =>
           Seq.empty // TODO
         case HijackedClass =>
           throw new AssertionError("Cannot test HijackedClass because it fails earlier")
@@ -237,7 +237,7 @@ class AnalyzerTest {
             AbstractJSType =>
           Seq(Class, ModuleClass, Interface, JSClass,
               JSModuleClass, NativeJSClass, NativeJSModuleClass)
-        case NativeWasmComponentResourceClass | NativeWasmComponentInterfaceClass =>
+        case NativeWasmComponentResourceClass =>
           Seq.empty // TODO
         case HijackedClass =>
           throw new AssertionError("Cannot test HijackedClass because it fails earlier")
@@ -1002,7 +1002,7 @@ object AnalyzerTest {
         Some(ObjectClass)
       case JSClass | JSModuleClass =>
         Some(ClassName("scala.scalajs.js.Object"))
-      case NativeWasmComponentResourceClass | NativeWasmComponentInterfaceClass =>
+      case NativeWasmComponentResourceClass =>
         None // TODO
       case Interface | AbstractJSType =>
         None

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -2079,7 +2079,13 @@ object Build {
       exampleSettings,
       name := "Testing module for component model",
       scalaJSLinkerConfig ~= {
-        _.withPrettyPrint(true).withWasmFeatures(_.withExceptionHandling(false).withTargetPureWasm(true)).withModuleKind(ModuleKind.ESModule)
+        _.withPrettyPrint(true)
+         .withModuleKind(ModuleKind.ESModule)
+         .withWasmFeatures(
+           _.withExceptionHandling(false)
+            .withTargetPureWasm(true)
+            .withComponentModel(true)
+         )
       },
   ).withScalaJSCompiler.dependsOnLibrary
 

--- a/project/JavalibIRCleaner.scala
+++ b/project/JavalibIRCleaner.scala
@@ -79,8 +79,10 @@ final class JavalibIRCleaner(baseDirectoryURI: URI) {
         case AbstractJSType | NativeJSClass | NativeJSModuleClass =>
           // discard
 
-        case NativeWasmComponentResourceClass | NativeWasmComponentInterfaceClass =>
-          ??? // TODO
+        case NativeWasmComponentResourceClass =>
+          val cleanedTree = cleanTree(tree, jsTypes, errorManager)
+          writeIRFile(output, cleanedTree)
+          resultBuilder += output
 
         case JSClass | JSModuleClass  =>
           errorManager.reportError(
@@ -470,6 +472,11 @@ final class JavalibIRCleaner(baseDirectoryURI: URI) {
           ApplyStatic(t.flags, transformNonJSClassName(t.className),
               transformMethodIdent(t.method), t.args)(transformType(t.tpe))
 
+        case t: ComponentFunctionApply =>
+          ComponentFunctionApply(t.receiver,
+              transformNonJSClassName(t.className),
+              transformMethodIdent(t.method), t.args)(transformType(t.tpe))
+
         case NewArray(typeRef, lengths) =>
           NewArray(transformArrayTypeRef(typeRef), lengths)
         case ArrayValue(typeRef, elems) =>
@@ -617,8 +624,13 @@ final class JavalibIRCleaner(baseDirectoryURI: URI) {
         (enclosingClassName == TypedArrayBufferBridge || enclosingClassName == TypedArrayBufferBridgeMod)
       }
 
+      def isWasmComponent = {
+        cls.nameString.startsWith("scala.scalajs.component")
+      }
+
       def isAnException: Boolean =
-        isJavaScriptExceptionWithinItself || isTypedArrayBufferBridgeWithinItself
+        isJavaScriptExceptionWithinItself || isTypedArrayBufferBridgeWithinItself ||
+            isWasmComponent
 
       if (cls.nameString.startsWith("scala.") && !isAnException)
         reportError(s"Illegal reference to Scala class ${cls.nameString}")


### PR DESCRIPTION
- Now Wasm Component Model related APIs are scalalib free, and usable from javalib. (Enum, Variant, and Result types are defined in scalalib. We ignore them as exceptions in JavalibIRCleaner, but in future, we should re-design it so we don't need to make them exceptions).
- Now,  Optimizer tracks the variable usage in ComponentFunctionApply. Previously, optimizer eliminates the variable used in ComponentFunctionApply as it's not marked as used.
- Refactor ComponentModel related annotations.

```scala
object WallClock {
  // (import "wasi:clocks/wall-clock@0.2.0" "now" ...)
  @ComponentImport("wasi:clocks/wall-clock@0.2.0", "now")
  def now(): Datetime = cm.native
}

object Foo {
  // (export "component:testing/tests#roundtrip-string" ...)
  @ComponentExport("component:testing/tests", "roundtrip-string")
  def roundtripString(a: String): String = a
}
```

```scala
@ComponentResourceImport("wasi:io/streams@0.2.0", "output-stream")
trait OutputStream {
  // (import "wasi:io/streams@0.2.0", "[method]output-stream.blocking-write-and-flush" ...)
  @ComponentResourceMethod("blocking-write-and-flush")
  def blockingWriteAndFlush(contents: Array[UByte]): cm.Result[Unit, StreamError] = cm.native

  // (import "wasi:io/streams@0.2.0", "[resource-drop]output-stream" ...)
  @ComponentResourceDrop
  def close(): Unit = cm.native
}

object OutputStream {
  // (import "wasi:io/streams@0.2.0", "[static]output-stream".static-function" ...)
  @ComponentResourceStaticMethod("static-function")
  def staticFunction(): ...

  // (import "wasi:io/streams@0.2.0", "[constructor]output-stream" ... )
  @ComponentResourceConstructor
  def apply(): OutputStream = cm.native
}
```