### PR TITLE
Add ES2021 to the build matrices of the Wasm build.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,9 @@ jobs:
       fail-fast: false
       matrix:
         suffix: [2_13]
-        esVersion: [ES5_1, ES2021]
+        esVersion: [ES5_1, ES2015, ES2021]
+    env:
+      SBT_SET_COMMAND: 'set Seq(ThisBuild/scalaJSLinkerConfig ~= (_.withESFeatures(_.withESVersion(ESVersion.${{ matrix.esVersion }}))))'
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-java@v4
@@ -35,14 +37,11 @@ jobs:
       - name: npm install
         run: npm install
       - name: helloworld${{ matrix.suffix }}/run
-        run: sbt 'set scalaJSLinkerConfig in helloworld.v${{ matrix.suffix }} ~= (_.withESFeatures(_.withESVersion(ESVersion.${{ matrix.esVersion }}))) ' \
-            helloworld${{ matrix.suffix }}/run
+        run: sbt "$SBT_SET_COMMAND" "helloworld${{ matrix.suffix }}/run"
       - name: testSuite${{ matrix.suffix }}/test
-        run: sbt 'set scalaJSLinkerConfig in testSuite.v${{ matrix.suffix }} ~= (_.withESFeatures(_.withESVersion(ESVersion.${{ matrix.esVersion }}))) ' \
-            testSuite${{ matrix.suffix }}/test
+        run: sbt "$SBT_SET_COMMAND" "testSuite${{ matrix.suffix }}/test"
       - name: testSuiteEx${{ matrix.suffix }}/test
-        run: sbt 'set scalaJSLinkerConfig in testSuiteEx.v${{ matrix.suffix }} ~= (_.withESFeatures(_.withESVersion(ESVersion.${{ matrix.esVersion }}))) ' \
-            testSuiteEx${{ matrix.suffix }}/test
+        run: sbt "$SBT_SET_COMMAND" "testSuiteEx${{ matrix.suffix }}/test"
 
   test-suite-webassembly:
     runs-on: ubuntu-latest
@@ -50,6 +49,9 @@ jobs:
       fail-fast: false
       matrix:
         suffix: [2_12, 2_13]
+        esVersion: [ES2015, ES2021] # Some javalib features depend on the target ES version
+    env:
+      SBT_SET_COMMAND: 'set Seq(Global/enableWasmEverywhere := true, ThisBuild/scalaJSLinkerConfig ~= (_.withESFeatures(_.withESVersion(ESVersion.${{ matrix.esVersion }}))))'
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-java@v4
@@ -64,11 +66,11 @@ jobs:
       - name: npm install
         run: npm install
       - name: helloworld${{ matrix.suffix }}/run
-        run: sbt 'set Global/enableWasmEverywhere := true' helloworld${{ matrix.suffix }}/run
+        run: sbt "$SBT_SET_COMMAND" "helloworld${{ matrix.suffix }}/run"
       - name: testSuite${{ matrix.suffix }}/test
-        run: sbt 'set Global/enableWasmEverywhere := true' testSuite${{ matrix.suffix }}/test
+        run: sbt "$SBT_SET_COMMAND" "testSuite${{ matrix.suffix }}/test"
       - name: testSuiteEx${{ matrix.suffix }}/test
-        run: sbt 'set Global/enableWasmEverywhere := true' testSuiteEx${{ matrix.suffix }}/test
+        run: sbt "$SBT_SET_COMMAND" "testSuiteEx${{ matrix.suffix }}/test"
 
   test-suite-pure-wasm:
     runs-on: ubuntu-latest
@@ -76,7 +78,10 @@ jobs:
       fail-fast: false
       matrix:
         suffix: [2_12] # TODO: test with 2_13 too
+        esVersion: [ES2015, ES2021] # Some javalib features depend on the target ES version
         eh-support: [true, false]
+    env:
+      SBT_SET_COMMAND: 'set Seq(Global/enableWasmEverywhere := true, ThisBuild/scalaJSLinkerConfig ~= (_.withESFeatures(_.withESVersion(ESVersion.${{ matrix.esVersion }})).withWasmFeatures(_.withTargetPureWasm(true).withExceptionHandling(${{ matrix.eh-support }}))))'
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-java@v4
@@ -91,12 +96,11 @@ jobs:
       - name: npm install
         run: npm install
       - name: helloworld-wasm${{ matrix.suffix }}/run
-        run: sbt "helloworldWasm${{ matrix.suffix }}/run"
+        run: sbt "$SBT_SET_COMMAND" "helloworldWasm${{ matrix.suffix }}/run"
       - name: helloworld-wasm${{ matrix.suffix }}/test
-        run: sbt "helloworldWasm${{ matrix.suffix }}/test"
+        run: sbt "$SBT_SET_COMMAND" "helloworldWasm${{ matrix.suffix }}/test"
       - name: testSuite${{ matrix.suffix }}/test
-        run: |
-          sbt "set Seq(Global/enableWasmEverywhere := true, testSuite.v${{ matrix.suffix }}/scalaJSLinkerConfig ~= (_.withWasmFeatures(_.withTargetPureWasm(true).withExceptionHandling(${{ matrix.eh-support }}))))" testSuite${{ matrix.suffix }}/test
+        run: sbt "$SBT_SET_COMMAND" "testSuite${{ matrix.suffix }}/test"
 
   test-suite-component:
     runs-on: ubuntu-latest


### PR DESCRIPTION
The target ES version affects some features of the javalib, so we should also test them on Wasm.

Also, add ES2015 to the JS build, as ES2015-but-not-ES2018 is an important config for regular expression support.