### PR TITLE
Refactor Component Model APIs: ResourceType and Variants

### DIFF
--- a/compiler/src/main/scala/org/scalajs/nscplugin/GenJSCode.scala
+++ b/compiler/src/main/scala/org/scalajs/nscplugin/GenJSCode.scala
@@ -3470,6 +3470,8 @@ abstract class GenJSCode[G <: Global with Singleton](val global: G)
             genNewArray(arr, args.map(genExpr))
           case prim: jstpe.PrimRef =>
             abort(s"unexpected primitive type $prim in New at $pos")
+          case jstpe.ComponentResourceTypeRef(_) =>
+            abort(s"unexpected component resource type in New at $pos")
           case typeRef: jstpe.TransientTypeRef =>
             abort(s"unexpected special type ref $typeRef in New at $pos")
         }

--- a/compiler/src/main/scala/org/scalajs/nscplugin/JSDefinitions.scala
+++ b/compiler/src/main/scala/org/scalajs/nscplugin/JSDefinitions.scala
@@ -81,6 +81,7 @@ trait JSDefinitions {
     lazy val ComponentImportAnnotation = getRequiredClass("scala.scalajs.component.annotation.ComponentImport")
     lazy val ComponentExportAnnotation = getRequiredClass("scala.scalajs.component.annotation.ComponentExport")
     lazy val ComponentRecordAnnotation = getRequiredClass("scala.scalajs.component.annotation.ComponentRecord")
+    lazy val ComponentVariantAnnotation = getRequiredClass("scala.scalajs.component.annotation.ComponentVariant")
     lazy val ComponentFlagsAnnotation  = getRequiredClass("scala.scalajs.component.annotation.ComponentFlags")
 
     lazy val ComponentResourceImportAnnotation = getRequiredClass("scala.scalajs.component.annotation.ComponentResourceImport")
@@ -92,7 +93,6 @@ trait JSDefinitions {
     lazy val ComponentResultClass      = getRequiredClass("scala.scalajs.component.Result")
     lazy val ComponentResultOkClass    = getRequiredClass("scala.scalajs.component.Ok")
     lazy val ComponentResultErrClass   = getRequiredClass("scala.scalajs.component.Err")
-    lazy val ComponentVariantClass     = getRequiredClass("scala.scalajs.component.Variant")
 
     lazy val ScalaJSComponentUnsignedPackageModule = getPackageObject("scala.scalajs.component.unsigned")
       lazy val ComponentUnsigned_UByte = getTypeMember(ScalaJSComponentUnsignedPackageModule, newTermName("UByte"))

--- a/compiler/src/main/scala/org/scalajs/nscplugin/JSEncoding.scala
+++ b/compiler/src/main/scala/org/scalajs/nscplugin/JSEncoding.scala
@@ -272,6 +272,7 @@ trait JSEncoding[G <: Global with Singleton] extends SubComponent {
   def encodeClassType(sym: Symbol): jstpe.Type = {
     if (sym == definitions.ObjectClass) jstpe.AnyType
     else if (isJSType(sym)) jstpe.AnyType
+    else if (isWasmComponentResourceType(sym)) jstpe.ComponentResourceType(encodeClassName(sym))
     else {
       assert(sym != definitions.ArrayClass,
           "encodeClassType() cannot be called with ArrayClass")

--- a/compiler/src/main/scala/org/scalajs/nscplugin/PrepJSInterop.scala
+++ b/compiler/src/main/scala/org/scalajs/nscplugin/PrepJSInterop.scala
@@ -173,9 +173,11 @@ abstract class PrepJSInterop[G <: Global with Singleton](val global: G)
 
       checkJSCallingConventionAnnots(sym)
 
-      if (WasmComponentFunctionAnnots.exists(sym.hasAnnotation(_)))
+      if (WasmComponentResourceAnnots.exists(sym.hasAnnotation(_)))
+        checkWasmComponentResourceAnnotationContext(tree.pos, sym)
+      else if (WasmComponentFunctionAnnots.exists(sym.hasAnnotation(_)))
         checkWasmComponentFunction(tree.pos, sym)
-      if (sym.hasAnnotation(ComponentResourceImportAnnotation))
+      else if (sym.hasAnnotation(ComponentResourceImportAnnotation))
         checkWasmComponentResourceImport(tree.pos, sym)
 
       // @unchecked needed because MemberDef is not marked `sealed`
@@ -778,24 +780,14 @@ abstract class PrepJSInterop[G <: Global with Singleton](val global: G)
       }
     }
 
-    private def checkWasmComponentFunction(pos: Position, sym: Symbol): Unit =
-      checkAndGetWasmComponentFunctionAnnotOf(pos, sym).foreach { annot =>
-        val isFunction = annot.symbol == ComponentImportAnnotation
-        val isResourceMethod = annot.symbol == ComponentResourceMethodAnnotation
-        val isStaticMethod = annot.symbol == ComponentResourceStaticMethodAnnotation
-        val isConstructor = annot.symbol == ComponentResourceConstructorAnnotation
-        val isDrop = annot.symbol == ComponentResourceDropAnnotation
+    private def checkWasmComponentResourceAnnotationContext(pos: Position, sym: Symbol): Unit = {
+      sym.annotations.foreach { annot =>
+        if (WasmComponentResourceAnnots.contains(annot.symbol)) {
+          val isResourceMethod = annot.symbol == ComponentResourceMethodAnnotation
+          val isStaticMethod = annot.symbol == ComponentResourceStaticMethodAnnotation
+          val isConstructor = annot.symbol == ComponentResourceConstructorAnnotation
+          val isDrop = annot.symbol == ComponentResourceDropAnnotation
 
-        if (sym.isLocalToBlock) {
-          reporter.error(pos,
-              s"$annot is not allowed on local definitions")
-        } else if (!sym.isMethod) {
-          reporter.error(pos,
-              s"$annot is allowed on static method definition")
-        } else if (sym.isConstructor) {
-          reporter.error(pos,
-              s"$annot is not allowed on constructor")
-        } else {
           if ((isResourceMethod || isDrop) && (
               !sym.owner.isTraitOrInterface ||
               !sym.owner.hasAnnotation(ComponentResourceImportAnnotation))) {
@@ -808,22 +800,36 @@ abstract class PrepJSInterop[G <: Global with Singleton](val global: G)
               !sym.owner.companionClass.hasAnnotation(ComponentResourceImportAnnotation))) {
             reporter.error(pos,
                 s"$annot is allowed in companion object of trait annotated with @ComponentResourceImport")
-          } else if (isConstructor && sym.name != nme.apply) {
-             reporter.error(pos,
-                 s"@ComponentResourceConstructor is allowed only on an apply method")
-          } else {
-            for (overridden <- sym.allOverriddenSymbols.headOption) {
-              val verb = if (overridden.isDeferred) "implement" else "override"
-              reporter.error(pos,
-                  s"An $annot member cannot $verb the inherited member " +
-                  overridden.fullName)
-            }
-            val funcType = jsInterop.ComponentFunctionType(
-              (if (sym.tpe.paramss.isEmpty) Nil else sym.tpe.paramss.head).map(_.tpe),
-              sym.tpe.resultType
-            )
-            jsInterop.storeComponentFunctionType(sym, funcType)
           }
+        }
+      }
+    }
+
+    private def checkWasmComponentFunction(pos: Position, sym: Symbol): Unit =
+      checkAndGetWasmComponentFunctionAnnotOf(pos, sym).foreach { annot =>
+        if (sym.isLocalToBlock) {
+          reporter.error(pos,
+              s"$annot is not allowed on local definitions")
+        } else if (!sym.isMethod) {
+          reporter.error(pos,
+              s"$annot is allowed on static method definition")
+        } else if (sym.isConstructor) {
+          reporter.error(pos,
+              s"$annot is not allowed on constructor")
+        } else {
+          // Validate @ComponentImport-specific rules
+          for (overridden <- sym.allOverriddenSymbols.headOption) {
+            val verb = if (overridden.isDeferred) "implement" else "override"
+            reporter.error(pos,
+                s"An $annot member cannot $verb the inherited member " +
+                overridden.fullName)
+          }
+
+          val funcType = jsInterop.ComponentFunctionType(
+            (if (sym.tpe.paramss.isEmpty) Nil else sym.tpe.paramss.head).map(_.tpe),
+            sym.tpe.resultType
+          )
+          jsInterop.storeComponentFunctionType(sym, funcType)
         }
     }
 
@@ -831,7 +837,129 @@ abstract class PrepJSInterop[G <: Global with Singleton](val global: G)
       if (!sym.isTrait) {
         reporter.error(pos,
             "@ComponentResourceImport is allowed for traits")
-      } // what else?
+        return
+      }
+
+      // Resource imports should not be sealed
+      if (sym.isSealed) {
+        reporter.error(pos,
+            "@ComponentResourceImport traits cannot be sealed")
+        return
+      }
+
+      var dropMethodCount = 0
+      for (member <- sym.info.decls) {
+        if (member.isMethod && !member.isConstructor && !member.isSynthetic) {
+          val hasResourceMethod = member.hasAnnotation(ComponentResourceMethodAnnotation)
+          val hasResourceDrop = member.hasAnnotation(ComponentResourceDropAnnotation)
+          val hasResourceConstructor = member.hasAnnotation(ComponentResourceConstructorAnnotation)
+          val hasResourceStaticMethod = member.hasAnnotation(ComponentResourceStaticMethodAnnotation)
+
+          // @ComponentResourceConstructor and @ComponentResourceStaticMethod are not allowed in trait
+          if (hasResourceConstructor) {
+            reporter.error(member.pos,
+                "@ComponentResourceConstructor can only be used on apply method in companion object")
+          }
+          if (hasResourceStaticMethod) {
+            reporter.error(member.pos,
+                "@ComponentResourceStaticMethod can only be used in companion object")
+          }
+
+          val hasResourceMethodAnnotation = hasResourceMethod || hasResourceDrop
+          if (!hasResourceMethodAnnotation) {
+            reporter.error(member.pos,
+                s"Method '${member.name}' in @ComponentResourceImport trait must be " +
+                "annotated with @ComponentResourceMethod or @ComponentResourceDrop")
+          }
+
+          if (hasResourceDrop) {
+            dropMethodCount += 1
+            val methodType = member.tpe
+            val paramCount = if (methodType.paramss.isEmpty) 0 else methodType.paramss.head.length
+            val returnType = methodType.resultType
+
+            if (paramCount > 0) {
+              reporter.error(member.pos,
+                  "@ComponentResourceDrop method must take no parameters")
+            }
+            if (returnType.typeSymbol != definitions.UnitClass) {
+              reporter.error(member.pos,
+                  "@ComponentResourceDrop method must return Unit")
+            }
+          }
+
+          if (hasResourceMethodAnnotation) {
+            val methodType = member.tpe
+            val paramTypes = if (methodType.paramss.isEmpty) Nil else methodType.paramss.head.map(_.tpe)
+            val returnType = methodType.resultType
+
+            paramTypes.foreach { paramType =>
+              if (!isComponentModelCompatible(paramType)) {
+                reporter.error(member.pos,
+                    s"Parameter type '${paramType}' in method '${member.name}' is not compatible with Component Model")
+              }
+            }
+
+            if (!isComponentModelCompatible(returnType)) {
+              reporter.error(member.pos,
+                  s"Return type '${returnType}' in method '${member.name}' is not compatible with Component Model")
+            }
+
+            // Check for overriding inherited members
+            for (overridden <- member.allOverriddenSymbols.headOption) {
+              val verb = if (overridden.isDeferred) "implement" else "override"
+              reporter.error(member.pos,
+                  s"A @ComponentResourceMethod or @ComponentResourceDrop member cannot $verb the inherited member " +
+                  overridden.fullName)
+            }
+          }
+
+          val funcType = jsInterop.ComponentFunctionType(
+            (if (member.tpe.paramss.isEmpty) Nil else member.tpe.paramss.head).map(_.tpe),
+            member.tpe.resultType
+          )
+          jsInterop.storeComponentFunctionType(member, funcType)
+        }
+      }
+
+      // Ensure there is at most one drop method
+      if (dropMethodCount > 1) {
+        reporter.error(pos,
+            s"@ComponentResourceImport trait can have at most one @ComponentResourceDrop method, found $dropMethodCount")
+      }
+
+      // Check companion object if it exists
+      val companion = sym.companionSymbol
+      if (companion != NoSymbol && companion.isModule) {
+        val companionClass = companion.moduleClass
+        for (member <- companionClass.info.decls) {
+          if (member.isMethod && !member.isConstructor) {
+            val hasConstructorAnnot = member.hasAnnotation(ComponentResourceConstructorAnnotation)
+            val hasStaticMethodAnnot = member.hasAnnotation(ComponentResourceStaticMethodAnnotation)
+
+            // @ComponentResourceConstructor must be on apply method
+            if (hasConstructorAnnot && member.name != nme.apply) {
+              reporter.error(member.pos,
+                  "@ComponentResourceConstructor can only be used on apply method")
+            }
+
+            // Public methods in companion must have @ComponentResourceConstructor or @ComponentResourceStaticMethod
+            if (!hasConstructorAnnot &&
+                !hasStaticMethodAnnot &&
+                !member.isSynthetic) {
+              reporter.error(member.pos,
+                  s"Public method '${member.name}' in companion object of @ComponentResourceImport trait must be " +
+                  "annotated with @ComponentResourceConstructor or @ComponentResourceStaticMethod")
+            }
+
+            val funcType = jsInterop.ComponentFunctionType(
+              (if (member.tpe.paramss.isEmpty) Nil else member.tpe.paramss.head).map(_.tpe),
+              member.tpe.resultType
+            )
+            jsInterop.storeComponentFunctionType(member, funcType)
+          }
+        }
+      }
     }
 
     /** Validates a @ComponentVariant annotated sealed trait and its cases. */
@@ -903,7 +1031,7 @@ abstract class PrepJSInterop[G <: Global with Singleton](val global: G)
       val fullName = sym.fullName
 
       // Check primitives
-      if (sym == ByteClass || sym == ShortClass || sym == IntClass || sym == LongClass ||
+      if (sym == UnitClass || sym == ByteClass || sym == ShortClass || sym == IntClass || sym == LongClass ||
           sym == FloatClass || sym == DoubleClass || sym == CharClass || sym == BooleanClass) {
         true
       } else if (sym.fullName == "java.lang.String") {
@@ -1875,13 +2003,16 @@ abstract class PrepJSInterop[G <: Global with Singleton](val global: G)
 
   }
 
-  private lazy val WasmComponentFunctionAnnots: Set[Symbol] = {
-    Set(ComponentImportAnnotation,
-        ComponentResourceMethodAnnotation,
-        ComponentResourceStaticMethodAnnotation,
-        ComponentResourceConstructorAnnotation,
-        ComponentResourceDropAnnotation)
-  }
+  private lazy val WasmComponentFunctionAnnots: Set[Symbol] =
+    Set(ComponentImportAnnotation)
+
+  private lazy val WasmComponentResourceAnnots: Set[Symbol] =
+    Set(
+      ComponentResourceMethodAnnotation,
+      ComponentResourceStaticMethodAnnotation,
+      ComponentResourceConstructorAnnotation,
+      ComponentResourceDropAnnotation
+    )
 }
 
 object PrepJSInterop {

--- a/compiler/src/main/scala/org/scalajs/nscplugin/TypeConversions.scala
+++ b/compiler/src/main/scala/org/scalajs/nscplugin/TypeConversions.scala
@@ -74,7 +74,6 @@ trait TypeConversions[G <: Global with Singleton] extends SubComponent {
   }
 
   private lazy val primitiveIRWIT: Map[Types.Type, wit.ValType] = Map(
-    Types.VoidType -> wit.VoidType,
     Types.BooleanType -> wit.BoolType,
     Types.ByteType -> wit.S8Type,
     Types.ShortType -> wit.S16Type,
@@ -101,7 +100,12 @@ trait TypeConversions[G <: Global with Singleton] extends SubComponent {
   )
 
   private def makeNonArrayTypeRef(sym: Symbol): Types.NonArrayTypeRef =
-    primitiveRefMap.getOrElse(sym, Types.ClassRef(encodeClassName(sym)))
+    primitiveRefMap.getOrElse(sym, {
+      if (isWasmComponentResourceType(sym))
+        Types.ComponentResourceTypeRef(encodeClassName(sym))
+      else
+        Types.ClassRef(encodeClassName(sym))
+    })
 
   private def makeArrayTypeRef(base: Symbol, depth: Int): Types.ArrayTypeRef =
     Types.ArrayTypeRef(makeNonArrayTypeRef(base), depth)

--- a/compiler/src/test/scala/org/scalajs/nscplugin/test/ComponentModelInteropTest.scala
+++ b/compiler/src/test/scala/org/scalajs/nscplugin/test/ComponentModelInteropTest.scala
@@ -1,0 +1,338 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
+package org.scalajs.nscplugin.test
+
+import org.scalajs.nscplugin.test.util._
+
+import org.junit.Test
+
+class ComponentModelInteropTest extends DirectTest with TestHelpers {
+
+  override def preamble: String =
+    """
+    import scala.scalajs.{component => cm}
+    import scala.scalajs.component.annotation._
+    import scala.scalajs.component.unsigned._
+    """
+
+  @Test def resourceImportMustBeOnTrait: Unit = {
+    """
+    @ComponentResourceImport("test:module", "resource")
+    class MyResource
+    """ hasErrors
+    """
+      |newSource1.scala:7: error: @ComponentResourceImport is allowed for traits
+      |    class MyResource
+      |          ^
+    """
+
+    """
+    @ComponentResourceImport("test:module", "resource")
+    object MyResource
+    """ hasErrors
+    """
+      |newSource1.scala:7: error: @ComponentResourceImport is allowed for traits
+      |    object MyResource
+      |           ^
+    """
+  }
+
+  @Test def resourceImportCannotBeSealed: Unit = {
+    """
+    @ComponentResourceImport("test:module", "resource")
+    sealed trait MyResource
+    """ hasErrors
+    """
+      |newSource1.scala:7: error: @ComponentResourceImport traits cannot be sealed
+      |    sealed trait MyResource
+      |                 ^
+    """
+  }
+
+  @Test def resourceMethodsMustHaveAnnotation: Unit = {
+    """
+    @ComponentResourceImport("test:module", "resource")
+    trait MyResource {
+      def doSomething(): Unit
+    }
+    """ hasErrors
+    """
+      |newSource1.scala:8: error: Method 'doSomething' in @ComponentResourceImport trait must be annotated with @ComponentResourceMethod or @ComponentResourceDrop
+      |      def doSomething(): Unit
+      |          ^
+    """
+
+    """
+    @ComponentResourceImport("test:module", "resource")
+    trait MyResource {
+      def method1(): Unit
+      def method2(x: Int): String
+    }
+    """ hasErrors
+    """
+      |newSource1.scala:8: error: Method 'method1' in @ComponentResourceImport trait must be annotated with @ComponentResourceMethod or @ComponentResourceDrop
+      |      def method1(): Unit
+      |          ^
+      |newSource1.scala:9: error: Method 'method2' in @ComponentResourceImport trait must be annotated with @ComponentResourceMethod or @ComponentResourceDrop
+      |      def method2(x: Int): String
+      |          ^
+    """
+
+    """
+    @ComponentResourceImport("test:module", "resource")
+    trait MyResource {
+      @ComponentResourceMethod("annotated")
+      def annotated(): Unit = cm.native
+
+      def unannotated(): Unit = cm.native
+    }
+    """ hasErrors
+    """
+      |newSource1.scala:11: error: Method 'unannotated' in @ComponentResourceImport trait must be annotated with @ComponentResourceMethod or @ComponentResourceDrop
+      |      def unannotated(): Unit = cm.native
+      |          ^
+    """
+  }
+
+  @Test def resourceMethodParametersMustBeCompatible: Unit = {
+    """
+    class NotCompatible
+
+    @ComponentResourceImport("test:module", "resource")
+    trait MyResource {
+      @ComponentResourceMethod("invalid")
+      def invalidMethod(x: NotCompatible): Unit = cm.native
+    }
+    """ hasErrors
+    """
+      |newSource1.scala:11: error: Parameter type 'NotCompatible' in method 'invalidMethod' is not compatible with Component Model
+      |      def invalidMethod(x: NotCompatible): Unit = cm.native
+      |          ^
+    """
+  }
+
+  @Test def resourceMethodReturnTypeMustBeCompatible: Unit = {
+    """
+    class NotCompatible
+
+    @ComponentResourceImport("test:module", "resource")
+    trait MyResource {
+      @ComponentResourceMethod("invalid")
+      def invalidMethod(): NotCompatible = cm.native
+    }
+    """ hasErrors
+    """
+      |newSource1.scala:11: error: Return type 'NotCompatible' in method 'invalidMethod' is not compatible with Component Model
+      |      def invalidMethod(): NotCompatible = cm.native
+      |          ^
+    """
+  }
+
+  @Test def resourceCompanionObjectMethodsMustHaveAnnotation: Unit = {
+    """
+    @ComponentResourceImport("test:module", "resource")
+    trait MyResource {
+      @ComponentResourceMethod("do-something")
+      def doSomething(): Unit = cm.native
+    }
+    object MyResource {
+      def invalidMethod(): Unit = ???
+    }
+    """ hasErrors
+    """
+      |newSource1.scala:12: error: Public method 'invalidMethod' in companion object of @ComponentResourceImport trait must be annotated with @ComponentResourceConstructor or @ComponentResourceStaticMethod
+      |      def invalidMethod(): Unit = ???
+      |          ^
+    """
+  }
+
+  @Test def resourceDropMustHaveNoParametersAndReturnUnit: Unit = {
+    """
+    @ComponentResourceImport("test:module", "resource")
+    trait MyResource {
+      @ComponentResourceDrop
+      def close(x: Int): Unit = cm.native
+    }
+    """ hasErrors
+    """
+      |newSource1.scala:9: error: @ComponentResourceDrop method must take no parameters
+      |      def close(x: Int): Unit = cm.native
+      |          ^
+    """
+
+    """
+    @ComponentResourceImport("test:module", "resource")
+    trait MyResource {
+      @ComponentResourceDrop
+      def close(): Int = cm.native
+    }
+    """ hasErrors
+    """
+      |newSource1.scala:9: error: @ComponentResourceDrop method must return Unit
+      |      def close(): Int = cm.native
+      |          ^
+    """
+  }
+
+  @Test def resourceCanHaveAtMostOneDropMethod: Unit = {
+    """
+    @ComponentResourceImport("test:module", "resource")
+    trait MyResource {
+      @ComponentResourceDrop
+      def close(): Unit = cm.native
+
+      @ComponentResourceDrop
+      def dispose(): Unit = cm.native
+    }
+    """ hasErrors
+    """
+      |newSource1.scala:7: error: @ComponentResourceImport trait can have at most one @ComponentResourceDrop method, found 2
+      |    trait MyResource {
+      |          ^
+    """
+  }
+
+  @Test def resourceConstructorOnlyInCompanionObject: Unit = {
+    """
+    @ComponentResourceImport("test:module", "resource")
+    trait MyResource {
+      @ComponentResourceConstructor
+      def create(): MyResource = cm.native
+    }
+    """ hasErrors
+    """
+      |newSource1.scala:9: error: @ComponentResourceConstructor can only be used on apply method in companion object
+      |      def create(): MyResource = cm.native
+      |          ^
+    """
+  }
+
+  @Test def resourceStaticMethodOnlyInCompanionObject: Unit = {
+    """
+    @ComponentResourceImport("test:module", "resource")
+    trait MyResource {
+      @ComponentResourceStaticMethod("factory")
+      def factory(): MyResource = cm.native
+    }
+    """ hasErrors
+    """
+      |newSource1.scala:9: error: @ComponentResourceStaticMethod can only be used in companion object
+      |      def factory(): MyResource = cm.native
+      |          ^
+    """
+  }
+
+  @Test def resourceConstructorMustBeOnApply: Unit = {
+    """
+    @ComponentResourceImport("test:module", "resource")
+    trait MyResource
+    object MyResource {
+      @ComponentResourceConstructor
+      def create(): MyResource = cm.native
+    }
+    """ hasErrors
+    """
+      |newSource1.scala:10: error: @ComponentResourceConstructor can only be used on apply method
+      |      def create(): MyResource = cm.native
+      |          ^
+    """
+  }
+
+  @Test def resourceAnnotationsOnlyInResourceImportTraits: Unit = {
+    """
+    trait NotAResource {
+      @ComponentResourceMethod("invalid")
+      def method(): Unit = cm.native
+    }
+    """ hasErrors
+    """
+      |newSource1.scala:8: error: scala.scalajs.component.annotation.ComponentResourceMethod("invalid") is allowed in trait annotated with @ComponentResourceImport
+      |      def method(): Unit = cm.native
+      |          ^
+    """
+
+    """
+    trait NotAResource {
+      @ComponentResourceDrop
+      def drop(): Unit = cm.native
+    }
+    """ hasErrors
+    """
+      |newSource1.scala:8: error: scala.scalajs.component.annotation.ComponentResourceDrop is allowed in trait annotated with @ComponentResourceImport
+      |      def drop(): Unit = cm.native
+      |          ^
+    """
+  }
+
+  @Test def resourceConstructorAnnotationsOnlyInResourceCompanions: Unit = {
+    """
+    object NotAResourceCompanion {
+      @ComponentResourceConstructor
+      def apply(): String = ???
+    }
+    """ hasErrors
+    """
+      |newSource1.scala:8: error: scala.scalajs.component.annotation.ComponentResourceConstructor is allowed in companion object of trait annotated with @ComponentResourceImport
+      |      def apply(): String = ???
+      |          ^
+    """
+
+    """
+    object NotAResourceCompanion {
+      @ComponentResourceStaticMethod("foo")
+      def foo(): String = ???
+    }
+    """ hasErrors
+    """
+      |newSource1.scala:8: error: scala.scalajs.component.annotation.ComponentResourceStaticMethod("foo") is allowed in companion object of trait annotated with @ComponentResourceImport
+      |      def foo(): String = ???
+      |          ^
+    """
+  }
+
+  @Test def resourceValidExample: Unit = {
+    """
+    @ComponentResourceImport("test:io/streams", "input-stream")
+    trait InputStream {
+      @ComponentResourceMethod("read")
+      def read(len: ULong): cm.Result[Array[UByte], String] = cm.native
+
+      @ComponentResourceMethod("blocking-read")
+      def blockingRead(len: ULong): cm.Result[Array[UByte], String] = cm.native
+
+      @ComponentResourceDrop
+      def close(): Unit = cm.native
+    }
+
+    @ComponentResourceImport("test:io/streams", "output-stream")
+    trait OutputStream {
+      @ComponentResourceMethod("write")
+      def write(data: Array[UByte]): cm.Result[Unit, String] = cm.native
+
+      @ComponentResourceMethod("flush")
+      def flush(): cm.Result[Unit, String] = cm.native
+
+      @ComponentResourceDrop
+      def close(): Unit = cm.native
+    }
+    object OutputStream {
+      @ComponentResourceConstructor
+      def apply(): OutputStream = cm.native
+
+      @ComponentResourceConstructor
+      def apply(x: Int): OutputStream = cm.native
+    }
+    """.hasNoWarns()
+  }
+
+}

--- a/examples/test-component-model/rust-exports/src/lib.rs
+++ b/examples/test-component-model/rust-exports/src/lib.rs
@@ -75,6 +75,18 @@ impl GuestCounter for GuestCounterImpl {
 
 impl Countable for Component {
   type Counter = GuestCounterImpl;
+
+  fn try_create_counter(value: i32) -> Result<Counter, String> {
+    if value >= 0 {
+      Ok(Counter::new(GuestCounterImpl::create(value)))
+    } else {
+      Err("Counter value must be non-negative".to_string())
+    }
+  }
+
+  fn maybe_get_counter() -> Option<Counter> {
+    Some(Counter::new(GuestCounterImpl::create(42)))
+  }
 }
 
 #[allow(unused_variables)]

--- a/examples/test-component-model/src/main/scala/componentmodel/Exports.scala
+++ b/examples/test-component-model/src/main/scala/componentmodel/Exports.scala
@@ -7,6 +7,7 @@ import scala.scalajs.component.annotation._
 import scala.scalajs.component.unsigned._
 
 import java.util.Optional
+import scala.scalajs.ComponentUtils.toEither
 
 object TestsExport {
   @ComponentExport("component:testing/tests", "roundtrip-basics1")
@@ -151,15 +152,15 @@ object TestImports {
     assert(Optional.empty == roundtripDoubleOption(Optional.empty[Optional[String]]))
     // assert(new cm.Err("aaa") != new cm.Err("bbb"))
 
-    // assert(new cm.Ok(()) == roundtripResult(new cm.Ok(())))
-    // assert(new cm.Err(()) == roundtripResult(new cm.Err(())))
-    // assert(new cm.Ok(3.0f) == roundtripStringError(new cm.Ok(3.0f)))
-    // assert(new cm.Err("err") == roundtripStringError(new cm.Err("err")))
-    // assert(new cm.Ok(C1.A(432)) == roundtripEnumError(new cm.Ok(C1.A(432))))
-    // assert(new cm.Ok(C1.B(0.0f)) == roundtripEnumError(new cm.Ok(C1.B(0.0f))))
-    // assert(new cm.Err(E1.A) == roundtripEnumError(new cm.Err(E1.A)))
-    // assert(new cm.Err(E1.B) == roundtripEnumError(new cm.Err(E1.B)))
-    // assert(new cm.Err(E1.C) == roundtripEnumError(new cm.Err(E1.C)))
+    assert(new cm.Ok(()) == roundtripResult(new cm.Ok(())))
+    assert(new cm.Err(()) == roundtripResult(new cm.Err(())))
+    assert(new cm.Ok(3.0f) == roundtripStringError(new cm.Ok(3.0f)))
+    assert(new cm.Err("err") == roundtripStringError(new cm.Err("err")))
+    assert(new cm.Ok(C1.A(432)) == roundtripEnumError(new cm.Ok(C1.A(432))))
+    assert(new cm.Ok(C1.B(0.0f)) == roundtripEnumError(new cm.Ok(C1.B(0.0f))))
+    assert(new cm.Err(E1.A) == roundtripEnumError(new cm.Err(E1.A)))
+    assert(new cm.Err(E1.B) == roundtripEnumError(new cm.Err(E1.B)))
+    assert(new cm.Err(E1.C) == roundtripEnumError(new cm.Err(E1.C)))
 
     import TestImportsHelper._
     assert((F1.b3 | F1.b6 | F1.b7) == roundtripF8(F1.b3 | F1.b6 | F1.b7))
@@ -175,6 +176,20 @@ object TestImports {
     val result3: (Int, String, Boolean) = roundtripTuple3((123, "world", true))
     assert(result3 == (123, "world", true))
 
+    // Test resource wrappers
+    locally {
+      val successResult = toEither(tryCreateCounter(10))
+      assert(successResult.isRight)
+      assert(10 == successResult.right.get.valueOf())
+
+      val errorResult = toEither(tryCreateCounter(-5))
+      assert(errorResult.isLeft)
+
+      val maybeCounter = maybeGetCounter()
+      assert(maybeCounter.isPresent)
+      assert(42 == maybeCounter.get().valueOf())
+    }
+
     locally {
       val c1 = Counter(0)
       c1.up()
@@ -184,10 +199,10 @@ object TestImports {
       c2.down()
       assert(99 == c2.valueOf())
 
-      // val s1 = Counter.sum(c1, c2)
-      // val s2 = Counter.sum(c1, c2)
-      // assert(s1.valueOf() == s2.valueOf())
-      // assert(100 == s.valueOf())
+      val s1 = Counter.sum(c1, c2)
+      val s2 = Counter.sum(c1, c2)
+      assert(s1.valueOf() == s2.valueOf())
+      assert(100 == s1.valueOf())
 
       // use c1 multiple times fails with
       // unknown handle index 1 (?)

--- a/examples/test-component-model/src/main/scala/componentmodel/Exports.scala
+++ b/examples/test-component-model/src/main/scala/componentmodel/Exports.scala
@@ -275,42 +275,24 @@ object TestImportsHelper {
 @ComponentRecord
 final case class Point(x: Int, y: Int)
 
-sealed trait C1 extends Variant
+@ComponentVariant
+sealed trait C1
 object C1 {
-  final case class A(value: Int) extends C1 {
-    type T = Int
-    val _index = 0
-  }
-  final case class B(value: Float) extends C1 {
-    type T = Float
-    val _index = 1
-  }
+  final case class A(value: Int) extends C1
+  final case class B(value: Float) extends C1
 }
 
-sealed trait Z1 extends Variant
+@ComponentVariant
+sealed trait Z1
 object Z1 {
-  final case class A(value: Int) extends Z1 {
-    type T = Int
-    val _index = 0
-  }
-  // if the field is typed Unit, there's no fields generated in SJSIR
-  // there's only a getter
-  final case object B extends Z1 {
-    type T = Unit
-    val value = ()
-    val _index = 1
-  }
+  final case class A(value: Int) extends Z1
+  final case object B extends Z1
 }
 
-sealed trait E1 extends cm.Enum
+@ComponentVariant
+sealed trait E1
 object E1 {
-  final case object A extends E1 {
-    val _index = 0
-  }
-  final case object B extends E1 {
-    val _index = 1
-  }
-  final case object C extends E1 {
-    val _index = 2
-  }
+  case object A extends E1
+  case object B extends E1
+  case object C extends E1
 }

--- a/examples/test-component-model/src/main/scala/componentmodel/Test.scala
+++ b/examples/test-component-model/src/main/scala/componentmodel/Test.scala
@@ -64,6 +64,12 @@ object Countable {
     @ComponentResourceStaticMethod("sum")
     def sum(a: Counter, b: Counter): Counter = cm.native
   }
+
+  @ComponentImport("component:testing/countable", "try-create-counter")
+  def tryCreateCounter(value: Int): cm.Result[Counter, String] = cm.native
+
+  @ComponentImport("component:testing/countable", "maybe-get-counter")
+  def maybeGetCounter(): Optional[Counter] = cm.native
 }
 
 import TestImportsHelper._

--- a/examples/test-component-model/wit/world.wit
+++ b/examples/test-component-model/wit/world.wit
@@ -48,6 +48,9 @@ interface countable {
     down: func();
     value-of: func() -> s32;
   }
+
+  try-create-counter: func(value: s32) -> result<counter, string>;
+  maybe-get-counter: func() -> option<counter>;
 }
 
 interface tests {
@@ -102,7 +105,6 @@ interface tests {
 
   roundtrip-tuple2: func(a: tuple<s32, string>) -> tuple<s32, string>;
   roundtrip-tuple3: func(a: tuple<s32, string, bool>) -> tuple<s32, string, bool>;
-
 }
 
 interface test-imports {

--- a/ir/shared/src/main/scala/org/scalajs/ir/Hashers.scala
+++ b/ir/shared/src/main/scala/org/scalajs/ir/Hashers.scala
@@ -617,6 +617,9 @@ object Hashers {
       case ClassRef(className) =>
         mixTag(TagClassRef)
         mixName(className)
+      case ComponentResourceTypeRef(className) =>
+        mixTag(TagComponentResourceTypeRef)
+        mixName(className)
       case typeRef: ArrayTypeRef =>
         mixTag(TagArrayTypeRef)
         mixArrayTypeRef(typeRef)
@@ -650,6 +653,10 @@ object Hashers {
 
       case ClassType(className, nullable) =>
         mixTag(if (nullable) TagClassType else TagNonNullClassType)
+        mixName(className)
+
+      case ComponentResourceType(className) =>
+        mixTag(TagComponentResourceType)
         mixName(className)
 
       case ArrayType(arrayTypeRef, nullable) =>

--- a/ir/shared/src/main/scala/org/scalajs/ir/Names.scala
+++ b/ir/shared/src/main/scala/org/scalajs/ir/Names.scala
@@ -429,6 +429,8 @@ object Names {
           }
         case ClassRef(className) =>
           builder.append('L').append(className.nameString)
+        case ComponentResourceTypeRef(className) =>
+          builder.append('L').append(className.nameString)
         case ArrayTypeRef(base, dimensions) =>
           var i = 0
           while (i != dimensions) {

--- a/ir/shared/src/main/scala/org/scalajs/ir/Printers.scala
+++ b/ir/shared/src/main/scala/org/scalajs/ir/Printers.scala
@@ -1178,6 +1178,10 @@ object Printers {
         print(tpe)
       case ClassRef(className) =>
         print(className)
+      case ComponentResourceTypeRef(className) =>
+        print("resource<")
+        print(className)
+        print(">")
       case ArrayTypeRef(base, dims) =>
         print(base)
         for (i <- 1 to dims)
@@ -1207,6 +1211,11 @@ object Printers {
         print(className)
         if (!nullable)
           print("!")
+
+      case ComponentResourceType(className) =>
+        print("resource<")
+        print(className)
+        print(">")
 
       case ArrayType(arrayTypeRef, nullable) =>
         print(arrayTypeRef)

--- a/ir/shared/src/main/scala/org/scalajs/ir/Tags.scala
+++ b/ir/shared/src/main/scala/org/scalajs/ir/Tags.scala
@@ -201,6 +201,10 @@ private[ir] object Tags {
   final val TagClosureType = TagNonNullArrayType + 1
   final val TagNonNullClosureType = TagClosureType + 1
 
+  // New in Component Model support
+
+  final val TagComponentResourceType = TagNonNullClosureType + 1
+
   // Tags for TypeRefs
 
   final val TagVoidRef = 1
@@ -220,6 +224,10 @@ private[ir] object Tags {
   // New in 1.19
 
   final val TagTransientTypeRefHashingOnly = TagArrayTypeRef + 1
+
+  // New in Component Model support
+
+  final val TagComponentResourceTypeRef = TagTransientTypeRefHashingOnly + 1
 
   // Tags for JS native loading specs
 

--- a/ir/shared/src/main/scala/org/scalajs/ir/WellKnownNames.scala
+++ b/ir/shared/src/main/scala/org/scalajs/ir/WellKnownNames.scala
@@ -164,8 +164,6 @@ object WellKnownNames {
     ClassName("scala.scalajs.component.Err")
   final val ComponentVariantValueFieldName: SimpleFieldName =
     SimpleFieldName("value")
-  final val ComponentVariantIndexFieldName: SimpleFieldName =
-    SimpleFieldName("_index")
 
   final val juOptionalClass = ClassName("java.util.Optional")
 }

--- a/library/src/main/scala/scala/scalajs/component/Enum.scala
+++ b/library/src/main/scala/scala/scalajs/component/Enum.scala
@@ -1,6 +1,0 @@
-package scala.scalajs.component
-
-trait Enum extends Variant {
-  type T = Unit
-  val value = ()
-}

--- a/library/src/main/scala/scala/scalajs/component/Result.scala
+++ b/library/src/main/scala/scala/scalajs/component/Result.scala
@@ -1,11 +1,19 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package scala.scalajs.component
 
-sealed trait Result[+A, +B] extends Variant
-final class Ok[A](val value: A) extends Result[A, Nothing] {
-  type T = A
-  val _index: Int = 0
-}
-final class Err[B](val value: B) extends Result[Nothing, B] {
-  type T = B
-  val _index: Int = 1
-}
+sealed trait Result[+A, +B]
+
+final case class Ok[A](val value: A) extends Result[A, Nothing]
+
+final case class Err[B](val value: B) extends Result[Nothing, B]

--- a/library/src/main/scala/scala/scalajs/component/Variant.scala
+++ b/library/src/main/scala/scala/scalajs/component/Variant.scala
@@ -1,7 +1,0 @@
-package scala.scalajs.component
-
-trait Variant {
-  type T
-  val value: T
-  val _index: Int
-}

--- a/library/src/main/scala/scala/scalajs/component/annotation/ComponentVariant.scala
+++ b/library/src/main/scala/scala/scalajs/component/annotation/ComponentVariant.scala
@@ -1,0 +1,49 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
+package scala.scalajs.component.annotation
+
+import scala.annotation.meta._
+
+/** Marks a sealed trait as a WebAssembly Component Model variant type.
+ *
+ *  The sealed trait must have only case classes or case objects as direct
+ *  children. Each case class must have at most one field `value`, and that
+ *  field must be a type compatible with the Component Model.
+ *  Case objects represent variant cases with no payload (unit variants).
+ *
+ *  The order of case declaration determines the discriminant indices assigned
+ *  to each variant case.
+ *
+ *  Example:
+ *  {{{
+ *  @ComponentVariant
+ *  sealed trait Result
+ *  object Result {
+ *    final case class Ok(value: Int) extends Result
+ *    final case class Err(message: String) extends Result
+ *  }
+ *  }}}
+ *
+ *  Example with case object (enum-like):
+ *  {{{
+ *  @ComponentVariant
+ *  sealed trait Status
+ *  object Status {
+ *    case object Pending extends Status
+ *    case object Running extends Status
+ *    case object Done extends Status
+ *  }
+ *  }}}
+ */
+@field @getter @setter
+class ComponentVariant extends scala.annotation.StaticAnnotation

--- a/library/src/main/scala/scala/scalajs/wasi/http/types/ErrorCode.scala
+++ b/library/src/main/scala/scala/scalajs/wasi/http/types/ErrorCode.scala
@@ -51,192 +51,47 @@ import cm.unsigned._
 //   /// between implementations.
 //   internal-error(option<string>)
 // }
-sealed trait ErrorCode extends cm.Variant
+@ComponentVariant
+sealed trait ErrorCode
 object ErrorCode {
-  object DNS_timeout extends ErrorCode {
-    val _index: Int = 0
-    val value = ()
-    type T = Unit
-  }
-
-  class DNSError(val value: DNSErrorPayload) extends ErrorCode {
-    val _index: Int = 1
-    type T = DNSErrorPayload
-  }
-
-  object DestinationNotFound extends ErrorCode {
-    val _index: Int = 2
-    val value = ()
-    type T = Unit
-  }
-
-  object DestinationUnavailable extends ErrorCode {
-    val _index: Int = 3
-    val value = ()
-    type T = Unit
-  }
-
-  object DestinationIPProhibited extends ErrorCode {
-    val _index: Int = 4
-    val value = ()
-    type T = Unit
-  }
-
-  object DestinationIPUnroutable extends ErrorCode {
-    val _index: Int = 5
-    val value = ()
-    type T = Unit
-  }
-
-  object ConnectionRefused extends ErrorCode {
-    val _index: Int = 6
-    val value = ()
-    type T = Unit
-  }
-  object ConnectionTerminated extends ErrorCode {
-    val _index: Int = 7
-    val value = ()
-    type T = Unit
-  }
-  object ConnectionTimeout extends ErrorCode {
-    val _index: Int = 8
-    val value = ()
-    type T = Unit
-  }
-  object ConnectionReadTimeout extends ErrorCode {
-    val _index: Int = 9
-    val value = ()
-    type T = Unit
-  }
-  object ConnectionWriteTimeout extends ErrorCode {
-    val _index: Int = 10
-    val value = ()
-    type T = Unit
-  }
-  object ConnectionLimitReached extends ErrorCode {
-    val _index: Int = 11
-    val value = ()
-    type T = Unit
-  }
-  object TLSProtocolError extends ErrorCode {
-    val _index: Int = 12
-    val value = ()
-    type T = Unit
-  }
-  object TLSCertificateError extends ErrorCode {
-    val _index: Int = 13
-    val value = ()
-    type T = Unit
-  }
-  class TLSAlertReceived(val value: TLSAlertReceivedPayload) extends ErrorCode {
-    val _index: Int = 14
-    type T = TLSAlertReceivedPayload
-  }
-
-  object HTTPRequestDenied extends ErrorCode {
-    val _index: Int = 15
-    val value = ()
-    type T = Unit
-  }
-  object HTTPRequestLengthRequired extends ErrorCode {
-    val _index: Int = 16
-    val value = ()
-    type T = Unit
-  }
-  class HTTPRequestBodySize(val value: Optional[ULong]) extends ErrorCode {
-    val _index: Int = 17
-    type T = Optional[ULong]
-  }
-  object HTTPRequestMethodInvalid extends ErrorCode {
-    val _index: Int = 18
-    val value = ()
-    type T = Unit
-  }
-  object HTTPRequestURIInvalid extends ErrorCode {
-    val _index: Int = 19
-    val value = ()
-    type T = Unit
-  }
-  object HTTPRequestURITooLong extends ErrorCode {
-    val _index: Int = 20
-    val value = ()
-    type T = Unit
-  }
-  class HTTPRequestHeaderSectionSize(val value: Optional[UInt]) extends ErrorCode {
-    val _index: Int = 21
-    type T = Optional[UInt]
-  }
-  class HTTPRequestHeaderSize(val value: Optional[FieldSizePayload]) extends ErrorCode {
-    val _index: Int = 22
-    type T = Optional[FieldSizePayload]
-  }
-  class HTTPRequestTrailerSectionSize(val value: Optional[UInt]) extends ErrorCode {
-    val _index: Int = 23
-    type T = Optional[UInt]
-  }
-  class HTTPRequestTrailerSize(val value: Optional[FieldSizePayload]) extends ErrorCode {
-    val _index: Int = 24
-    type T = Optional[FieldSizePayload]
-  }
-  object HTTPResponseIncomplete extends ErrorCode {
-    val _index: Int = 25
-    val value = ()
-    type T = Unit
-  }
-
-  class HTTPResponseHeaderSectionSize(val value: Optional[UInt]) extends ErrorCode {
-    val _index: Int = 26
-    type T = Optional[UInt]
-  }
-  class HTTPResponseHeaderSize(val value: Optional[FieldSizePayload]) extends ErrorCode {
-    val _index: Int = 27
-    type T = Optional[FieldSizePayload]
-  }
-  class HTTPResponseBodySize(val value: Optional[ULong]) extends ErrorCode {
-    val _index: Int = 28
-    type T = Optional[ULong]
-  }
-  class HTTPResponseTrailerSectionSize(val value: Optional[UInt]) extends ErrorCode {
-    val _index: Int = 29
-    type T = Optional[UInt]
-  }
-  class HTTPResponseTrailerSize(val value: Optional[FieldSizePayload]) extends ErrorCode {
-    val _index: Int = 30
-    type T = Optional[FieldSizePayload]
-  }
-  class HTTPResponseTransferCoding(val value: Optional[String]) extends ErrorCode {
-    val _index: Int = 31
-    type T = Optional[String]
-  }
-  class HTTPResponseContentCoding(val value: Optional[String]) extends ErrorCode {
-    val _index: Int = 32
-    type T = Optional[String]
-  }
-  object HTTPResponseTimeout extends ErrorCode {
-    val _index: Int = 33
-    val value = ()
-    type T = Unit
-  }
-  object HTTPUpgradeFailed extends ErrorCode {
-    val _index: Int = 34
-    val value = ()
-    type T = Unit
-  }
-  object HTTPProtocolError extends ErrorCode {
-    val _index: Int = 35
-    val value = ()
-    type T = Unit
-  }
-  object LoopDetected extends ErrorCode {
-    val _index: Int = 36
-    val value = ()
-    type T = Unit
-  }
-  object ConfigurationError extends ErrorCode {
-    val _index: Int = 37
-    val value = ()
-    type T = Unit
-  }
+  case object DNS_timeout extends ErrorCode
+  final case class DNSError(value: DNSErrorPayload) extends ErrorCode
+  case object DestinationNotFound extends ErrorCode
+  case object DestinationUnavailable extends ErrorCode
+  case object DestinationIPProhibited extends ErrorCode
+  case object DestinationIPUnroutable extends ErrorCode
+  case object ConnectionRefused extends ErrorCode
+  case object ConnectionTerminated extends ErrorCode
+  case object ConnectionTimeout extends ErrorCode
+  case object ConnectionReadTimeout extends ErrorCode
+  case object ConnectionWriteTimeout extends ErrorCode
+  case object ConnectionLimitReached extends ErrorCode
+  case object TLSProtocolError extends ErrorCode
+  case object TLSCertificateError extends ErrorCode
+  final case class TLSAlertReceived(value: TLSAlertReceivedPayload) extends ErrorCode
+  case object HTTPRequestDenied extends ErrorCode
+  case object HTTPRequestLengthRequired extends ErrorCode
+  final case class HTTPRequestBodySize(value: Optional[ULong]) extends ErrorCode
+  case object HTTPRequestMethodInvalid extends ErrorCode
+  case object HTTPRequestURIInvalid extends ErrorCode
+  case object HTTPRequestURITooLong extends ErrorCode
+  final case class HTTPRequestHeaderSectionSize(value: Optional[UInt]) extends ErrorCode
+  final case class HTTPRequestHeaderSize(value: Optional[FieldSizePayload]) extends ErrorCode
+  final case class HTTPRequestTrailerSectionSize(value: Optional[UInt]) extends ErrorCode
+  final case class HTTPRequestTrailerSize(value: Optional[FieldSizePayload]) extends ErrorCode
+  case object HTTPResponseIncomplete extends ErrorCode
+  final case class HTTPResponseHeaderSectionSize(value: Optional[UInt]) extends ErrorCode
+  final case class HTTPResponseHeaderSize(value: Optional[FieldSizePayload]) extends ErrorCode
+  final case class HTTPResponseBodySize(value: Optional[ULong]) extends ErrorCode
+  final case class HTTPResponseTrailerSectionSize(value: Optional[UInt]) extends ErrorCode
+  final case class HTTPResponseTrailerSize(value: Optional[FieldSizePayload]) extends ErrorCode
+  final case class HTTPResponseTransferCoding(value: Optional[String]) extends ErrorCode
+  final case class HTTPResponseContentCoding(value: Optional[String]) extends ErrorCode
+  case object HTTPResponseTimeout extends ErrorCode
+  case object HTTPUpgradeFailed extends ErrorCode
+  case object HTTPProtocolError extends ErrorCode
+  case object LoopDetected extends ErrorCode
+  case object ConfigurationError extends ErrorCode
 
   /** This is a catch-all error for anything that doesn't fit cleanly into a
     * more specific case. It also includes an optional string for an
@@ -244,10 +99,7 @@ object ErrorCode {
     * string for diagnosing errors, as it's not required to be consistent
     * between implementations.
     */
-  class InternalError(val value: Optional[String]) extends ErrorCode {
-    val _index: Int = 38
-    type T = Optional[String]
-  }
+  final case class InternalError(value: Optional[String]) extends ErrorCode
 
 
 

--- a/library/src/main/scala/scala/scalajs/wasi/http/types/HeaderError.scala
+++ b/library/src/main/scala/scala/scalajs/wasi/http/types/HeaderError.scala
@@ -1,25 +1,14 @@
 package scala.scalajs.wasi.http.types
 
-import scala.scalajs.{component => cm}
+import scala.scalajs.component.annotation._
 
 /** This type enumerates the different kinds of errors that may occur when
  *  setting or appending to a `fields` resource.
  */
-sealed trait HeaderError extends cm.Variant
+@ComponentVariant
+sealed trait HeaderError
 object HeaderError {
-  final object InvalidSyntax extends HeaderError {
-    type T = Unit
-    val _index: Int = 0
-    val value = ()
-  }
-  final object Forbidden extends HeaderError {
-    type T = Unit
-    val _index: Int = 1
-    val value = ()
-  }
-  final object Immutable extends HeaderError {
-    type T = Unit
-    val _index: Int = 2
-    val value = ()
-  }
+  case object InvalidSyntax extends HeaderError
+  case object Forbidden extends HeaderError
+  case object Immutable extends HeaderError
 }

--- a/library/src/main/scala/scala/scalajs/wasi/io/Streams.scala
+++ b/library/src/main/scala/scala/scalajs/wasi/io/Streams.scala
@@ -59,17 +59,10 @@ object Streams {
     def close(): Unit = cm.native
   }
 
-  sealed trait StreamError extends cm.Variant
+  @ComponentVariant
+  sealed trait StreamError
   object StreamError {
-    final class LastOperationFailed(val value: WasiIOError) extends StreamError {
-      type T = WasiIOError
-      val _index: Int = 0
-    }
-
-    final object Closed extends StreamError {
-      type T = Unit
-      val value = ()
-      val _index = 1
-    }
+    final case class LastOperationFailed(value: WasiIOError) extends StreamError
+    final case object Closed extends StreamError
   }
 }

--- a/linker/shared/src/main/scala/org/scalajs/linker/analyzer/Infos.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/analyzer/Infos.scala
@@ -248,6 +248,9 @@ object Infos {
           addMethodCalledStatically(ObjectClass,
               NamespacedMethodName(MemberNamespace.Public, method))
 
+        case ComponentResourceType(className) =>
+          addMethodCalled(className, method)
+
         case NullType | NothingType =>
           // Nothing to do
 
@@ -766,10 +769,10 @@ object Infos {
           for (c <- cases) {
             val ctor = wit.makeCtorName(c.tpe)
             builder.addInstantiatedClass(c.className, MethodName.constructor(List(ClassRef(ObjectClass))))
-            // builder.maybeAddReferencedClass(ClassRef(c.className))
-            builder.addFieldRead(FieldName(c.className, ComponentVariantIndexFieldName))
-            builder.addFieldRead(FieldName(c.className, ComponentVariantValueFieldName))
-            generateForWIT(c.tpe)
+            c.tpe.foreach { tpe =>
+              builder.addFieldRead(FieldName(c.className, ComponentVariantValueFieldName))
+              generateForWIT(tpe)
+            }
           }
 
         case wit.VariantType(className, cases) =>
@@ -779,13 +782,14 @@ object Infos {
           for (c <- cases) {
             val ctor = wit.makeCtorName(c.tpe)
             builder.addInstantiatedClass(c.className, ctor)
-            // builder.maybeAddReferencedClass(ClassRef(c.className)) // forClass
-            builder.addFieldRead(FieldName(c.className, ComponentVariantIndexFieldName))
-            builder.addFieldRead(FieldName(c.className, ComponentVariantValueFieldName))
-            generateForWIT(c.tpe)
+            c.tpe.foreach { tpe =>
+              builder.addFieldRead(FieldName(c.className, ComponentVariantValueFieldName))
+              generateForWIT(tpe)
+            }
           }
 
         case wit.ResourceType(className) =>
+          builder.maybeAddReferencedClass(ClassRef(className))
 
         case _ =>
       }

--- a/linker/shared/src/main/scala/org/scalajs/linker/backend/emitter/CoreJSLib.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/backend/emitter/CoreJSLib.scala
@@ -1671,6 +1671,8 @@ private[emitter] object CoreJSLib {
               (globalVar(VarField.ah, ObjectClass).prototype := prototypeFor(ArrayClass)) :: Nil
             case _: PrimRef =>
               clsDef
+            case ComponentResourceTypeRef(_) =>
+              throw new AssertionError(s"Unexpected component resource type in JS backend.")
           }
         }
       }

--- a/linker/shared/src/main/scala/org/scalajs/linker/backend/emitter/NameGen.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/backend/emitter/NameGen.scala
@@ -168,6 +168,8 @@ private[backend] final class NameGen {
             appendTypeRef(base)
           case TransientTypeRef(name) =>
             builder.append('t').append(genName(name))
+          case ComponentResourceTypeRef(className) =>
+            throw new AssertionError(s"Unexpected component resource type ref in JS backend.")
         }
       }
 

--- a/linker/shared/src/main/scala/org/scalajs/linker/backend/emitter/SJSGen.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/backend/emitter/SJSGen.scala
@@ -477,7 +477,8 @@ private[emitter] final class SJSGen(
       case AnyNotNullType => expr !== Null()
 
       case VoidType | NullType | NothingType | AnyType |
-          ClassType(_, true) | ArrayType(_, true) | _:ClosureType | _:RecordType =>
+          ClassType(_, true) | ArrayType(_, true) | _:ClosureType | _:RecordType |
+          _:ComponentResourceType =>
         throw new AssertionError(s"Unexpected type $tpe in genIsInstanceOf")
     }
   }
@@ -551,7 +552,8 @@ private[emitter] final class SJSGen(
           genCallPolyfillableBuiltin(FroundBuiltin, expr)
 
         case VoidType | NullType | NothingType | AnyNotNullType |
-            ClassType(_, false) | ArrayType(_, false) | _:ClosureType | _:RecordType =>
+            ClassType(_, false) | ArrayType(_, false) | _:ClosureType | _:RecordType |
+            _:ComponentResourceType =>
           throw new AssertionError(s"Unexpected type $tpe in genAsInstanceOf")
       }
     } else {
@@ -577,7 +579,8 @@ private[emitter] final class SJSGen(
         case AnyType     => expr
 
         case VoidType | NullType | NothingType | AnyNotNullType |
-            ClassType(_, false) | ArrayType(_, false) | _:ClosureType | _:RecordType =>
+            ClassType(_, false) | ArrayType(_, false) | _:ClosureType | _:RecordType |
+            _:ComponentResourceType =>
           throw new AssertionError(s"Unexpected type $tpe in genAsInstanceOf")
       }
 

--- a/linker/shared/src/main/scala/org/scalajs/linker/backend/emitter/VarGen.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/backend/emitter/VarGen.scala
@@ -233,6 +233,9 @@ private[emitter] final class VarGen(jsGen: JSGen, nameGen: NameGen,
       case ClassRef(className) =>
         implicit val classScope: Scope[ClassName] = Scope.ClassScope
         globalVar(field, className)
+
+      case ComponentResourceTypeRef(_) =>
+        throw new AssertionError(s"Unexpected component resource type in JS backend")
     }
   }
 
@@ -400,13 +403,15 @@ private[emitter] final class VarGen(jsGen: JSGen, nameGen: NameGen,
 
     implicit object NonArrayTypeRefScope extends Scope[NonArrayTypeRef] {
       def subField(x: NonArrayTypeRef): String = x match {
-        case ClassRef(className) => ClassScope.subField(className)
-        case x: PrimRef          => PrimRefScope.subField(x)
+        case ClassRef(className)        => ClassScope.subField(className)
+        case x: PrimRef                 => PrimRefScope.subField(x)
+        case _:ComponentResourceTypeRef => throw new AssertionError(s"Unexpected component resource type")
       }
 
       def reprClass(x: Types.NonArrayTypeRef): Names.ClassName = x match {
-        case ClassRef(className) => ClassScope.reprClass(className)
-        case x: PrimRef          => PrimRefScope.reprClass(x)
+        case ClassRef(className)        => ClassScope.reprClass(className)
+        case x: PrimRef                 => PrimRefScope.reprClass(x)
+        case _:ComponentResourceTypeRef => throw new AssertionError(s"Unexpected component resource type")
       }
     }
   }

--- a/linker/shared/src/main/scala/org/scalajs/linker/backend/wasmemitter/VarGen.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/backend/wasmemitter/VarGen.scala
@@ -476,10 +476,14 @@ object VarGen {
        */
       case object left extends FieldID
     }
+
+    /** Resource handle for Component Model resource type. */
+    final case object handle extends FieldID
   }
 
   object genTypeID {
     final case class forClass(className: ClassName) extends TypeID
+    final case class forResourceClass(className: ClassName) extends TypeID
     final case class captureData(index: Int) extends TypeID
     final case class forVTable(className: ClassName) extends TypeID
     final case class forITable(className: ClassName) extends TypeID

--- a/linker/shared/src/main/scala/org/scalajs/linker/backend/wasmemitter/WasmContext.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/backend/wasmemitter/WasmContext.scala
@@ -120,6 +120,8 @@ final class WasmContext(
         AnyType
       else
         ClassType(className, nullable = true)
+    case ComponentResourceTypeRef(className) =>
+      ComponentResourceType(className)
     case typeRef: ArrayTypeRef =>
       ArrayType(typeRef, nullable = true)
     case typeRef: TransientTypeRef =>
@@ -334,9 +336,6 @@ object WasmContext {
 
     def isInterface: Boolean =
       kind == ClassKind.Interface
-
-    def isWasmComponentResource: Boolean =
-      kind == ClassKind.NativeWasmComponentResourceClass
   }
 
   final class ConcreteMethodInfo(val ownerClass: ClassName, val methodName: MethodName) {

--- a/linker/shared/src/main/scala/org/scalajs/linker/backend/webassembly/component/Flatten.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/backend/webassembly/component/Flatten.scala
@@ -72,7 +72,6 @@ object Flatten {
 
   def flattenType(tpe: wit.ValType): List[watpe.Type] =
     wit.despecialize(tpe) match {
-      case wit.VoidType => Nil
       case wit.BoolType => List(watpe.Int32)
       case wit.U8Type | wit.U16Type | wit.U32Type => List(watpe.Int32)
       case wit.S8Type | wit.S16Type | wit.S32Type => List(watpe.Int32)
@@ -97,8 +96,8 @@ object Flatten {
     private def flattenRecord(t: wit.RecordType): List[watpe.Type] =
       t.fields.flatMap(f => flattenType(f.tpe))
 
-    private def flattenVariant(t: wit.VariantType): List[watpe.Type] = {
-      val variantTypes = t.cases.collect { case wit.CaseType(_, tpe) => tpe }
+    def flattenVariant(t: wit.VariantType): List[watpe.Type] = {
+      val variantTypes = t.cases.flatMap { case wit.CaseType(_, tpe) => tpe }
       List(watpe.Int32) ++ flattenVariants(variantTypes)
     }
 

--- a/linker/shared/src/main/scala/org/scalajs/linker/checker/IRChecker.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/checker/IRChecker.scala
@@ -880,6 +880,7 @@ private final class IRChecker(linkTimeProperties: LinkTimeProperties,
       case ClassRef(className)        => classNameToType(className)
       case arrayTypeRef: ArrayTypeRef => ArrayType(arrayTypeRef, nullable = true)
       case typeRef: TransientTypeRef  => typeRef.tpe
+      case ComponentResourceTypeRef(className) => ComponentResourceType(className)
     }
   }
 

--- a/project/JavalibIRCleaner.scala
+++ b/project/JavalibIRCleaner.scala
@@ -566,10 +566,11 @@ final class JavalibIRCleaner(baseDirectoryURI: URI) {
 
     private def transformTypeRef(typeRef: TypeRef)(
         implicit pos: Position): TypeRef = typeRef match {
-      case typeRef: PrimRef          => typeRef
-      case typeRef: ClassRef         => transformClassRef(typeRef)
-      case typeRef: ArrayTypeRef     => transformArrayTypeRef(typeRef)
-      case typeRef: TransientTypeRef => TransientTypeRef(typeRef.name)(transformType(typeRef.tpe))
+      case typeRef: PrimRef                  => typeRef
+      case typeRef: ClassRef                 => transformClassRef(typeRef)
+      case ComponentResourceTypeRef(className) => ComponentResourceTypeRef(transformClassName(className))
+      case typeRef: ArrayTypeRef             => transformArrayTypeRef(typeRef)
+      case typeRef: TransientTypeRef         => TransientTypeRef(typeRef.name)(transformType(typeRef.tpe))
     }
 
     private def postTransformChecks(classDef: ClassDef): Unit = {
@@ -598,6 +599,8 @@ final class JavalibIRCleaner(baseDirectoryURI: URI) {
           ArrayType(transformArrayTypeRef(arrayTypeRef), nullable)
         case ClosureType(paramTypes, resultType, nullable) =>
           ClosureType(paramTypes.map(transformType(_)), transformType(resultType), nullable)
+        case ComponentResourceType(className) =>
+          ComponentResourceType(transformClassName(className))
         case AnyType | AnyNotNullType | _:PrimType | _:RecordType =>
           tpe
       }


### PR DESCRIPTION
TODO:
- [x] Add tests on Result/Optional, that wraps resources
- [x] Add validations on resource types.
- [x] Add frontend tests on validation.

https://github.com/scala-wasm/scala-wasm/issues/67

This overhauls the representation of Component Model resources and variants.

**New IR Types for Component Resources**

Introduced `ComponentResourceType` and `ComponentResourceTypeRef` to the IR. Previously, resources were represented as `ClassType` with a specific `ComponentResourceClassKind`. This required manual tracking and special-case handling during codegen to convert these classes to `i32` handles. `ComponentResourceType` is now lowered to a struct (e.g., `struct { handle: i32 }`), which allows it to be used as a reference type. The compiler now explicitly handles wrapping/unwrapping between the struct and the raw `i32` handle at component boundaries.

**Annotation-based Variant Implementation**

Switched from a trait-based Variant impl to an annotation-based approach using `@ComponentVariant`. Removed boilerplate fields like `_index` from the `Variant` trait. Users can now define case classes or case objects extending a sealed trait annotated with `@ComponentVariant`. The discriminator index is now automatically generated based on declaration order (ensuring consistent mapping between Scala and WIT).

**Misc**

Removed `VoidType` from WIT types to align with the official WIT specification. Updated unit-valued variants to use `Option[ValType] = None`, and `Result` type to use `Option[ValType]` for both `ok` and `err` cases.