### PR TITLE
Add scala.scalajs.component.Tuple for Component Model

### DIFF
--- a/compiler/src/main/scala/org/scalajs/nscplugin/GenWasmComponentModelInterop.scala
+++ b/compiler/src/main/scala/org/scalajs/nscplugin/GenWasmComponentModelInterop.scala
@@ -48,6 +48,9 @@ trait GenWasmComponentModelInterop[G <: Global with Singleton] extends SubCompon
   def isWasmComponentRecordClass(sym: Symbol): Boolean =
     sym.hasAnnotation(ComponentRecordAnnotation) && sym.isFinal
 
+  def isWasmComponentTupleClass(sym: Symbol): Boolean =
+    sym.fullName.startsWith("scala.scalajs.component.Tuple")
+
   def isWasmComponentFlags(sym: Symbol): Boolean =
     sym.hasAnnotation(ComponentFlagsAnnotation)
 
@@ -228,7 +231,7 @@ trait GenWasmComponentModelInterop[G <: Global with Singleton] extends SubCompon
       primitiveIRWIT.get(toIRType(tpe.dealiasWiden))
     }.getOrElse {
       tpe.dealiasWiden.typeSymbol match {
-        case tsym if tsym.fullName.startsWith("scala.Tuple") =>
+        case tsym if isWasmComponentTupleClass(tsym) =>
           wit.TupleType(tpe.typeArgs.map(toWIT(_)))
 
         case tsym if isWasmComponentRecordClass(tsym) =>

--- a/examples/test-component-model/Makefile
+++ b/examples/test-component-model/Makefile
@@ -16,7 +16,7 @@ compose: new
 	wac plug --plug scala.wasm rust-run/target/wasm32-wasip1/release/rust_run.wasm -o out.wasm
 
 run: compose
-	wasmtime -W function-references,gc -C collector=null out.wasm
+	wasmtime -W function-references,gc out.wasm
 
 clean:
 	rm -f main.wasm out.wasm

--- a/examples/test-component-model/rust-exports/src/lib.rs
+++ b/examples/test-component-model/rust-exports/src/lib.rs
@@ -100,6 +100,8 @@ impl Tests for Component {
   fn roundtrip_f16(a: F2) -> F2 { a }
   fn roundtrip_f32(a: F3) -> F3 { a }
   fn roundtrip_flags(a: (F1, F1)) -> (F1, F1) { a }
+  fn roundtrip_tuple2(a: (i32, String)) -> (i32, String) { a }
+  fn roundtrip_tuple3(a: (i32, String, bool)) -> (i32, String, bool) { a }
 }
 
 bindings::export!(Component with_types_in bindings);

--- a/examples/test-component-model/rust-run/src/lib.rs
+++ b/examples/test-component-model/rust-run/src/lib.rs
@@ -95,6 +95,9 @@ impl Run for Component {
 
       assert_eq!(roundtrip_flags((F1::B0 | F1::B7, F1::B3)), (F1::B0 | F1::B7, F1::B3));
 
+      assert_eq!(roundtrip_tuple2((111, "hello")), (111, "hello".to_string()));
+      assert_eq!(roundtrip_tuple3((111, "hello", false)), (111, "hello".to_string(), false));
+
       return Ok(());
     }
 }

--- a/examples/test-component-model/src/main/scala/componentmodel/Exports.scala
+++ b/examples/test-component-model/src/main/scala/componentmodel/Exports.scala
@@ -10,8 +10,8 @@ import java.util.Optional
 
 object TestsExport {
   @ComponentExport("component:testing/tests", "roundtrip-basics1")
-  def roundtripBasics1(a: (UByte, Byte, UShort, Short, UInt, Int, Float, Double, Char)):
-      (UByte, Byte, UShort, Short, UInt, Int, Float, Double, Char) = a
+  def roundtripBasics1(a: cm.Tuple9[UByte, Byte, UShort, Short, UInt, Int, Float, Double, Char]):
+      cm.Tuple9[UByte, Byte, UShort, Short, UInt, Int, Float, Double, Char] = a
 
   @ComponentExport("component:testing/tests", "roundtrip-list-u16")
   def roundtripListU16(a: Array[UShort]): Array[UShort] = a
@@ -41,7 +41,7 @@ object TestsExport {
   def roundtripEnum(a: E1): E1 = a
 
   @ComponentExport("component:testing/tests", "roundtrip-tuple")
-  def roundtripTuple(a: (C1, Z1)): (C1, Z1) = a
+  def roundtripTuple(a: cm.Tuple2[C1, Z1]): cm.Tuple2[C1, Z1] = a
 
   @ComponentExport("component:testing/tests", "roundtrip-option")
   def roundtripOption(a: Optional[String]): Optional[String] = a
@@ -69,7 +69,13 @@ object TestsExport {
   def roundtripF32(a: F3): F3 = a
 
   @ComponentExport("component:testing/tests", "roundtrip-flags")
-  def roundtripFlags(a: (F1, F1)): (F1, F1) = a
+  def roundtripFlags(a: cm.Tuple2[F1, F1]): cm.Tuple2[F1, F1] = a
+
+  @ComponentExport("component:testing/tests", "roundtrip-tuple2")
+  def roundtripTuple2(a: cm.Tuple2[Int, String]): cm.Tuple2[Int, String] = a
+
+  @ComponentExport("component:testing/tests", "roundtrip-tuple3")
+  def roundtripTuple3(a: cm.Tuple3[Int, String, Boolean]): cm.Tuple3[Int, String, Boolean] = a
 }
 
 object TestImports {
@@ -93,10 +99,17 @@ object TestImports {
 
     assert('a' == roundtripChar('a'))
 
-    assert(
-      (127, 127, 32767, 32767, 532423, 2147483647, 0.0f, 0.0, 'x') ==
-      roundtripBasics1((127, 127, 32767, 32767, 532423, 2147483647, 0.0f, 0.0, 'x'))
-    )
+    val basics1Input = (127.asInstanceOf[UByte], 127.toByte, 32767.asInstanceOf[UShort], 32767.toShort, 532423, 2147483647, 0.0f, 0.0, 'x')
+    val basics1Result = roundtripBasics1(basics1Input)
+    assert(basics1Result._1 == 127)
+    assert(basics1Result._2 == 127)
+    assert(basics1Result._3 == 32767)
+    assert(basics1Result._4 == 32767)
+    assert(basics1Result._5 == 532423)
+    assert(basics1Result._6 == 2147483647)
+    assert(basics1Result._7 == 0.0f)
+    assert(basics1Result._8 == 0.0)
+    assert(basics1Result._9 == 'x')
 
     val arr = Array[UShort](0, 1, 2)
     assert(arr.sameElements(roundtripListU16(arr)))
@@ -122,10 +135,14 @@ object TestImports {
     assert(E1.B == roundtripEnum(E1.B))
     assert(E1.C == roundtripEnum(E1.C))
 
-    assert((C1.A(5), Z1.A(500)) == roundtripTuple((C1.A(5), Z1.A(500))))
-    assert((C1.B(200.0f), Z1.B) == roundtripTuple((C1.B(200.0f), Z1.B)))
-    assert(C1.A(4) == roundtripTuple(C1.A(4), Z1.B)._1)
-    assert(Z1.B == roundtripTuple(C1.A(4), Z1.B)._2)
+    val tupleResult1: (C1, Z1) = roundtripTuple((C1.A(5), Z1.A(500)))
+    assert(tupleResult1 == (C1.A(5), Z1.A(500)))
+
+    val tupleResult2: (C1, Z1) = roundtripTuple((C1.B(200.0f), Z1.B))
+    assert(tupleResult2 == (C1.B(200.0f), Z1.B))
+
+    val tupleResult3: (C1, Z1) = roundtripTuple((C1.A(4), Z1.B))
+    assert(tupleResult3 == (C1.A(4), Z1.B))
 
     assert(Optional.of("ok") == roundtripOption(Optional.of("ok")))
     assert(Optional.empty == roundtripOption(Optional.empty[String]))
@@ -147,10 +164,16 @@ object TestImports {
     import TestImportsHelper._
     assert((F1.b3 | F1.b6 | F1.b7) == roundtripF8(F1.b3 | F1.b6 | F1.b7))
 
-    assert(
-      (F1.b3 | F1.b6, F1.b2 | F1.b3 | F1.b7) ==
-      roundtripFlags((F1.b3 | F1.b6, F1.b2 | F1.b3 | F1.b7))
-    )
+    val flagsTuple = new cm.Tuple2(F1.b3 | F1.b6, F1.b2 | F1.b3 | F1.b7)
+    val flagsResult = roundtripFlags(flagsTuple)
+    assert(flagsResult._1 == (F1.b3 | F1.b6))
+    assert(flagsResult._2 == (F1.b2 | F1.b3 | F1.b7))
+
+    val result2: (Int, String) = roundtripTuple2((42, "hello"))
+    assert(result2 == (123, "world"))
+
+    val result3: (Int, String, Boolean) = roundtripTuple3((123, "world", true))
+    assert(result3 == (123, "world", true))
 
     locally {
       val c1 = Counter(0)

--- a/examples/test-component-model/src/main/scala/componentmodel/Test.scala
+++ b/examples/test-component-model/src/main/scala/componentmodel/Test.scala
@@ -69,8 +69,8 @@ object Countable {
 import TestImportsHelper._
 object Tests {
   @ComponentImport("component:testing/tests", "roundtrip-basics1")
-  def roundtripBasics1(a: (UByte, Byte, UShort, Short, UInt, Int, Float, Double, Char)):
-      (UByte, Byte, UShort, Short, UInt, Int, Float, Double, Char) = cm.native
+  def roundtripBasics1(a: cm.Tuple9[UByte, Byte, UShort, Short, UInt, Int, Float, Double, Char]):
+      cm.Tuple9[UByte, Byte, UShort, Short, UInt, Int, Float, Double, Char] = cm.native
 
   @ComponentImport("component:testing/tests", "roundtrip-list-u16")
   def roundtripListU16(a: Array[UShort]): Array[UShort] = cm.native
@@ -100,7 +100,7 @@ object Tests {
   def roundtripEnum(a: E1): E1 = cm.native
 
   @ComponentImport("component:testing/tests", "roundtrip-tuple")
-  def roundtripTuple(a: (C1, Z1)): (C1, Z1) = cm.native
+  def roundtripTuple(a: cm.Tuple2[C1, Z1]): cm.Tuple2[C1, Z1] = cm.native
 
   @ComponentImport("component:testing/tests", "roundtrip-option")
   def roundtripOption(a: Optional[String]): Optional[String] = cm.native
@@ -121,5 +121,11 @@ object Tests {
   def roundtripF8(a: F1): F1 = cm.native
 
   @ComponentImport("component:testing/tests", "roundtrip-flags")
-  def roundtripFlags(a: (F1, F1)): (F1, F1) = cm.native
+  def roundtripFlags(a: cm.Tuple2[F1, F1]): cm.Tuple2[F1, F1] = cm.native
+
+  @ComponentImport("component:testing/tests", "roundtrip-tuple2")
+  def roundtripTuple2(a: cm.Tuple2[Int, String]): cm.Tuple2[Int, String] = cm.native
+
+  @ComponentImport("component:testing/tests", "roundtrip-tuple3")
+  def roundtripTuple3(a: cm.Tuple3[Int, String, Boolean]): cm.Tuple3[Int, String, Boolean] = cm.native
 }

--- a/examples/test-component-model/wit/world.wit
+++ b/examples/test-component-model/wit/world.wit
@@ -100,6 +100,9 @@ interface tests {
   roundtrip-string-error: func(a: result<f32, string>) -> result<f32, string>;
   roundtrip-enum-error: func(a: result<c1, e1>) -> result<c1, e1>;
 
+  roundtrip-tuple2: func(a: tuple<s32, string>) -> tuple<s32, string>;
+  roundtrip-tuple3: func(a: tuple<s32, string, bool>) -> tuple<s32, string, bool>;
+
 }
 
 interface test-imports {

--- a/ir/shared/src/main/scala/org/scalajs/ir/WasmInterfaceTypes.scala
+++ b/ir/shared/src/main/scala/org/scalajs/ir/WasmInterfaceTypes.scala
@@ -93,7 +93,7 @@ object WasmInterfaceTypes {
   }
 
   final case class TupleType(ts: List[ValType]) extends SpecializedType {
-    def toIRType(): jstpe.Type = jstpe.ClassType(ClassName("scala.Tuple" + ts.size), true)
+    def toIRType(): jstpe.Type = jstpe.ClassType(ClassName("scala.scalajs.component.Tuple" + ts.size), true)
   }
 
   final case class CaseType(className: ClassName, tpe: ValType) {
@@ -140,7 +140,7 @@ object WasmInterfaceTypes {
     case ListType(elemType, length) =>
       jstpe.ArrayTypeRef.of(toTypeRef(elemType))
     case RecordType(className, fields) => jstpe.ClassRef(className)
-    case TupleType(ts) => jstpe.ClassRef(ClassName("scala.Tuple" + ts.size))
+    case TupleType(ts) => jstpe.ClassRef(ClassName("scala.scalajs.component.Tuple" + ts.size))
     case VariantType(className, cases) => jstpe.ClassRef(className)
     case ResultType(ok, err) => jstpe.ClassRef(ComponentResultClass)
     case EnumType(labels) => ???
@@ -165,7 +165,7 @@ object WasmInterfaceTypes {
     case st: SpecializedType => st match {
 
       case TupleType(ts) =>
-        val className = ClassName("scala.Tuple" + ts.size)
+        val className = ClassName("scala.scalajs.component.Tuple" + ts.size)
         RecordType(
           className,
           ts.zipWithIndex.map { case (t, i) =>

--- a/library/src/main/scala/scala/scalajs/component/Tuple.scala
+++ b/library/src/main/scala/scala/scalajs/component/Tuple.scala
@@ -1,0 +1,188 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
+package scala.scalajs.component
+
+import scala.language.implicitConversions
+
+final class Tuple1[+T1](val _1: T1)
+
+object Tuple1 {
+  def apply[T1](_1: T1): Tuple1[T1] = new Tuple1(_1)
+
+  @inline def unapply[T1](t: Tuple1[T1]): Some[Tuple1[T1]] =
+    Some(Tuple1(t._1))
+
+  @inline implicit def fromScalaTuple1[T1](t: Tuple1[T1]): Tuple1[T1] =
+    apply(t._1)
+
+  @inline implicit def toScalaTuple1[T1](t: Tuple1[T1]): Tuple1[T1] =
+    Tuple1(t._1)
+}
+
+final class Tuple2[+T1, +T2](val _1: T1, val _2: T2)
+
+object Tuple2 {
+  def apply[T1, T2](_1: T1, _2: T2): Tuple2[T1, T2] = new Tuple2(_1, _2)
+
+  @inline def unapply[T1, T2](t: Tuple2[T1, T2]): Some[(T1, T2)] =
+    Some((t._1, t._2))
+
+  @inline implicit def fromScalaTuple2[T1, T2](t: (T1, T2)): Tuple2[T1, T2] =
+    apply(t._1, t._2)
+
+  @inline implicit def toScalaTuple2[T1, T2](t: Tuple2[T1, T2]): (T1, T2) =
+    (t._1, t._2)
+}
+
+final class Tuple3[+T1, +T2, +T3](val _1: T1, val _2: T2, val _3: T3)
+
+object Tuple3 {
+  def apply[T1, T2, T3](_1: T1, _2: T2, _3: T3): Tuple3[T1, T2, T3] = new Tuple3(_1, _2, _3)
+
+  @inline def unapply[T1, T2, T3](t: Tuple3[T1, T2, T3]): Some[(T1, T2, T3)] =
+    Some((t._1, t._2, t._3))
+
+  @inline implicit def fromScalaTuple3[T1, T2, T3](t: (T1, T2, T3)): Tuple3[T1, T2, T3] =
+    apply(t._1, t._2, t._3)
+
+  @inline implicit def toScalaTuple3[T1, T2, T3](t: Tuple3[T1, T2, T3]): (T1, T2, T3) =
+    (t._1, t._2, t._3)
+}
+
+final class Tuple4[+T1, +T2, +T3, +T4](val _1: T1, val _2: T2, val _3: T3, val _4: T4)
+
+object Tuple4 {
+  def apply[T1, T2, T3, T4](_1: T1, _2: T2, _3: T3, _4: T4): Tuple4[T1, T2, T3, T4] =
+    new Tuple4(_1, _2, _3, _4)
+
+  @inline def unapply[T1, T2, T3, T4](t: Tuple4[T1, T2, T3, T4]): Some[(T1, T2, T3, T4)] =
+    Some((t._1, t._2, t._3, t._4))
+
+  @inline implicit def fromScalaTuple4[T1, T2, T3, T4](t: (T1, T2, T3, T4)): Tuple4[T1, T2, T3, T4] =
+    apply(t._1, t._2, t._3, t._4)
+
+  @inline implicit def toScalaTuple4[T1, T2, T3, T4](t: Tuple4[T1, T2, T3, T4]): (T1, T2, T3, T4) =
+    (t._1, t._2, t._3, t._4)
+}
+
+final class Tuple5[+T1, +T2, +T3, +T4, +T5](val _1: T1, val _2: T2, val _3: T3, val _4: T4, val _5: T5)
+
+object Tuple5 {
+  def apply[T1, T2, T3, T4, T5](_1: T1, _2: T2, _3: T3, _4: T4, _5: T5): Tuple5[T1, T2, T3, T4, T5] =
+    new Tuple5(_1, _2, _3, _4, _5)
+
+  @inline def unapply[T1, T2, T3, T4, T5](t: Tuple5[T1, T2, T3, T4, T5]): Some[(T1, T2, T3, T4, T5)] =
+    Some((t._1, t._2, t._3, t._4, t._5))
+
+  @inline implicit def fromScalaTuple5[T1, T2, T3, T4, T5](t: (T1, T2, T3, T4, T5)): Tuple5[T1, T2, T3, T4, T5] =
+    apply(t._1, t._2, t._3, t._4, t._5)
+
+  @inline implicit def toScalaTuple5[T1, T2, T3, T4, T5](t: Tuple5[T1, T2, T3, T4, T5]): (T1, T2, T3, T4, T5) =
+    (t._1, t._2, t._3, t._4, t._5)
+}
+
+final class Tuple6[+T1, +T2, +T3, +T4, +T5, +T6](val _1: T1, val _2: T2, val _3: T3, val _4: T4, val _5: T5, val _6: T6)
+
+object Tuple6 {
+  def apply[T1, T2, T3, T4, T5, T6](_1: T1, _2: T2, _3: T3, _4: T4, _5: T5, _6: T6): Tuple6[T1, T2, T3, T4, T5, T6] =
+    new Tuple6(_1, _2, _3, _4, _5, _6)
+
+  @inline def unapply[T1, T2, T3, T4, T5, T6](t: Tuple6[T1, T2, T3, T4, T5, T6]): Some[(T1, T2, T3, T4, T5, T6)] =
+    Some((t._1, t._2, t._3, t._4, t._5, t._6))
+
+  @inline implicit def fromScalaTuple6[T1, T2, T3, T4, T5, T6](t: (T1, T2, T3, T4, T5, T6)): Tuple6[T1, T2, T3, T4, T5, T6] =
+    apply(t._1, t._2, t._3, t._4, t._5, t._6)
+
+  @inline implicit def toScalaTuple6[T1, T2, T3, T4, T5, T6](t: Tuple6[T1, T2, T3, T4, T5, T6]): (T1, T2, T3, T4, T5, T6) =
+    (t._1, t._2, t._3, t._4, t._5, t._6)
+}
+
+final class Tuple7[+T1, +T2, +T3, +T4, +T5, +T6, +T7](
+  val _1: T1, val _2: T2, val _3: T3, val _4: T4, val _5: T5, val _6: T6, val _7: T7
+)
+
+object Tuple7 {
+  def apply[T1, T2, T3, T4, T5, T6, T7](
+    _1: T1, _2: T2, _3: T3, _4: T4, _5: T5, _6: T6, _7: T7
+  ): Tuple7[T1, T2, T3, T4, T5, T6, T7] =
+    new Tuple7(_1, _2, _3, _4, _5, _6, _7)
+
+  @inline def unapply[T1, T2, T3, T4, T5, T6, T7](t: Tuple7[T1, T2, T3, T4, T5, T6, T7]): Some[(T1, T2, T3, T4, T5, T6, T7)] =
+    Some((t._1, t._2, t._3, t._4, t._5, t._6, t._7))
+
+  @inline implicit def fromScalaTuple7[T1, T2, T3, T4, T5, T6, T7](t: (T1, T2, T3, T4, T5, T6, T7)): Tuple7[T1, T2, T3, T4, T5, T6, T7] =
+    apply(t._1, t._2, t._3, t._4, t._5, t._6, t._7)
+
+  @inline implicit def toScalaTuple7[T1, T2, T3, T4, T5, T6, T7](t: Tuple7[T1, T2, T3, T4, T5, T6, T7]): (T1, T2, T3, T4, T5, T6, T7) =
+    (t._1, t._2, t._3, t._4, t._5, t._6, t._7)
+}
+
+final class Tuple8[+T1, +T2, +T3, +T4, +T5, +T6, +T7, +T8](
+  val _1: T1, val _2: T2, val _3: T3, val _4: T4, val _5: T5, val _6: T6, val _7: T7, val _8: T8
+)
+
+object Tuple8 {
+  def apply[T1, T2, T3, T4, T5, T6, T7, T8](
+    _1: T1, _2: T2, _3: T3, _4: T4, _5: T5, _6: T6, _7: T7, _8: T8
+  ): Tuple8[T1, T2, T3, T4, T5, T6, T7, T8] =
+    new Tuple8(_1, _2, _3, _4, _5, _6, _7, _8)
+
+  @inline def unapply[T1, T2, T3, T4, T5, T6, T7, T8](t: Tuple8[T1, T2, T3, T4, T5, T6, T7, T8]): Some[(T1, T2, T3, T4, T5, T6, T7, T8)] =
+    Some((t._1, t._2, t._3, t._4, t._5, t._6, t._7, t._8))
+
+  @inline implicit def fromScalaTuple8[T1, T2, T3, T4, T5, T6, T7, T8](t: (T1, T2, T3, T4, T5, T6, T7, T8)): Tuple8[T1, T2, T3, T4, T5, T6, T7, T8] =
+    apply(t._1, t._2, t._3, t._4, t._5, t._6, t._7, t._8)
+
+  @inline implicit def toScalaTuple8[T1, T2, T3, T4, T5, T6, T7, T8](t: Tuple8[T1, T2, T3, T4, T5, T6, T7, T8]): (T1, T2, T3, T4, T5, T6, T7, T8) =
+    (t._1, t._2, t._3, t._4, t._5, t._6, t._7, t._8)
+}
+
+final class Tuple9[+T1, +T2, +T3, +T4, +T5, +T6, +T7, +T8, +T9](
+  val _1: T1, val _2: T2, val _3: T3, val _4: T4, val _5: T5, val _6: T6, val _7: T7, val _8: T8, val _9: T9
+)
+
+object Tuple9 {
+  def apply[T1, T2, T3, T4, T5, T6, T7, T8, T9](
+    _1: T1, _2: T2, _3: T3, _4: T4, _5: T5, _6: T6, _7: T7, _8: T8, _9: T9
+  ): Tuple9[T1, T2, T3, T4, T5, T6, T7, T8, T9] =
+    new Tuple9(_1, _2, _3, _4, _5, _6, _7, _8, _9)
+
+  @inline def unapply[T1, T2, T3, T4, T5, T6, T7, T8, T9](t: Tuple9[T1, T2, T3, T4, T5, T6, T7, T8, T9]): Some[(T1, T2, T3, T4, T5, T6, T7, T8, T9)] =
+    Some((t._1, t._2, t._3, t._4, t._5, t._6, t._7, t._8, t._9))
+
+  @inline implicit def fromScalaTuple9[T1, T2, T3, T4, T5, T6, T7, T8, T9](t: (T1, T2, T3, T4, T5, T6, T7, T8, T9)): Tuple9[T1, T2, T3, T4, T5, T6, T7, T8, T9] =
+    apply(t._1, t._2, t._3, t._4, t._5, t._6, t._7, t._8, t._9)
+
+  @inline implicit def toScalaTuple9[T1, T2, T3, T4, T5, T6, T7, T8, T9](t: Tuple9[T1, T2, T3, T4, T5, T6, T7, T8, T9]): (T1, T2, T3, T4, T5, T6, T7, T8, T9) =
+    (t._1, t._2, t._3, t._4, t._5, t._6, t._7, t._8, t._9)
+}
+
+final class Tuple10[+T1, +T2, +T3, +T4, +T5, +T6, +T7, +T8, +T9, +T10](
+  val _1: T1, val _2: T2, val _3: T3, val _4: T4, val _5: T5, val _6: T6, val _7: T7, val _8: T8, val _9: T9, val _10: T10
+)
+
+object Tuple10 {
+  def apply[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10](
+    _1: T1, _2: T2, _3: T3, _4: T4, _5: T5, _6: T6, _7: T7, _8: T8, _9: T9, _10: T10
+  ): Tuple10[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10] =
+    new Tuple10(_1, _2, _3, _4, _5, _6, _7, _8, _9, _10)
+
+  @inline def unapply[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10](t: Tuple10[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10]): Some[(T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)] =
+    Some((t._1, t._2, t._3, t._4, t._5, t._6, t._7, t._8, t._9, t._10))
+
+  @inline implicit def fromScalaTuple10[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10](t: (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)): Tuple10[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10] =
+    apply(t._1, t._2, t._3, t._4, t._5, t._6, t._7, t._8, t._9, t._10)
+
+  @inline implicit def toScalaTuple10[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10](t: Tuple10[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10]): (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10) =
+    (t._1, t._2, t._3, t._4, t._5, t._6, t._7, t._8, t._9, t._10)
+}

--- a/library/src/main/scala/scala/scalajs/wasi/http/types/Fields.scala
+++ b/library/src/main/scala/scala/scalajs/wasi/http/types/Fields.scala
@@ -35,7 +35,7 @@ trait Fields {
 
   // entries: func() -> list<tuple<field-name,field-value>>;
   @ComponentResourceMethod("entries")
-  def entries(): Array[(FieldName, FieldValue)] = cm.native
+  def entries(): Array[cm.Tuple2[FieldName, FieldValue]] = cm.native
 
   // clone: func() -> fields;
   @ComponentResourceMethod("clone")
@@ -46,5 +46,5 @@ object Fields {
   def apply(): Fields = cm.native
 
   @ComponentResourceStaticMethod("from-list")
-  def fromList(entries: Array[(FieldName, FieldValue)]): Fields = cm.native
+  def fromList(entries: Array[cm.Tuple2[FieldName, FieldValue]]): Fields = cm.native
 }

--- a/linker/shared/src/main/scala/org/scalajs/linker/analyzer/Infos.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/analyzer/Infos.scala
@@ -729,9 +729,13 @@ object Infos {
           resultType.foreach { t => generateForWIT(t) }
 
         case wit.TupleType(fields) =>
-          val className = ClassName("scala.Tuple" + fields.size)
+          val className = ClassName("scala.scalajs.component.Tuple" + fields.size)
           val ctorID = MethodName.constructor(List.fill(fields.size)(ClassRef(ObjectClass)))
           builder.addInstantiatedClass(className, ctorID)
+          // Add field reads for each tuple field
+          for (i <- 1 to fields.size) {
+            builder.addFieldRead(FieldName(className, SimpleFieldName(s"_$i")))
+          }
           for (f <- fields) generateForWIT(f)
 
         case wit.RecordType(className, fields) =>

--- a/linker/shared/src/main/scala/org/scalajs/linker/backend/wasmemitter/canonicalabi/CABIToScalaJS.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/backend/wasmemitter/canonicalabi/CABIToScalaJS.scala
@@ -119,8 +119,8 @@ object CABIToScalaJS {
         // genAlignTo(fb, wit.alignment(tpe), ptr)
 
       case wit.TupleType(fields) =>
-        val ctor = MethodName.constructor(fields.map(_ => ClassRef(ObjectClass)))
-        val className = ClassName("scala.Tuple" + fields.size)
+        val ctor = MethodName.constructor(List.fill(fields.size)(ClassRef(ObjectClass)))
+        val className = ClassName("scala.scalajs.component.Tuple" + fields.size)
         val ptr = fb.addLocal(NoOriginalName, watpe.Int32)
         fb += wa.LocalSet(ptr)
         genNewScalaClass(fb, className, ctor) {
@@ -220,8 +220,8 @@ object CABIToScalaJS {
         vi.next(watpe.Int32)
 
       case wit.TupleType(fields) =>
-        val ctor = MethodName.constructor(fields.map(_ => ClassRef(ObjectClass)))
-        val className = ClassName("scala.Tuple" + fields.size)
+        val ctor = MethodName.constructor(List.fill(fields.size)(ClassRef(ObjectClass)))
+        val className = ClassName("scala.scalajs.component.Tuple" + fields.size)
         genNewScalaClass(fb, className, ctor) {
           for (f <- fields) {
             val fieldType = Flatten.flattenType(f)

--- a/linker/shared/src/main/scala/org/scalajs/linker/backend/wasmemitter/canonicalabi/ScalaJSToCABI.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/backend/wasmemitter/canonicalabi/ScalaJSToCABI.scala
@@ -94,8 +94,7 @@ object ScalaJSToCABI {
         fb += wa.I32Store()
 
       case wit.TupleType(fields) =>
-        val className = ClassName("scala.Tuple" + fields.size)
-        val isSpecialized = fields.size <= 2
+        val className = ClassName("scala.scalajs.component.Tuple" + fields.size)
         val ptr = fb.addLocal(NoOriginalName, watpe.Int32)
         val tuple = fb.addLocal(NoOriginalName, watpe.RefType.nullable(genTypeID.forClass(className)))
         fb += wa.RefCast(watpe.RefType.nullable(genTypeID.forClass(className)))
@@ -105,16 +104,11 @@ object ScalaJSToCABI {
         for ((f, i) <- fields.zipWithIndex) {
           genAlignTo(fb, wit.alignment(f), ptr)
           fb += wa.LocalGet(ptr)
-          if (isSpecialized) {
-            val methodName = MethodName(s"_${i + 1}", Nil, ClassRef(ObjectClass))
-            genVTableDispatch(fb, className, methodName, tuple)
-          } else {
-            fb += wa.LocalGet(tuple)
-            fb += wa.StructGet(
-              genTypeID.forClass(className),
-              genFieldID.forClassInstanceField(FieldName(className, SimpleFieldName(s"_${i + 1}")))
-            )
-          }
+          fb += wa.LocalGet(tuple)
+          fb += wa.StructGet(
+            genTypeID.forClass(className),
+            genFieldID.forClassInstanceField(FieldName(className, SimpleFieldName(s"_${i + 1}")))
+          )
           f.toIRType() match {
             case t: PrimTypeWithRef => genUnbox(fb, t)
             case _ =>
@@ -240,22 +234,16 @@ object ScalaJSToCABI {
       case wit.FlagsType(_) =>
 
       case wit.TupleType(fields) =>
-        val className = ClassName("scala.Tuple" + fields.size)
+        val className = ClassName("scala.scalajs.component.Tuple" + fields.size)
         val tuple = fb.addLocal(NoOriginalName, watpe.RefType.nullable(genTypeID.forClass(className)))
-        val isSpecialized = fields.size <= 2
         fb += wa.RefCast(watpe.RefType.nullable(genTypeID.forClass(className)))
         fb += wa.LocalSet(tuple)
         for ((f, i) <- fields.zipWithIndex) {
-          if (isSpecialized) {
-            val methodName = MethodName(s"_${i + 1}", Nil, ClassRef(ObjectClass))
-            genVTableDispatch(fb, className, methodName, tuple)
-          } else {
-            fb += wa.LocalGet(tuple)
-            fb += wa.StructGet(
-              genTypeID.forClass(className),
-              genFieldID.forClassInstanceField(FieldName(className, SimpleFieldName(s"_${i + 1}")))
-            )
-          }
+          fb += wa.LocalGet(tuple)
+          fb += wa.StructGet(
+            genTypeID.forClass(className),
+            genFieldID.forClassInstanceField(FieldName(className, SimpleFieldName(s"_${i + 1}")))
+          )
           f.toIRType() match {
             case t: PrimTypeWithRef => genUnbox(fb, t)
             case _ =>


### PR DESCRIPTION
Implement cm.Tuple (Tuple1-Tuple10 for now) classes that map to the Component Model's tuple type, and replace the previous scala.Tuple usage for component model interop. Using scala.Tuple was tricky because Tuple1 and Tuple2 is specialized for primitive types.