### PR TITLE
Fix boxed primitive equality and identityHashCode

### DIFF
--- a/linker/shared/src/main/scala/org/scalajs/linker/backend/wasmemitter/CoreWasmLib.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/backend/wasmemitter/CoreWasmLib.scala
@@ -3942,11 +3942,18 @@ final class CoreWasmLib(coreSpec: CoreSpec, globalInfo: LinkedGlobalInfo) {
       fb += I32Const(0)
       fb += Return
     }
-    fb += LocalTee(objNonNullLocal)
 
-    // If `obj` is one of our objects, skip all the jsValueType tests
-    fb += RefTest(RefType(genTypeID.ObjectStruct))
-    fb += I32Eqz
+    if (targetPureWasm) {
+      // In pure Wasm, the boxed primitives are our objects, and
+      // the scalaValueType tests are needed.
+      fb += LocalSet(objNonNullLocal)
+      fb += I32Const(1)
+    } else {
+      // If `obj` is one of our objects, skip all the jsValueType tests
+      fb += LocalTee(objNonNullLocal)
+      fb += RefTest(RefType(genTypeID.ObjectStruct))
+      fb += I32Eqz
+    }
     fb.ifThen() {
       fb.switch() { () =>
         fb += LocalGet(objNonNullLocal)

--- a/scalalib/overrides/scala/runtime/BoxesRunTime.scala
+++ b/scalalib/overrides/scala/runtime/BoxesRunTime.scala
@@ -53,8 +53,12 @@ object BoxesRunTime {
 
   def equals(x: Object, y: Object): Boolean =
     linkTimeIf(LinkingInfo.targetPureWasm) {
-      if (x eq y) true
-      else equals2(x, y)
+      if (x eq y) {
+        x match {
+          case x: java.lang.Double => x == x // rejects NaN
+          case _                   => true
+        }
+      } else equals2(x, y)
     } {
       if (scala.scalajs.js.special.strictEquals(x, y)) true
       else equals2(x, y)

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/compiler/RegressionTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/compiler/RegressionTest.scala
@@ -628,7 +628,6 @@ class RegressionTest {
   }
 
   @Test def eqEqJLDouble(): Unit = {
-    assumeFalse("TODO: assertion fail in pure Wasm", executingInPureWebAssembly)
     // Taken from run/sd329.scala in scala/scala
 
     def d1: Double = 0.0
@@ -670,7 +669,6 @@ class RegressionTest {
   }
 
   @Test def eqEqJLFloat(): Unit = {
-    assumeFalse("TODO: assertion fail in pure Wasm", executingInPureWebAssembly)
     // Taken from run/sd329.scala in scala/scala
 
     def f1: Float = 0.0f

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/util/MapTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/util/MapTest.scala
@@ -172,7 +172,6 @@ trait MapTest {
   }
 
   @Test def testSizeGetPutWithDoublesCornerCasesOfEquals(): Unit = {
-    assumeFalse("signed 0 doesn't work well in pure Wasm", executingInPureWebAssembly)
     assumeNotIdentityHashMapOnJVM()
 
     val mp = factory.empty[Double, Double]
@@ -263,7 +262,6 @@ trait MapTest {
   }
 
   @Test def testRemoveWithDoublesCornerCasesOfEquals(): Unit = {
-    assumeFalse("Double value as a key doesn't work in pure Wasm", executingInPureWebAssembly)
     assumeNotIdentityHashMapOnJVM()
 
     val mp = factory.empty[Double, String]
@@ -722,7 +720,6 @@ trait MapTest {
   }
 
   @Test def testKeySetIsViewForQueriesWithDoublesCornerCaseOfEquals(): Unit = {
-    assumeFalse("signed 0 doesn't work well in pure Wasm", executingInPureWebAssembly)
     assumeNotIdentityHashMapOnJVM()
 
     val nummp = factory.empty[Double, Double]


### PR DESCRIPTION
- NaN === NaN should be false
- `identityHashCode` on a FloatBox, DoubleBox, and IntegerBox, should perform the hashCode function on respective class, such as Double.hashCode. However, previously, in pure Wasm, the implementation of the boxed class was to use the value taken from the `lastIDHashCode`, so that `hashCode` functions of two `java.lang.Double` classes with the same value returned different hashCode values.