### PR TITLE
Parse float: Bellerophon algorithm from "How to Read Floating Point Numbers Accurately"

### DIFF
--- a/javalib/src/main/scala/java/lang/Integer.scala
+++ b/javalib/src/main/scala/java/lang/Integer.scala
@@ -566,7 +566,14 @@ object Integer {
     }
   }
 
-  @inline def toUnsignedString(i: scala.Int): String = toUnsignedString(i, 10)
+  @inline def toUnsignedString(i: scala.Int): String = {
+    // TODO: pure wasm toUnsignedString(i, radix)
+    LinkingInfo.linkTimeIf(LinkingInfo.targetPureWasm) {
+      java.lang.Long.toString(Integer.toUnsignedLong(i))
+    } {
+      toUnsignedString(i, 10)
+    }
+  }
 
   @inline def hashCode(value: Int): Int = value.hashCode
 

--- a/javalib/src/main/scala/java/lang/Long.scala
+++ b/javalib/src/main/scala/java/lang/Long.scala
@@ -241,10 +241,11 @@ object Long {
 
   // Must be called only with a valid radix
   @inline def parseLongPlatform(s: String, radix: Int): scala.Long = {
-    if (LinkingInfo.isWebAssembly)
+    LinkingInfo.linkTimeIf(LinkingInfo.isWebAssembly) {
       parseLongImplWasm(s, radix, divideUnsigned(Int.MinValue, radix.toLong))
-    else
+    } {
       parseLongImplJS(s, radix)
+    }
   }
 
   /* Must be called only with a valid radix.
@@ -360,10 +361,11 @@ object Long {
 
   // Must be called only with a valid radix
   @inline def parseUnsignedLongPlatform(s: String, radix: Int): scala.Long = {
-    if (LinkingInfo.isWebAssembly)
+    LinkingInfo.linkTimeIf(LinkingInfo.isWebAssembly) {
       parseUnsignedLongImplWasm(s, radix, divideUnsigned(-1L, radix.toLong))
-    else
+    } {
       parseUnsignedLongImplJS(s, radix)
+    }
   }
 
   /* Must be called only with a valid radix.

--- a/javalib/src/main/scala/java/lang/dectoflt/Bellerophon.scala
+++ b/javalib/src/main/scala/java/lang/dectoflt/Bellerophon.scala
@@ -1,0 +1,310 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
+package java.lang.dectoflt
+
+import java.math.BigInteger
+import java.lang.dectoflt.Tables._
+
+import scala.annotation.tailrec
+
+/** An implementation of the conversion from a decimal floating-point number
+ *  to a binary floating-point number (Float or Double).
+ *
+ *  This code implements the Bellerophon algorithm, from
+ *  "How to Read Floating Point Numbers Accurately" by William D. Clinger.
+ *  It takes an input decimal number, represented by a significand `f` and
+ *  an exponent `e` to form the value `f * 10^e`, and finds the best
+ *  binary approximation.
+ */
+private[lang] object Bellerophon {
+  private val TableSize = smallPowerOfTens.length
+
+  private final val ExtendedSigBits = 64
+  private final val ExtendedMaxSig = BigInteger.ZERO.setBit(ExtendedSigBits)
+
+  def bellerophonFloat(f: BigInteger, e: Int): scala.Float =
+    bellerophon(f, e, Binary32)
+
+  def bellerophonDouble(f: BigInteger, e: Int): scala.Double =
+    bellerophon(f, e, Binary64)
+
+  /** An implementation of Bellerophon algorithm from
+   *  "How to Read Floating Point Numbers Accurately" by William D. Clinger.
+   *
+   *  The Bellerophon algorithm efficiently finds the best binary
+   *  approximation for a decimal number `f * 10^e`.
+   *  While an iterative approach like AlgorithmM (defined in the paper)
+   *  can find the best approximation by repeatedly using slow
+   *  BigInteger arithmetic, Bellerophon provides non-iterative approach.
+   *
+   *  The basic idea is, instead of directly computing the best approximation
+   *  for `f * 10^e` it uses higher-precision (p-bit (64-bit) significand)
+   *  floating-point numbers to approximate `f` and `10^e` separately.
+   *  Then multiplies these approximations and analyzes the
+   *  error when multiplying and rounding the result to the target
+   *  n-bit (n-bit significand) precision.
+   *
+   *  In some cases, the calculated approximation isn't the best, and in that case
+   *  the algorithm falls back to AlgorithmR.
+   *  This algorithm takes a good appoximation as a starting point,
+   *  and iteratively finds the best approximation.
+   *  Since the calculated approximation by Bellerophon is very close to the best
+   *  it converges in just a few steps.
+   *
+   *  For extreme values that would overflow to infinity or underflow to a
+   *  subnormal number or zero, neither the Bellerophon nor AlgorithmR does work.
+   *  In these cases, the algorithm falls back to the original, slower AlgorithmM
+   *  with the modification mentioned in section 8 of the paper.
+   *  > With IEEE arithmetic, for example, a denormalized result
+   *  > may be required. Denormalized results can be generate
+   *  > by a modified form of AlgorithmM that terminates immediately
+   *  > when the minimum exponent is reached.
+   */
+  private def bellerophon(f: BigInteger, e: Int, fmt: FloatingPointFormat): fmt.Repr = {
+    /* Fast path: when f < 2^sigbits (2^53 for Double), and |e| < ceil(log5(2^sigbits)),
+     * both f and 10^e can be represented perfectly in target precision without error.
+     *
+     * Since 10^e = 5^e * 2^e, the 2^e part can be absorbed into the binary exponent.
+     * Therefore, the 10^e can be represented without error if 5^e fits within the significand.
+     * This condition is expressed as 5^e < 2^sigbits <=> e < log5(2^sigbits).
+     * As `e` is an integer, the condition is equivalent to e < ceil(log5(2^sigbits)).
+     */
+    val sigFitsInTargetFloat = f.compareTo(fmt.MaxSigBigInt) < 0
+    if (sigFitsInTargetFloat && e >= 0 && e < fmt.CeilLog5OfMaxSig) {
+      fmt.mul(fmt.fromLong(f.longValueExact()), fmt.powerOfTen(e))
+    } else if (sigFitsInTargetFloat && e < 0 && -e < fmt.CeilLog5OfMaxSig) {
+      fmt.div(fmt.fromLong(f.longValueExact()), fmt.powerOfTen(-e))
+    } else {
+      /* When f and 10^e cannot be represented exactly at the target precision.
+       * Instead of computing it directly, bellerophon calculate the best approximation by:
+       * 1. Approximate f and 10^e using 64-bit extended precision floats
+       * 2. Multiply the approximations to get z = approx(f) * approx(10^e)
+       * 3. Analyze if rounding z to target precision (single of double) gives the correct result
+       * 4. If uncertain, fall back to slow path (Algorithm R) with the close approximation.
+       *
+       * The following error analysis is based on Lemma 2 and Corollary 3 from the paper:
+       * when `a` and `b` are 64-bit approximations with errors δ1 and δ2,
+       * the error δ of their product (a*b) is bounded by |δ| < 0.5 + 2(δ1 + δ2) ULPs,
+       * if 0 < δ1 + δ2 < 4 or δ1 < 1 or δ2 < 1.
+       *
+       * Below, δ1 represents the error for the 64-bit approximation of the significand 'f',
+       * and δ2 represents the error for the approximation of 10^e.
+       *
+       * Error bounds for δ1 (approximation of f):
+       * - If f < 2^64, then δ1 = 0, as f is exactly representable with a 64-bit significand.
+       * - If f >= 2^64, then δ1 <= 0.5 ULP, as we use the best approximation.
+       *
+       * Error bounds for δ2 (approximation of 10^e):
+       * - If 0 <= e < table_size, then δ2 = 0, as the value is taken from a pre-computed
+       *   table of exact powers of ten.
+       * - Otherwise, 10^e is calculated as approx(10^x) * approx(10^y),
+       *   where x is 0<=x<table_size, and x+y=e. The error for approx(10^x) is 0,
+       *   while the error for approx(10^y) is <= 0.5 ULP (because it might be too big).
+       *   Applying the Lemmsa, the resulting error δ2 is bounded by: |δ2| < 0.5 + 2*(0 + 0.5) = 1.5 ULPs.
+       *
+       * The total error for the final product, approx(f) * approx(10^e), is then bounded by
+       * applying the formula |δ| < 0.5 + 2(δ1 + δ2) again for each case:
+       *
+       * - f < 2^64, 0 <= e < table_size:    δ1=0,    δ2=0.   |δ| < 0.5 ULPs.
+       * - f < 2^64, e outside table range:  δ1=0,    δ2<1.5. |δ| < 0.5 + 2*(0 + 1.5)  = 3.5 ULPs.
+       * - f >= 2^64, 0 <= e < table_size:   δ1<=0.5, δ2=0.   |δ| < 0.5 + 2*(0.5 + 0)  = 1.5 ULPs.
+       * - f >= 2^64, e outside table range: δ1<=0.5, δ2<1.5. |δ| < 0.5 + 2*(0.5 + 1.5) = 4.5 ULPs.
+       *
+       * When rounding z to target precision, check the low-order bits.
+       * If (low_bits ± error_bound) doesn't cross the rounding boundary (halfway),
+       * the rounding direction is certain. Otherwise, fallback to slow path.
+       */
+      val slop = if (f.compareTo(ExtendedMaxSig) < 0) {
+        if (e >= 0 && e < TableSize) 0
+        else 3
+      } else {
+        if (e >= 0 && e < TableSize) 1
+        else 4
+      }
+      multiplyAndTest(f, e, slop, fmt)
+    }
+  }
+
+  private def multiplyAndTest(f: BigInteger, e: Int, slop: Int,
+      fmt: FloatingPointFormat): fmt.Repr = {
+    if (e < -LargeTableRange*TableSize || e > LargeTableRange*TableSize) {
+      // Can't calculate the approximaton of 10^e from pre-computed power of tens, fallback to slow path
+      algorithmM(f, e, fmt)
+    } else {
+      val x = FloatingPoint(f)
+      val y = powerOfTen(e)
+      val z = x.mul(y)
+      if (z.doesOverflowOnRound(fmt)) {
+        // bellerophon and algorithmR doesn't converge for overflow and underflow, fallback to slow path
+        algorithmM(f, e, fmt)
+      } else {
+        // Least significant bits to be rounded
+        val lowBits = z.f & ((1L << (ExtendedSigBits - fmt.SigBits)) - 1)
+        val diff = Math.abs(lowBits - (1L << (ExtendedSigBits - fmt.SigBits - 1)))
+        if (diff <= slop) {
+          // The value is too close to a rounding boundary. Use a safe backup algorithm.
+          algorithmR(f, e, z, fmt)
+        } else {
+          fmt.toIEEE754(z)
+        }
+      }
+    }
+  }
+
+  /** Calculate the approximation of power of ten in 64-bit extended floating point. */
+  private def powerOfTen(e: Int): FloatingPoint = {
+    if (0 <= e && e < TableSize) {
+      smallPowerOfTens(e)
+    } else {
+      val q = Math.floorDiv(e, TableSize)
+      val r = e - q * TableSize
+      smallPowerOfTens(r).mul(largePowerOfTens(q + LargeTableRange))
+    }
+  }
+
+  private def algorithmM(f: BigInteger, e: Int,
+      fmt: FloatingPointFormat): fmt.Repr = {
+    val MinSig = BigInteger.ZERO.setBit(fmt.SigBits - 1)
+    val MaxSig = BigInteger.ZERO.setBit(fmt.SigBits)
+
+    val MaxExp = (1 << fmt.ExpBits - 1) - 1 - fmt.ExplicitSigBits
+    val MinExp = -(1 << fmt.ExpBits - 1) + 2 - fmt.ExplicitSigBits // min exp for normal
+
+    // Approximate decimal f*10^e by binary (u/v)*2^k
+    // starting from k=0, iterate until u/v is normalized.
+    @tailrec def loop(u: BigInteger, v: BigInteger, k: Int): fmt.Repr = {
+      val divRem = u.divideAndRemainder(v)
+      val q = divRem(0)
+      val rem = divRem(1)
+
+      val isBelowNormalizedRange = q.compareTo(MinSig) < 0
+      val isAboveNormalizedRange = q.compareTo(MaxSig) >= 0
+      val isNormalized = !(isBelowNormalizedRange || isAboveNormalizedRange)
+
+      if (k == MinExp) {
+        if (isNormalized) {
+          val z = fmt.toIEEE754(FloatingPoint(q, k))
+          roundByRemainder(q, rem, v, z)
+        } else {
+          underflow(q, v, rem)
+        }
+      } else if (k > MaxExp) {
+        fmt.PositiveInfinity
+      } else if (isNormalized) {
+        val z = fmt.toIEEE754(FloatingPoint(q, k))
+        roundByRemainder(q, rem, v, z)
+      } else if (isBelowNormalizedRange) {
+        loop(u.shiftLeft(1), v, k - 1)
+      } else { // x > 2^m
+        loop(u, v.shiftLeft(1), k + 1)
+      }
+    }
+
+    def roundByRemainder(q: BigInteger, rem: BigInteger, v: BigInteger,
+        z: fmt.Repr): fmt.Repr = {
+      /* u = v*q + r (0 <= r < v)
+       * u/v = q + r/v (0 <= r/v < 1)
+       * therefore, q <= u/v < q+1
+       * if u/v < q + 1/2 then round down
+       * if u/v > q + 1/2 then round up
+       *
+       * u/v < q + 1/2 <=> q + r/v < q + 1/2 <=>
+       * r/v < 1/2 <=> r < r/2 <=> 2r < v <=> r < v - r
+       */
+      val vMinusR = v.subtract(rem)
+      val cmp = rem.compareTo(vMinusR)
+      if (cmp < 0) z
+      else if (cmp > 0) fmt.nextUp(z)
+      else if (!q.testBit(0)) z // even
+      else fmt.nextUp(z)
+    }
+
+    @inline
+    def underflow(q: BigInteger, v: BigInteger, rem: BigInteger): fmt.Repr = {
+      if (q.compareTo(MinSig) < 0) { // mantissa is small enough
+        roundByRemainder(q, rem, v, fmt.reinterpretBits(q))
+      } else {
+        throw new AssertionError("Shouldn't reach here.")
+      }
+    }
+
+    if (e < 0) loop(f, BigInteger.TEN.pow(-e), 0)
+    else loop(f.multiply(BigInteger.TEN.pow(e)), BigInteger.ONE, 0)
+  }
+
+  /** Given an exact floating point number f * 10^e and
+   *  a floating point number z0 (initial approximation),
+   *  returns the best floating point approximation to f * 10^e.
+   */
+  private def algorithmR(f: BigInteger, e: Int, z0: FloatingPoint,
+      fmt: FloatingPointFormat): fmt.Repr = {
+    /* Given exact floating point number f * 10^e = (m+ε)*2^k, where ε is an rouding error.
+     * AlgorithmR find positive integers x and y, such that, x/y = f*10^e/m*2^k and |ε| < 1/2.
+     * x/y = ((m+ε)*2^k)/(m*2^k)=(m+ε)/m <=> ε=m(x-y)/y.
+     * Therefore, |ε|<1/2 <=> |m(x-y)/y|<1/2 <=> |x-y|*2m < y.
+     * Now, given D=x-y, and D2=2m*|D|, |ε|<1/2 means D2 < y.
+     *
+     * If |ε|>=1/2, test D<0 (x<y) or not, when x<y, current approximation (y=(m*2^k))
+     * is too big, iterate with the previous floating point number.
+     */
+    @tailrec
+    def loop(z: fmt.Repr): fmt.Repr = {
+      val (m, exp) = fmt.frexp(z)
+      val mantissa = BigInteger.valueOf(m)
+      val (x, y) = {
+        if (e >= 0) {
+          if (exp >= 0)
+            (f.multiply(BigInteger.TEN.pow(e)), mantissa.shiftLeft(exp))
+          else
+            (f.multiply(BigInteger.TEN.pow(e)).shiftLeft(-exp), mantissa)
+        } else {
+          if (exp >= 0)
+            (f, mantissa.shiftLeft(exp).multiply(BigInteger.TEN.pow(-e)))
+          else // e < 0 && exponent < 0
+            (f.shiftLeft(-exp), mantissa.multiply(BigInteger.TEN.pow(-e)))
+        }
+      }
+      val d = x.subtract(y) // D = x-y
+      val d2 = mantissa.shiftLeft(1).multiply(d.abs()) // D2=2m*|D|
+      val cmp = d2.compareTo(y)
+
+      if (cmp < 0) { // D2 < y (|ε|<1/2), found the best approximation.
+        /* If m is on the normalization boundary:
+         * m = 2^(n-1) (where n is significand bits) and ε=-1/4,
+         * there are two closest approximation.
+         */
+        if ((m == (1 << (fmt.SigBits - 1))) &&
+            d2.shiftLeft(1).compareTo(y) > 0 && d.signum() < 0)
+          loop(fmt.nextDown(z))
+        else z
+      } else if (cmp == 0) { // on boundary (x equals y), round to even
+        if ((m & 1) == 0) {
+          if (m == (1 << (fmt.SigBits - 1)) && d.signum() < 0)
+            loop(fmt.nextDown(z))
+          else z
+        } else if (d.signum() < 0) {
+          loop(fmt.nextDown(z))
+        } else {
+          loop(fmt.nextUp(z))
+        }
+      } else { // D2 > y (|ε|>1/2)
+        if (d.signum() < 0) {
+          loop(fmt.nextDown(z))
+        } else {
+          loop(fmt.nextUp(z))
+        }
+      }
+    }
+    loop(fmt.toIEEE754(z0))
+  }
+}

--- a/javalib/src/main/scala/java/lang/dectoflt/FloatingPoint.scala
+++ b/javalib/src/main/scala/java/lang/dectoflt/FloatingPoint.scala
@@ -1,0 +1,152 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
+package java.lang.dectoflt
+
+import java.math.BigInteger
+import java.lang.{Long => JLong}
+
+/** DIY floating point number with 64-bit significant bits */
+private[dectoflt] class FloatingPoint private (val f: Long, val e: Int) {
+  import FloatingPoint._
+
+  override def toString(): String =
+    s"${this.f} * 2^${this.e}"
+
+  /** Returns a normalized product */
+  def mul(other: FloatingPoint): FloatingPoint = {
+    val low = f * other.f
+    val high = Math.unsignedMultiplyHigh(f, other.f)
+
+    val nlz = JLong.numberOfLeadingZeros(high)
+    val excessBits = 64 - nlz
+    val shiftedF =
+      if (nlz == 0) high
+      else (high << nlz) | (low >>> excessBits)
+    val newE = (this.e + other.e + excessBits)
+
+    val remainder = low & (-1L >>> nlz)
+    val halfway = 1L << (excessBits - 1)
+
+    val newF = {
+      if (JLong.unsigned_>(remainder, halfway)) // roundup
+        shiftedF + 1
+      else if (JLong.unsigned_<(remainder, halfway))
+        shiftedF
+      else if ((shiftedF & 1) == 1) // tie, rounddown is odd
+        shiftedF + 1 // round to even
+      else
+        shiftedF
+    }
+    if (newF == 0) {
+      // denormalized by carry, in case shiftedF = 111..111
+      // (111...111 + 1) >> 1
+      new FloatingPoint(Long.MinValue, newE + 1)
+    } else {
+      new FloatingPoint(newF, newE)
+    }
+  }
+
+  def doesOverflowOnRound(fmt: FloatingPointFormat): Boolean = {
+    val (sig, exponent) = roundNormal(fmt)
+
+    // Remove the leading implicit bit
+    val encodedSig: Long = sig - (1L << (fmt.ExplicitSigBits))
+
+    // Adjust the exponent for exponent bias and mantissa shift
+    val encodedExp: Int = exponent + ((1 << (fmt.ExpBits - 1)) - 1) + fmt.ExplicitSigBits
+
+    encodedExp <= 0 || encodedExp >= ((1 << fmt.ExpBits) - 1) ||
+        encodedSig <= 0 || encodedSig >= (1 << fmt.ExplicitSigBits)
+  }
+
+  /** Round the 64-bit significand to target#SigBits bits with half-to-even. */
+  private[dectoflt] def roundNormal(target: FloatingPointFormat): (Long, Int) = {
+    val excess = SigBits - target.SigBits // > 0
+    val halfway = 1L << (excess - 1)
+    val shiftedF = f >>> excess
+    val remainder = f & ((1L << excess) - 1) // > 0
+    val normalizedE = e + excess
+
+    val normalizedF = if (remainder > halfway) { // roundup
+      shiftedF + 1
+    } else if (remainder < halfway) { // rounddown
+      shiftedF
+    } else if ((shiftedF & 1) == 1) { // tie, rownddown (shiftedF) is odd (1 at LSB)
+      shiftedF + 1 // roundup is even
+    } else { // tie, rounddown is even
+      shiftedF
+    }
+    if (normalizedF > target.MaxSig) {
+      (normalizedF >> 1, normalizedE + 1)
+    } else {
+      (normalizedF, normalizedE)
+    }
+  }
+}
+
+object FloatingPoint {
+  private final val SigBits = 64
+
+  def apply(f: BigInteger): FloatingPoint = {
+    val (newF, newE) = normalize(f, 0)
+    new FloatingPoint(newF, newE)
+  }
+
+  def apply(f: BigInteger, e: Int): FloatingPoint = {
+    val (newF, newE) = normalize(f, e)
+    new FloatingPoint(newF, newE)
+  }
+
+  /** Create a FloatingPoint from normalized f and e. */
+  def normalized(f: Long, e: Int): FloatingPoint = {
+    new FloatingPoint(f, e)
+  }
+
+  /** Normalize the given floating point number z = f * 2^e
+   *
+   *  A floating point number is normalized iff β^(n-1) <= f < β^n (β=2, n=64)
+   */
+  private def normalize(f: BigInteger, e: Int): (Long, Int) = {
+    val shift = f.bitLength() - SigBits
+    if (shift == 0) {
+      (f.longValue(), e)
+    } else if (shift < 0) {
+      // Significand is smaller. Shift left to normalize.
+      (f.shiftLeft(-shift).longValue(), e + shift)
+    } else {
+      // shift > 0, significand is too big, round and shift right using round half to even.
+      val shiftedF = f.shiftRight(shift)
+      val remainder = f.and(BigInteger.ZERO.setBit(shift).subtract(BigInteger.ONE))
+      val halfway = BigInteger.ZERO.setBit(shift - 1)
+      val normalizedF = {
+        if (remainder.compareTo(halfway) > 0) { // roundup
+          shiftedF.add(BigInteger.ONE)
+        } else if (remainder.compareTo(halfway) < 0) { // rounddown
+          shiftedF
+        } else if (shiftedF.testBit(0)) { // tie, rownddown (shiftedF) is odd (1 at LSB)
+          shiftedF.add(BigInteger.ONE) // roundup is even
+        } else { // tie, rounddown is even
+          shiftedF
+        }
+      }
+      val normalizedE = e + shift
+
+      // Check for overflow from rounding
+      if (normalizedF.bitLength() > SigBits) {
+        (normalizedF.shiftRight(1).longValue(), normalizedE + 1)
+      } else {
+        (normalizedF.longValue(), normalizedE)
+      }
+    }
+  }
+}

--- a/javalib/src/main/scala/java/lang/dectoflt/FloatingPointFormat.scala
+++ b/javalib/src/main/scala/java/lang/dectoflt/FloatingPointFormat.scala
@@ -1,0 +1,158 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
+package java.lang.dectoflt
+
+import java.lang.Math
+import java.math.BigInteger
+
+sealed trait FloatingPointFormat {
+  type Repr
+
+  val ExpBits: Int
+  val SigBits: Int
+  val CeilLog5OfMaxSig: Int
+  val MaxSig: Long
+  val PositiveInfinity: Repr
+
+  final val ExplicitSigBits: Int = SigBits - 1
+  final val MaxSigBigInt: BigInteger = BigInteger.valueOf(MaxSig)
+
+  def powerOfTen(i: Int): Repr
+  def nextDown(v: Repr): Repr
+  def nextUp(v: Repr): Repr
+  def mul(a: Repr, b: Repr): Repr
+  def div(a: Repr, b: Repr): Repr
+  /** Decompose the given floating-point value into a normalized mantissa and a power of 2. */
+  def frexp(v: Repr): (Long, Int)
+  def fromLong(v: Long): Repr
+  def reinterpretBits(v: BigInteger): Repr
+  def toIEEE754(v: FloatingPoint): Repr
+}
+
+object Binary32 extends FloatingPointFormat {
+  type Repr = Float
+
+  final val ExpBits = 8
+  final val SigBits = 24
+
+  final val MaxSig = (1L << SigBits) - 1
+  final val CeilLog5OfMaxSig = 11
+  final val PositiveInfinity = Float.PositiveInfinity
+  private final val PowerOfTens = Array(
+    1.0f,
+    10.0f,
+    100.0f,
+    1000.0f,
+    10000.0f,
+    100000.0f,
+    1000000.0f,
+    10000000.0f,
+    100000000.0f,
+    1000000000.0f,
+    10000000000.0f,
+  )
+
+  def powerOfTen(i: Int): Repr = PowerOfTens(i)
+  def nextDown(v: Repr): Repr = Math.nextDown(v)
+  def nextUp(v: Repr): Repr = Math.nextUp(v)
+  def mul(a: Repr, b: Repr): Repr = a * b
+  def div(a: Repr, b: Repr): Repr = a / b
+  def frexp(v: Repr): (Long, Int) = {
+    val bits = java.lang.Float.floatToRawIntBits(v)
+    val m = (bits & 0x7fffff + (1 << ExplicitSigBits)).toLong
+    val exp = ((bits >>> ExplicitSigBits) & 0xff) - ((1 << (ExpBits - 1)) - 1) - ExplicitSigBits
+    (m, exp)
+  }
+
+  def reinterpretBits(v: BigInteger): Repr =
+    java.lang.Float.intBitsToFloat(v.intValue())
+
+  def fromLong(v: Long): Repr = v.toFloat
+
+  def toIEEE754(v: FloatingPoint): Repr = {
+    val (sig, exponent) = v.roundNormal(this)
+    // Remove the leading implicit bit
+    // It is safe cast sig.toInt, because Float has 23 sig bits
+    val encodedSig: Int = sig.toInt - (1 << (ExplicitSigBits))
+    // Adjust the exponent for exponent bias and mantissa shift
+    val encodedExp: Int = exponent + ((1 << (ExpBits - 1)) - 1) + ExplicitSigBits
+    // combine bits
+    val bits = (encodedExp << ExplicitSigBits) | encodedSig
+    java.lang.Float.intBitsToFloat(bits)
+  }
+}
+
+object Binary64 extends FloatingPointFormat {
+  type Repr = Double
+
+  final val ExpBits = 11
+  // final val ExplicitSigBits = 52
+  final val SigBits = 53
+  final val MaxSig: Long = (1L << SigBits) - 1;
+  final val CeilLog5OfMaxSig = 23
+  private final val PowerOfTens = Array(
+    1.0,
+    10.0,
+    100.0,
+    1000.0,
+    10000.0,
+    100000.0,
+    1000000.0,
+    10000000.0,
+    100000000.0,
+    1000000000.0,
+    10000000000.0,
+    100000000000.0,
+    1000000000000.0,
+    10000000000000.0,
+    100000000000000.0,
+    1000000000000000.0,
+    10000000000000000.0,
+    100000000000000000.0,
+    1000000000000000000.0,
+    10000000000000000000.0,
+    100000000000000000000.0,
+    1000000000000000000000.0,
+    10000000000000000000000.0,
+  )
+
+  final val PositiveInfinity = Double.PositiveInfinity
+
+  def powerOfTen(i: Int): Repr = PowerOfTens(i)
+  def nextDown(v: Repr): Repr = Math.nextDown(v)
+  def nextUp(v: Repr): Repr = Math.nextUp(v)
+  def mul(a: Repr, b: Repr): Repr = a * b
+  def div(a: Repr, b: Repr): Repr = a / b
+  def frexp(v: Repr): (Long, Int) = {
+    val bits = java.lang.Double.doubleToLongBits(v)
+    val m = bits & 0xfffffffffffffL + (1 << ExplicitSigBits)
+    val exp = ((bits >>> ExplicitSigBits) & 0x7ff).toInt - ((1 << (ExpBits - 1)) - 1) - ExplicitSigBits
+    (m, exp)
+  }
+
+  def reinterpretBits(v: BigInteger): Repr =
+    java.lang.Double.longBitsToDouble(v.longValue())
+
+  def fromLong(v: Long): Repr = v.toDouble
+
+  def toIEEE754(v: FloatingPoint): Repr = {
+    val (sig, exponent) = v.roundNormal(this)
+    // Remove the leading implicit bit
+    val encodedSig: Long = sig - (1L << (ExplicitSigBits))
+    // Adjust the exponent for exponent bias and mantissa shift
+    val encodedExp: Long = exponent + ((1 << (ExpBits - 1)) - 1) + ExplicitSigBits
+    // combine bits
+    val bits = encodedExp << ExplicitSigBits | encodedSig
+    java.lang.Double.longBitsToDouble(bits)
+  }
+}

--- a/javalib/src/main/scala/java/lang/dectoflt/Tables.scala
+++ b/javalib/src/main/scala/java/lang/dectoflt/Tables.scala
@@ -1,0 +1,192 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
+package java.lang.dectoflt
+
+import java.math.BigInteger
+import dectoflt.{FloatingPoint => FP}
+
+/** A list of power of ten for 64-bit significant floating point numbers.
+ *
+ *  The `smallPowerOfTens` has exact floating point values, because 64-bit
+ *  floating point numbers can exactly represent the 10^e up to e < 27.563...,
+ *  because 10^e = 5^e * 2^e and the 2^e part can be absorbed into the binary
+ *  exponent. Now 5^e < 2^64 is the requirement for significand, and
+ *  e < log5(2^64) =~ 27.5632997...
+ *  `largePowerOfTens` are the best approximations, and when we wanna calculate the
+ *  10^e (where e > 16 or e < 0), we calculate it by 10^a * 10^b (where
+ *  0 <= a < 16, and a+b=e) 10^a from `smallPowerOfTens` and 10^b from
+ *  `largePowerOfTens`).
+ *
+ *  Since largest normal number for double precision (Double.MaxValue) is
+ *  around 1.79...E308 and the smallest subnormal (java.lang.Double.longBitsToDouble(1L))
+ *  is 4.9E-324, tables covers enough with 10^-320 ~ 10^320.
+ *
+ *  Generated with:
+ *
+ *  ```
+ *  import java.math.BigInteger
+ *
+ *  val N = 64 // Size of the significand field in bits
+ *  val MIN_SIG: BigInteger = BigInteger.ONE.shiftLeft(N - 1)
+ *  val MAX_SIG: BigInteger = BigInteger.ONE.shiftLeft(N).subtract(BigInteger.ONE)
+ *
+ *  case class Fp(sig: BigInteger, exp: Int)
+ *
+ *  def algorithmM(f: BigInteger, e: Int): Fp = {
+ *    var (u: BigInteger, v: BigInteger) = if (e < 0) {
+ *      (f, BigInteger.TEN.pow(e.abs))
+ *    } else {
+ *      (f.multiply(BigInteger.TEN.pow(e)), BigInteger.ONE)
+ *    }
+ *    var k = 0
+ *
+ *    while (true) {
+ *      val x = u.divide(v)
+ *      if (x.compareTo(MIN_SIG) < 0) {
+ *        u = u.shiftLeft(1)
+ *        k -= 1
+ *      } else if (x.compareTo(MAX_SIG) >= 0) {
+ *        v = v.shiftLeft(1)
+ *        k += 1
+ *      } else {
+ *        return ratioToFloat(u, v, k)
+ *      }
+ *    }
+ *    throw new IllegalStateException("Unreachable")
+ *  }
+ *
+ *  def ratioToFloat(u: BigInteger, v: BigInteger, k: Int): Fp = {
+ *    val qr = u.divideAndRemainder(v)
+ *    val q = qr(0)
+ *    val r = qr(1)
+ *    val v_r = v.subtract(r)
+ *    val z = Fp(q, k)
+ *
+ *    if (r.compareTo(v_r) < 0) {
+ *      z
+ *    } else if (r.compareTo(v_r) > 0) {
+ *      nextFloat(z)
+ *    } else if (q.testBit(0)) { // q is odd
+ *      nextFloat(z)
+ *    } else { // q is even
+ *      z
+ *    }
+ *  }
+ *
+ *  def nextFloat(z: Fp): Fp = {
+ *    if (z.sig.equals(MAX_SIG)) {
+ *      Fp(MIN_SIG, z.exp + 1)
+ *    } else {
+ *      Fp(z.sig.add(BigInteger.ONE), z.exp)
+ *    }
+ *  }
+ *
+ *  @main def main(): Unit = {
+ *    val SmallTableSize = 16
+ *    // Generate multiples of SmallTableSize (16) for the range -20 to 20.
+ *    val LargeTableRange = 20
+ *
+ *    val powers = (0 until SmallTableSize).map { e =>
+ *      algorithmM(BigInteger.ONE, e)
+ *    }
+ *    val largePowers = (-LargeTableRange to LargeTableRange).map { i =>
+ *      (algorithmM(BigInteger.ONE, i*SmallTableSize), i)
+ *    }
+ *
+ *    println(
+ *    """
+ *    |private[dec2flt] object Tables {
+ *    |""".stripMargin)
+ *
+ *    println("  val smallPowerOfTens = Array[FP](")
+ *    for ((z, i) <- powers.zipWithIndex) {
+ *      println(f"    FP.normalized(${z.sig.longValue()}L, ${z.exp}), // $i")
+ *    }
+ *    println("  )") // end smallPowerOfTens
+ *    println("")
+ *    println("  val largePowerOfTens = Array[FP](")
+ *    for ((z, i) <- largePowers) {
+ *      println(f"    FP.normalized(${z.sig.longValue()}L, ${z.exp}), // ${i*SmallTableSize} ($i*$SmallTableSize)")
+ *    }
+ *    println("  )")
+ *    println(s"  final val LargeTableRange = $LargeTableRange")
+ *    println("}")
+ *  }
+ *  ```
+ */
+private[dectoflt] object Tables {
+
+  val smallPowerOfTens = Array[FP](
+    FP.normalized(-9223372036854775808L, -63), // 0
+    FP.normalized(-6917529027641081856L, -60), // 1
+    FP.normalized(-4035225266123964416L, -57), // 2
+    FP.normalized(-432345564227567616L, -54), // 3
+    FP.normalized(-7187745005283311616L, -50), // 4
+    FP.normalized(-4372995238176751616L, -47), // 5
+    FP.normalized(-854558029293551616L, -44), // 6
+    FP.normalized(-7451627795949551616L, -40), // 7
+    FP.normalized(-4702848726509551616L, -37), // 8
+    FP.normalized(-1266874889709551616L, -34), // 9
+    FP.normalized(-7709325833709551616L, -30), // 10
+    FP.normalized(-5024971273709551616L, -27), // 11
+    FP.normalized(-1669528073709551616L, -24), // 12
+    FP.normalized(-7960984073709551616L, -20), // 13
+    FP.normalized(-5339544073709551616L, -17), // 14
+    FP.normalized(-2062744073709551616L, -14), // 15
+  )
+
+  val largePowerOfTens = Array[FP](
+    FP.normalized(-215969822234494767L, -1127), // -320 (-20*16)
+    FP.normalized(-8326631408344020698L, -1073), // -304 (-19*16)
+    FP.normalized(-7211161980820077193L, -1020), // -288 (-18*16)
+    FP.normalized(-5972742139117552793L, -967), // -272 (-17*16)
+    FP.normalized(-4597819916706768582L, -914), // -256 (-16*16)
+    FP.normalized(-3071349608317525545L, -861), // -240 (-15*16)
+    FP.normalized(-1376627125537124674L, -808), // -224 (-14*16)
+    FP.normalized(-8970925639256982432L, -754), // -208 (-13*16)
+    FP.normalized(-7926472270612804602L, -701), // -192 (-12*16)
+    FP.normalized(-6766896092596731856L, -648), // -176 (-11*16)
+    FP.normalized(-5479507920956448621L, -595), // -160 (-10*16)
+    FP.normalized(-4050219931171323191L, -542), // -144 (-9*16)
+    FP.normalized(-2463391496091671391L, -489), // -128 (-8*16)
+    FP.normalized(-701658031336336515L, -436), // -112 (-7*16)
+    FP.normalized(-8596242524610931813L, -382), // -96 (-6*16)
+    FP.normalized(-7510490449794491994L, -329), // -80 (-5*16)
+    FP.normalized(-6305063497298744923L, -276), // -64 (-4*16)
+    FP.normalized(-4966770740134231719L, -223), // -48 (-3*16)
+    FP.normalized(-3480967307441105734L, -170), // -32 (-2*16)
+    FP.normalized(-1831394126398103205L, -117), // -16 (-1*16)
+    FP.normalized(-9223372036854775808L, -63), // 0 (0*16)
+    FP.normalized(-8206744073709551616L, -10), // 16 (1*16)
+    FP.normalized(-7078060301547948642L, 43), // 32 (2*16)
+    FP.normalized(-5824969590173362729L, 96), // 48 (3*16)
+    FP.normalized(-4433759430461380907L, 149), // 64 (4*16)
+    FP.normalized(-2889205879056697348L, 202), // 80 (5*16)
+    FP.normalized(-1174406963520662365L, 255), // 96 (6*16)
+    FP.normalized(-8858670899299929442L, 309), // 112 (7*16)
+    FP.normalized(-7801844473689174816L, 362), // 128 (8*16)
+    FP.normalized(-6628531442943809817L, 415), // 144 (9*16)
+    FP.normalized(-5325892301117581398L, 468), // 160 (10*16)
+    FP.normalized(-3879672333084147821L, 521), // 176 (11*16)
+    FP.normalized(-2274045625900771989L, 574), // 192 (12*16)
+    FP.normalized(-491441886632713914L, 627), // 208 (13*16)
+    FP.normalized(-8479549122611984080L, 681), // 224 (14*16)
+    FP.normalized(-7380934748073420954L, 734), // 240 (15*16)
+    FP.normalized(-6161227774276542834L, 787), // 256 (16*16)
+    FP.normalized(-4807081008671376254L, 840), // 272 (17*16)
+    FP.normalized(-3303676090774835316L, 893), // 288 (18*16)
+    FP.normalized(-1634561335591402499L, 946), // 304 (19*16)
+    FP.normalized(-9114107888677362826L, 1000), // 320 (20*16)
+  )
+  final val LargeTableRange = 20
+}

--- a/javalib/src/main/scala/java/util/regex/RegExpImpl.scala
+++ b/javalib/src/main/scala/java/util/regex/RegExpImpl.scala
@@ -1,0 +1,72 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
+package java.util.regex
+
+import scala.scalajs.LinkingInfo._
+
+/** A wrapper class to select regex implementation across different platforms.
+ *
+ *  This class provides a common interface for regular expression operations,
+ *  allowing the underlying implementation to be switched at link time.
+ *  For WebAssembly, it uses a Java-based implementation, while for JavaScript
+ *  environments, it delegates to the native `js.RegExp`.
+ */
+private[java] sealed abstract class RegExpImpl {
+  type PatRepr
+  type Repr
+
+  def compile(patternStr: String): PatRepr
+  def exec(pattern: PatRepr, string: String): Repr
+  def matches(r: Repr): Boolean
+  def exists(r: Repr, index: Int): Boolean
+  def get(r: Repr, index: Int): String
+  def getOrElse(r: Repr, index: Int, default: String): String
+}
+
+private[java] object RegExpImpl {
+  val impl = linkTimeIf[RegExpImpl](targetPureWasm) {
+    JavaRegExpImpl
+  } {
+    JSRegExpImpl
+  }
+
+  object JSRegExpImpl extends RegExpImpl {
+    import java.lang.Utils._
+    import scala.scalajs.js
+
+    type PatRepr = js.RegExp
+    type Repr = js.RegExp.ExecResult
+
+    def compile(patternStr: String): PatRepr = new js.RegExp(patternStr)
+    def exec(pattern: PatRepr, string: String): Repr = pattern.exec(string)
+    def matches(r: Repr): Boolean = r != null
+    def exists(r: Repr, index: Int): Boolean = undefOrIsDefined(r(index))
+    def get(r: Repr, index: Int): String = undefOrForceGet(r(index))
+    def getOrElse(r: Repr, index: Int, default: String): String = undefOrGetOrElse(r(index))(() => default)
+  }
+
+  private object JavaRegExpImpl extends RegExpImpl {
+    type PatRepr = Pattern
+    type Repr = Matcher
+
+    def compile(patternStr: String): PatRepr = Pattern.compile(patternStr)
+    def exec(pattern: PatRepr, string: String): Repr = pattern.matcher(string)
+    def matches(r: Repr): Boolean = r.matches()
+    def exists(r: Repr, index: Int): Boolean = r.group(index) != null
+    def get(r: Repr, index: Int): String = r.group(index)
+    def getOrElse(r: Repr, index: Int, default: String): String = {
+      val result = r.group(index)
+      if (result != null) result else default
+    }
+  }
+}

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/lang/DoubleTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/lang/DoubleTest.scala
@@ -111,9 +111,6 @@ class DoubleTest {
   }
 
   @Test def parseStringMethods(): Unit = {
-    assumeFalse("Parse floating point doesn't link in pure Wasm",
-        executingInPureWebAssembly)
-    LinkingInfo.linkTimeIf(!LinkingInfo.targetPureWasm) {
     // scalastyle:off line.size.limit
 
     /* First, a selection of large categories for which test the combination of
@@ -349,14 +346,61 @@ class DoubleTest {
     test("-0x1.1111111111112800000000000000000000000p52", -4.80383960252853e15)
     test("-0x1.1111111111112800000000000000000000001p52", -4.803839602528531e15)
 
+    // The following test data is derived from test cases in the Rust compiler,
+    // which is available under the MIT License. The original source can be found at:
+    // https://github.com/rust-lang/rust/blob/dfa22235d858086511bedc4acde9db1c045ffbac/library/coretests/tests/num/dec2flt/mod.rs
+    //
+    // The original Rust macro `test_literal!(x)` was translated
+    // into the format: `test(x.toString, java.lang.Double.parseDouble(x.toString))`
+
+    // ordinary
+    test("1.0", 1.0)
+    test("3e-5", 3.0E-5)
+    test("0.1", 0.1)
+    test("12345.", 12345.0)
+    test("0.9999999", 0.9999999)
+    test("2.2250738585072014e-308", 2.2250738585072014E-308)
+
+    // special_code_paths
+    test("36893488147419103229.0", 3.6893488147419103E19)
+    test("101e-33", 1.01E-31)
+    test("1e23", 1.0E23)
+    test("2075e23", 2.075E26)
+    test("8713e-23", 8.713E-20)
+
+    // large
+    test("1e300", 1.0E300)
+    test("123456789.34567e250", 1.2345678934567E258)
+    test("943794359898089732078308743689303290943794359843568973207830874368930329.", 9.437943598980897E71)
+
+    // subnormals
+    test("5e-324", 4.9E-324)
+    test("91e-324", 8.9E-323)
+    test("1e-322", 9.9E-323)
+    test("13245643e-320", 1.3245643E-313)
+    test("2.22507385851e-308", 2.22507385851E-308)
+    test("2.1e-308", 2.1E-308)
+    test("4.9406564584124654e-324", 4.9E-324)
+
+    // infinity
+    test("1e400", Double.PositiveInfinity)
+    test("1e309", Double.PositiveInfinity)
+    test("2e308", Double.PositiveInfinity)
+    test("1.7976931348624e308", Double.PositiveInfinity)
+
+    // zero
+    test("0.0", 0.0)
+    test("1e-325", 0.0)
+    test("1e-326", 0.0)
+    test("1e-500", 0.0)
+
+    // fast_path_correct
+    test("1.448997445238699", 1.448997445238699)
+
     // scalastyle:on line.size.limit
-    } {}
   }
 
   @Test def parseDoubleInvalidThrows(): Unit = {
-    assumeFalse("Parse floating point doesn't link in pure Wasm",
-        executingInPureWebAssembly)
-    LinkingInfo.linkTimeIf(!LinkingInfo.targetPureWasm) {
     for (padding <- List("", "  ", (0 to 0x20).map(x => x.toChar).mkString)) {
       def pad(s: String): String = padding + s + padding
 
@@ -373,7 +417,6 @@ class DoubleTest {
       test("0x.p1") // hex notation with both integral and fractional parts empty
       test("0x1.2") // missing 'p'
     }
-    } {}
   }
 
   @Test def compareToJavaDouble(): Unit = {

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/lang/FloatTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/lang/FloatTest.scala
@@ -125,9 +125,6 @@ class FloatTest {
   }
 
   @Test def parseStringMethods(): Unit = {
-    assumeFalse("Parse floating point doesn't link in pure Wasm",
-        executingInPureWebAssembly)
-    LinkingInfo.linkTimeIf(!LinkingInfo.targetPureWasm) {
     def test(expected: Float, s: String): Unit = {
       assertEquals(s, expected: Any, JFloat.parseFloat(s))
       assertEquals(s, expected: Any, JFloat.valueOf(s).floatValue())
@@ -387,13 +384,25 @@ class FloatTest {
     test(-4.8238549e15f, "-0x1.123454fffffffffffffffffffffffffffffffp52")
     test(-4.8238549e15f, "-0x1.1234550000000000000000000000000000000p52")
     test(-4.8238555e15f, "-0x1.1234550000000000000000000000000000001p52")
-    } {}
+
+    // Exactly halfway between 1 and the next float32.
+    test(1, "1.000000059604644775390625")
+    test(1, "1.000000059604644775390624")
+    test(1.0000001f, "1.000000059604644775390626")
+    test(1.0000001f, "1.00000005960464477539062500000000000000000000000000000000000000000000000000000000000000000000000000000000000000001")
+
+    // subnormal
+    test(1E-38f, "1E-38")
+    test(1E-39f, "1E-39")
+    test(1E-40f, "1E-40")
+    test(1E-43f, "1E-43")
+    test(1E-44f, "1E-44")
+    test(1.4E-45f, "1.4E-45") // smallest subnnormal
+    test(1.4E-45f, "2e-45")
+    test(3E-45f, "3e-45")
   }
 
   @Test def parseFloatInvalidThrows(): Unit = {
-    assumeFalse("Parse floating point doesn't link in pure Wasm",
-        executingInPureWebAssembly)
-    LinkingInfo.linkTimeIf(!LinkingInfo.targetPureWasm) {
     def test(s: String): Unit =
       assertThrows(classOf[NumberFormatException], JFloat.parseFloat(s))
 
@@ -407,7 +416,6 @@ class FloatTest {
 
     test("NaNf")
     test("Infinityf")
-    } {}
   }
 
   @Test def compareTo(): Unit = {


### PR DESCRIPTION
Implement bellerophon algorithm from "How to Read Floating Point Numbers Accurately" by William D. Clinger

TODO:
- [x] corner cases
  - [x] overflow
  - [x] underflow (subnormal / negative infinity)
- [x] Parse double
- [x] Parse hex (should be in another PR)
  - Math.pow and Long.parseLong are required
- [x] more test cases
  - maybe we wanna copy test cases from somewhere

---

This commit implements a Bellerophon algorithm from
"How to Read Floating Point Numbers Accurately" by William D. Clinger.

The Bellerophon algorithm efficiently finds the best binary
approximation for a decimal number `f * 10^e`.
While an iterative approach like AlgorithmM (defined in the same paper)
can find the best approximation by repeatedly using slow
BigInteger arithmetic, Bellerophon provides non-iterative approach.

The basic idea is, instead of directly computing the best approximation
for `f * 10^e` it uses higher-precision (p-bit (64-bit) significand)
floating-point numbers to approximate `f` and `10^e` separately.
Then multiplies these approximations and analyzes the
error when multiplying and rounding the result to the target
n-bit (n-bit significand) precision.

In some cases, the calculated approximation isn't the best, and in that case
the algorithm falls back to AlgorithmR.
This algorithm takes a good appoximation as a starting point,
and iteratively finds the best approximation.
Since the calculated approximation by Bellerophon is very close to the best
it converges in just a few steps.

For extreme values that would overflow to infinity or underflow to a
subnormal number or zero, neither the Bellerophon nor AlgorithmR does work.
In these cases, the algorithm falls back to the original, slower AlgorithmM
with the modification mentioned in section 8 of the paper.
> With IEEE arithmetic, for example, a denormalized result
> may be required. Denormalized results can be generate
> by a modified form of AlgorithmM that terminates immediately
> when the minimum exponent is reached.

In future, we might want to migrate to Eisel-Lemire algorithm?