### PR TITLE
Eliminate FloatBox class

### DIFF
--- a/linker/shared/src/main/scala/org/scalajs/linker/backend/wasmemitter/DerivedClasses.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/backend/wasmemitter/DerivedClasses.scala
@@ -39,7 +39,6 @@ object DerivedClasses {
         case clazz if clazz.className == BoxedCharacterClass ||
             clazz.className == BoxedLongClass ||
             clazz.className == BoxedIntegerClass ||
-            clazz.className == BoxedFloatClass ||
             clazz.className == BoxedDoubleClass ||
             clazz.className == BoxedBooleanClass =>
           deriveBoxClass(clazz)

--- a/linker/shared/src/main/scala/org/scalajs/linker/backend/wasmemitter/SpecialNames.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/backend/wasmemitter/SpecialNames.scala
@@ -29,7 +29,6 @@ object SpecialNames {
   // targetPureWasm
   val BooleanBoxClass = BoxedBooleanClass.withSuffix("Box")
   val IntegerBoxClass = BoxedIntegerClass.withSuffix("Box")
-  val FloatBoxClass = BoxedFloatClass.withSuffix("Box")
   val DoubleBoxClass = BoxedDoubleClass.withSuffix("Box")
   val BooleanBoxCtor = MethodName.constructor(List(BooleanRef))
 


### PR DESCRIPTION
f32 can be boxed into a DoubleBox. This reduces the number of ref.test against Box class in runtime type check. Similarly, i32 (especially, a value that does not fit in i31ref) can be boxed into the DoubleBox to eliminate the IntegerBox, but so we leave it as is for the time being, since it's not obvious to improve performance.