### PR TITLE
More test-suits in pure wasm

### DIFF
--- a/javalib/src/main/scala/java/nio/ByteOrder.scala
+++ b/javalib/src/main/scala/java/nio/ByteOrder.scala
@@ -15,6 +15,8 @@ package java.nio
 import scala.scalajs.js
 import scala.scalajs.js.typedarray._
 
+import scala.scalajs.LinkingInfo
+
 final class ByteOrder private (name: String) {
   override def toString(): String = name
 }
@@ -24,12 +26,16 @@ object ByteOrder {
   val LITTLE_ENDIAN: ByteOrder = new ByteOrder("LITTLE_ENDIAN")
 
   private[nio] val areTypedArraysBigEndian = {
-    if (js.typeOf(js.Dynamic.global.Int32Array) != "undefined") {
-      val arrayBuffer = new ArrayBuffer(4)
-      (new Int32Array(arrayBuffer))(0) = 0x01020304
-      (new Int8Array(arrayBuffer))(0) == 0x01
-    } else {
-      true // as good a value as any
+    LinkingInfo.linkTimeIf(LinkingInfo.targetPureWasm) {
+      true
+    } {
+      if (js.typeOf(js.Dynamic.global.Int32Array) != "undefined") {
+        val arrayBuffer = new ArrayBuffer(4)
+        (new Int32Array(arrayBuffer))(0) = 0x01020304
+        (new Int8Array(arrayBuffer))(0) == 0x01
+      } else {
+        true // as good a value as any
+      }
     }
   }
 

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -2225,10 +2225,7 @@ object Build {
 
         if (targetPureWasm) {
           List(
-            sharedTestSuiteDir / "compiler",
-            sharedTestSuiteDir / "utils",
-            sharedTestSuiteDir / "javalib" / "lang",
-            sharedTestSuiteDir / "javalib" / "util",
+            sharedTestSuiteDir,
             jsTestSuiteDir
           )
         } else {
@@ -2245,17 +2242,24 @@ object Build {
 
         (sources in Test).value
           .filter(f =>
-            contains(f, "/shared/src/test/scala/org/scalajs/testsuite/compiler") ||
-            contains(f, "/shared/src/test/scala/org/scalajs/testsuite/utils") ||
-            contains(f, "/shared/src/test/scala/org/scalajs/testsuite/javalib/lang") && (
-              !endsWith(f, "/CharacterUnicodeBlockTest.scala") && // String.replace, String.split
-              !endsWith(f, "/ClassValueTest.scala") && // js.Map in ClassValue
-              !endsWith(f, "/MathTest.scala") &&
-              !endsWith(f, "/SystemPropertiesTest.scala") // dictionary in SystemProperties
-            ) ||
-            contains(f, "/shared/src/test/scala/org/scalajs/testsuite/javalib/util") && (
-              !contains(f, "/util/regex") &&
+            contains(f, "/shared/src/test/scala/org/scalajs/testsuite/") && (
+              !contains(f, "/niocharset/") &&
 
+              // scalalib
+              !endsWith(f, "/scalalib/EnumerationTest.scala") && // Enumeration.toString -> String.split -> regex
+              !endsWith(f, "/scalalib/RangesTest.scala") && // BigDecimal
+              !endsWith(f, "/scalalib/SymbolTest.scala") && // Symbol#JSUniquenessCache
+
+              // javalib
+              !contains(f, "/javalib/util/regex/") &&
+              !contains(f, "/javalib/math/") &&
+              // javalib/lang
+              !endsWith(f, "/lang/CharacterUnicodeBlockTest.scala") && // String.replace, String.split
+              !endsWith(f, "/lang/ClassValueTest.scala") && // js.Map in ClassValue
+              !endsWith(f, "/lang/MathTest.scala") &&
+              !endsWith(f, "/lang/SystemPropertiesTest.scala") && // dictionary in SystemProperties
+
+              // javalib/util
               !endsWith(f, "/PriorityQueueTest.scala") && // js.Array
               !endsWith(f, "/Base64Test.scala") && // String.replaceAll in Base64Test
               !endsWith(f, "/FormatterTest.scala") &&
@@ -2286,7 +2290,17 @@ object Build {
               !endsWith(f, "/CollectionsOnSynchronizedCollectionTest.scala") &&
               !endsWith(f, "/CollectionsOnListsTest.scala") &&
               !endsWith(f, "/CollectionsOnCheckedListTest.scala") &&
-              !endsWith(f, "/CollectionsOnCheckedCollectionTest.scala")
+              !endsWith(f, "/CollectionsOnCheckedCollectionTest.scala") &&
+
+              // javalib/io
+              !endsWith(f, "/io/OutputStreamWriterTest.scala") && // CharSet.CharSetMap
+              !endsWith(f, "/io/PrintWriterTest.scala") && // Formatter
+              !endsWith(f, "/io/PrintStreamTest.scala") && // Formatter
+
+              // javalib/net
+              !endsWith(f, "/net/URLEncoderTest.scala") && // CharSet.CharSetMap
+              !endsWith(f, "/net/URLDecoderTest.scala") && // CharSet.CharSetMap
+              !endsWith(f, "/net/URITest.scala") // CharSet.CharSetMap, URI.normalize
             ) ||
             contains(f, "/js/src/test/scala/org/scalajs/testsuite/") && (
               // compiler
@@ -2310,8 +2324,9 @@ object Build {
         val javaV = javaVersion.value
         val scalaV = scalaVersion.value
 
-        if (targetPureWasm) Nil
-        else {
+        if (targetPureWasm) {
+          Nil
+        } else {
           List(sharedTestDir / "scala", sharedTestDir / "require-scala2") :::
           collectionsEraDependentDirectory(scalaV, sharedTestDir) ::
           includeIf(sharedTestDir / "require-jdk11", javaV >= 11) :::

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -2207,112 +2207,6 @@ object Build {
         List(sharedMainDir / "scala")
       },
 
-      unmanagedSourceDirectories in Test := {
-        val config = (scalaJSLinkerConfig in Test).value
-        val targetPureWasm = config.wasmFeatures.targetPureWasm
-
-        val testDir = (sourceDirectory in Test).value
-
-        val jsTestDir =
-          testDir.getParentFile.getParentFile.getParentFile / "js/src/test"
-        val jsTestSuiteDir =
-          jsTestDir / "scala" / "org" / "scalajs" / "testsuite"
-
-
-        val sharedTestDir =
-          testDir.getParentFile.getParentFile.getParentFile / "shared/src/test"
-        val sharedTestSuiteDir = sharedTestDir / "scala" / "org" / "scalajs" / "testsuite"
-
-        if (targetPureWasm) {
-          List(
-            sharedTestSuiteDir,
-            jsTestSuiteDir
-          )
-        } else {
-          (unmanagedSourceDirectories in Test).value
-        }
-      },
-
-      sources in Test := {
-        def endsWith(f: File, suffix: String): Boolean =
-          f.getPath().replace('\\', '/').endsWith(suffix)
-
-        def contains(f: File, substr: String): Boolean =
-          f.getPath().replace('\\', '/').contains(substr)
-
-        (sources in Test).value
-          .filter(f =>
-            contains(f, "/shared/src/test/scala/org/scalajs/testsuite/") && (
-              !contains(f, "/niocharset/") &&
-
-              // scalalib
-              !endsWith(f, "/scalalib/EnumerationTest.scala") && // Enumeration.toString -> String.split -> regex
-              !endsWith(f, "/scalalib/RangesTest.scala") && // BigDecimal
-              !endsWith(f, "/scalalib/SymbolTest.scala") && // Symbol#JSUniquenessCache
-
-              // javalib
-              !contains(f, "/javalib/util/regex/") &&
-              !contains(f, "/javalib/math/") &&
-              // javalib/lang
-              !endsWith(f, "/lang/CharacterUnicodeBlockTest.scala") && // String.replace, String.split
-              !endsWith(f, "/lang/ClassValueTest.scala") && // js.Map in ClassValue
-              !endsWith(f, "/lang/MathTest.scala") &&
-              !endsWith(f, "/lang/SystemPropertiesTest.scala") && // dictionary in SystemProperties
-
-              // javalib/util
-              !endsWith(f, "/PriorityQueueTest.scala") && // js.Array
-              !endsWith(f, "/Base64Test.scala") && // String.replaceAll in Base64Test
-              !endsWith(f, "/FormatterTest.scala") &&
-              !endsWith(f, "/ToDoubleFunctionTest.scala") && // parseDouble
-              !endsWith(f, "/ToLongFunctionTest.scala") && // Long.parseUnsignedLongInternal, StringRadixInfos
-              !endsWith(f, "/ToLongBiFunctionTest.scala") && // Long.parseUnsignedLongInternal, StringRadixInfos
-              !endsWith(f, "/ToDoubleBiFunctionTest.scala") && // parse Double
-              !endsWith(f, "/RandomTest.scala") && // Math.sqrt
-              !endsWith(f, "/ArraysTest.scala") && // float/double to String
-              !endsWith(f, "/IntConsumerTest.scala") && // Long#StringRadixInfos
-              !endsWith(f, "/DateTest.scala") && // js.Date
-              !endsWith(f, "/PropertiesTest.scala") && // Date.toString
-              !endsWith(f, "/ThreadLocalRandomTest.scala") && // Math.min/max
-              !endsWith(f, "/CollectionsTest.scala") && // Math$.floor(double) from Random.<init>
-              !endsWith(f, "/SplittableRandomTest.scala") && // Math$.floor(double) from Random.<init>
-
-              !endsWith(f, "/ConcurrentSkipListSetTest.scala") && // RedBlackTree.fromOrdered
-              //depends on ConcurrentSkipListSetTest
-              !endsWith(f, "/CollectionsOnCheckedSetTest.scala") &&
-              !endsWith(f, "/CollectionsOnSetsTest.scala") &&
-              !endsWith(f, "/CollectionsOnSynchronizedSetTest.scala") &&
-              !endsWith(f, "/NavigableSetTest.scala") &&
-              !endsWith(f, "/TreeSetTest.scala") && //depends on NavigableSetTest
-
-              !endsWith(f, "/CopyOnWriteArrayListTest.scala") &&
-               // depends on CopyOnWriteArrayListTest
-              !endsWith(f, "/CollectionsOnSynchronizedListTest.scala") &&
-              !endsWith(f, "/CollectionsOnSynchronizedCollectionTest.scala") &&
-              !endsWith(f, "/CollectionsOnListsTest.scala") &&
-              !endsWith(f, "/CollectionsOnCheckedListTest.scala") &&
-              !endsWith(f, "/CollectionsOnCheckedCollectionTest.scala") &&
-
-              // javalib/io
-              !endsWith(f, "/io/OutputStreamWriterTest.scala") && // CharSet.CharSetMap
-              !endsWith(f, "/io/PrintWriterTest.scala") && // Formatter
-              !endsWith(f, "/io/PrintStreamTest.scala") && // Formatter
-
-              // javalib/net
-              !endsWith(f, "/net/URLEncoderTest.scala") && // CharSet.CharSetMap
-              !endsWith(f, "/net/URLDecoderTest.scala") && // CharSet.CharSetMap
-              !endsWith(f, "/net/URITest.scala") // CharSet.CharSetMap, URI.normalize
-            ) ||
-            contains(f, "/js/src/test/scala/org/scalajs/testsuite/") && (
-              // compiler
-              endsWith(f, "/ModuleInitializersTest.scala") ||
-              endsWith(f, "/EqJSTest.scala") ||
-              // library
-              // endsWith(f, "/LinkTimeIfTest.scala") || Math.pow
-              endsWith(f, "/ReflectTest.scala")
-            )
-          )
-      },
-
       unmanagedSourceDirectories in Test ++= {
         val config = (scalaJSLinkerConfig in Test).value
         val targetPureWasm = config.wasmFeatures.targetPureWasm
@@ -2320,12 +2214,19 @@ object Build {
         val testDir = (sourceDirectory in Test).value
         val sharedTestDir =
           testDir.getParentFile.getParentFile.getParentFile / "shared/src/test"
+        val jsTestDir =
+          testDir.getParentFile.getParentFile.getParentFile / "js/src/test"
 
         val javaV = javaVersion.value
         val scalaV = scalaVersion.value
 
         if (targetPureWasm) {
-          Nil
+          List(
+            sharedTestDir / "scala",
+            jsTestDir, // run only a few tests (filtered out in sources)
+            sharedTestDir / "require-scala2",
+            collectionsEraDependentDirectory(scalaV, sharedTestDir)
+          )
         } else {
           List(sharedTestDir / "scala", sharedTestDir / "require-scala2") :::
           collectionsEraDependentDirectory(scalaV, sharedTestDir) ::
@@ -2335,6 +2236,98 @@ object Build {
           includeIf(testDir / "require-scala2", isJSTest)
         }
       },
+
+      sources in Test := {
+        val config = (scalaJSLinkerConfig in Test).value
+        val targetPureWasm = config.wasmFeatures.targetPureWasm
+
+        def endsWith(f: File, suffix: String): Boolean =
+          f.getPath().replace('\\', '/').endsWith(suffix)
+
+        def contains(f: File, substr: String): Boolean =
+          f.getPath().replace('\\', '/').contains(substr)
+
+        val originalSources = (sources in Test).value
+        if (!targetPureWasm) originalSources
+        else {
+          originalSources
+            .filter(f =>
+              contains(f, "/shared/src/test/scala-old-collections/") ||
+              contains(f, "/shared/src/test/require-scala2/") && (
+                !endsWith(f, "/scalalib/SymbolTestScala2.scala") // Symbol#JSUniquenessCache
+              ) ||
+              contains(f, "/shared/src/test/scala/org/scalajs/testsuite/") && (
+                !contains(f, "/niocharset/") &&
+
+                // scalalib
+                !endsWith(f, "/scalalib/EnumerationTest.scala") && // Enumeration.toString -> String.split -> regex
+                !endsWith(f, "/scalalib/RangesTest.scala") && // BigDecimal
+                !endsWith(f, "/scalalib/SymbolTest.scala") && // Symbol#JSUniquenessCache
+
+                // javalib
+                !contains(f, "/javalib/util/regex/") &&
+                !contains(f, "/javalib/math/") &&
+                // javalib/lang
+                !endsWith(f, "/lang/CharacterUnicodeBlockTest.scala") && // String.replace, String.split
+                !endsWith(f, "/lang/ClassValueTest.scala") && // js.Map in ClassValue
+                !endsWith(f, "/lang/MathTest.scala") &&
+                !endsWith(f, "/lang/SystemPropertiesTest.scala") && // dictionary in SystemProperties
+
+                // javalib/util
+                !endsWith(f, "/PriorityQueueTest.scala") && // js.Array
+                !endsWith(f, "/Base64Test.scala") && // String.replaceAll in Base64Test
+                !endsWith(f, "/FormatterTest.scala") &&
+                !endsWith(f, "/ToDoubleFunctionTest.scala") && // parseDouble
+                !endsWith(f, "/ToLongFunctionTest.scala") && // Long.parseUnsignedLongInternal, StringRadixInfos
+                !endsWith(f, "/ToLongBiFunctionTest.scala") && // Long.parseUnsignedLongInternal, StringRadixInfos
+                !endsWith(f, "/ToDoubleBiFunctionTest.scala") && // parse Double
+                !endsWith(f, "/RandomTest.scala") && // Math.sqrt
+                !endsWith(f, "/ArraysTest.scala") && // float/double to String
+                !endsWith(f, "/IntConsumerTest.scala") && // Long#StringRadixInfos
+                !endsWith(f, "/DateTest.scala") && // js.Date
+                !endsWith(f, "/PropertiesTest.scala") && // Date.toString
+                !endsWith(f, "/ThreadLocalRandomTest.scala") && // Math.min/max
+                !endsWith(f, "/CollectionsTest.scala") && // Math$.floor(double) from Random.<init>
+                !endsWith(f, "/SplittableRandomTest.scala") && // Math$.floor(double) from Random.<init>
+
+                !endsWith(f, "/ConcurrentSkipListSetTest.scala") && // RedBlackTree.fromOrdered
+                //depends on ConcurrentSkipListSetTest
+                !endsWith(f, "/CollectionsOnCheckedSetTest.scala") &&
+                !endsWith(f, "/CollectionsOnSetsTest.scala") &&
+                !endsWith(f, "/CollectionsOnSynchronizedSetTest.scala") &&
+                !endsWith(f, "/NavigableSetTest.scala") &&
+                !endsWith(f, "/TreeSetTest.scala") && //depends on NavigableSetTest
+
+                !endsWith(f, "/CopyOnWriteArrayListTest.scala") &&
+                 // depends on CopyOnWriteArrayListTest
+                !endsWith(f, "/CollectionsOnSynchronizedListTest.scala") &&
+                !endsWith(f, "/CollectionsOnSynchronizedCollectionTest.scala") &&
+                !endsWith(f, "/CollectionsOnListsTest.scala") &&
+                !endsWith(f, "/CollectionsOnCheckedListTest.scala") &&
+                !endsWith(f, "/CollectionsOnCheckedCollectionTest.scala") &&
+
+                // javalib/io
+                !endsWith(f, "/io/OutputStreamWriterTest.scala") && // CharSet.CharSetMap
+                !endsWith(f, "/io/PrintWriterTest.scala") && // Formatter
+                !endsWith(f, "/io/PrintStreamTest.scala") && // Formatter
+
+                // javalib/net
+                !endsWith(f, "/net/URLEncoderTest.scala") && // CharSet.CharSetMap
+                !endsWith(f, "/net/URLDecoderTest.scala") && // CharSet.CharSetMap
+                !endsWith(f, "/net/URITest.scala") // CharSet.CharSetMap, URI.normalize
+              ) ||
+              contains(f, "/js/src/test/scala/org/scalajs/testsuite/") && (
+                // compiler
+                endsWith(f, "/ModuleInitializersTest.scala") ||
+                endsWith(f, "/EqJSTest.scala") ||
+                // library
+                // endsWith(f, "/LinkTimeIfTest.scala") || Math.pow
+                endsWith(f, "/ReflectTest.scala")
+              )
+            )
+        }
+      },
+
   )
 
   def testSuiteBootstrapSetting(testSuiteLinker: Project) = Def.settings(

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/junit/JUnitAssertionsTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/junit/JUnitAssertionsTest.scala
@@ -15,9 +15,12 @@ package org.scalajs.testsuite.junit
 import org.junit.Test
 
 import org.junit.Assert._
+import org.junit.Assume._
 import org.hamcrest.CoreMatchers._
 
 import org.scalajs.testsuite.utils.AssertThrows.assertThrows
+
+import org.scalajs.testsuite.utils.Platform.executingInPureWebAssembly
 
 import scala.util.{Failure, Success, Try}
 
@@ -332,6 +335,8 @@ class JUnitAssertionsTest {
 
   @Test
   def testAssertThat(): Unit = {
+    assumeFalse("TODO: <42> is a java.lang.Byte in pure Wasm, but it should Int", executingInPureWebAssembly)
+
     testIfAsserts(assertThat("42", instanceOf[String](classOf[String])))
     testIfAsserts(assertThat("42", instanceOf[String](classOf[Int])), ShallNotPass)
 

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/scalalib/ClassTagTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/scalalib/ClassTagTest.scala
@@ -95,6 +95,8 @@ class ClassTagTest {
   }
 
   @Test def classTagBasedPatternMatchingOfPrimitives(): Unit = {
+    assumeFalse("TODO: 5 must be a java.lang.Integer, but Byte in pure Wasm",
+        executingInPureWebAssembly)
     def test[A: ClassTag](x: Any): Boolean = x match {
       case x: A => true
       case _    => false


### PR DESCRIPTION
Now, 3972 tests pass on pure Wasm (while when we run test-suites on Wasm on JS, 8879 runs)

Also, fix not to filter out `sources in Test` when it's not pure Wasm.