### PR TITLE
Support world level imports and exports

### DIFF
--- a/examples/test-component-model/rust-exports/src/lib.rs
+++ b/examples/test-component-model/rust-exports/src/lib.rs
@@ -6,10 +6,22 @@ use crate::bindings::exports::component::testing::countable::Guest as Countable;
 use crate::bindings::exports::component::testing::basics::Guest as Basics;
 use crate::bindings::exports::component::testing::tests::Guest as Tests;
 use crate::bindings::exports::component::testing::tests::*;
+use crate::bindings::Guest as RootGuest;
 
 use std::cell::RefCell;
 
 struct Component;
+
+// world level function exports - exported directly from the world, not from an interface
+impl RootGuest for Component {
+  fn bare_add(a: i32, b: i32) -> i32 {
+    a + b
+  }
+
+  fn bare_greet(name: String) -> String {
+    format!("Hello, {}!", name)
+  }
+}
 
 impl Basics for Component {
   fn roundtrip_u8(a: u8) -> u8 { a }

--- a/examples/test-component-model/rust-run/src/lib.rs
+++ b/examples/test-component-model/rust-run/src/lib.rs
@@ -4,11 +4,18 @@ mod bindings;
 use crate::bindings::exports::wasi::cli::run::Guest as Run;
 use crate::bindings::component::testing::tests::*;
 use crate::bindings::component::testing::test_imports;
+use crate::bindings::{bare_multiply, bare_uppercase};
 
 struct Component;
 
 impl Run for Component {
     fn run() -> Result<(), ()> {
+      // Test world level function imports (mapped from $root module in core wasm)
+      assert_eq!(bare_multiply(3, 4), 12);
+      assert_eq!(bare_multiply(7, 8), 56);
+      assert_eq!(bare_uppercase("hello"), "HELLO");
+      assert_eq!(bare_uppercase("world"), "WORLD");
+
       test_imports::run();
 
       assert_eq!(

--- a/examples/test-component-model/src/main/scala/componentmodel/RootImpl.scala
+++ b/examples/test-component-model/src/main/scala/componentmodel/RootImpl.scala
@@ -1,0 +1,15 @@
+package componentmodel
+
+import scala.scalajs.wit
+import scala.scalajs.wit.annotation._
+
+import componentmodel.exports.Root
+
+@WitImplementation
+object RootImpl extends Root {
+
+  override def bareMultiply(a: Int, b: Int): Int = a * b
+
+  override def bareUppercase(text: String): String = text.toUpperCase()
+
+}

--- a/examples/test-component-model/src/main/scala/componentmodel/TestImportsImpl.scala
+++ b/examples/test-component-model/src/main/scala/componentmodel/TestImportsImpl.scala
@@ -7,6 +7,7 @@ import scala.scalajs.wit.unsigned._
 import componentmodel.component.testing.basics._
 import componentmodel.component.testing.tests._
 import componentmodel.component.testing.countable._
+import componentmodel.root._
 import componentmodel.exports.component.testing.TestImports
 
 import scala.scalajs.WitUtils.toEither
@@ -18,6 +19,13 @@ object TestImportsImpl extends TestImports {
   override def run(): Unit = {
 
     val start = System.currentTimeMillis()
+
+    // Test world-level function imports
+    assert(5 == bareAdd(2, 3))
+    assert(10 == bareAdd(7, 3))
+    assert("Hello, World!" == bareGreet("World"))
+    assert("Hello, Scala!" == bareGreet("Scala"))
+
     assert(1 == roundtripU8(1))
     assert(0 == roundtripS8(0))
     assert(0 == roundtripU16(0))

--- a/examples/test-component-model/wit/world.wit
+++ b/examples/test-component-model/wit/world.wit
@@ -5,14 +5,26 @@ world scala {
   import tests;
   import countable;
 
+  // world level function imports
+  import bare-add: func(a: s32, b: s32) -> s32;
+  import bare-greet: func(name: string) -> string;
+
   export tests;
   export test-imports;
+
+  // world level function exports
+  export bare-multiply: func(a: s32, b: s32) -> s32;
+  export bare-uppercase: func(text: string) -> string;
 }
 
 world rust-exports {
   export basics;
   export tests;
   export countable;
+
+  // Bare function exports for Rust to implement
+  export bare-add: func(a: s32, b: s32) -> s32;
+  export bare-greet: func(name: string) -> string;
 }
 
 world rust-run {
@@ -20,6 +32,10 @@ world rust-run {
 
   import tests;
   import test-imports;
+
+  // world level function exports
+  import bare-multiply: func(a: s32, b: s32) -> s32;
+  import bare-uppercase: func(text: string) -> string;
 }
 
 interface basics {


### PR DESCRIPTION
```wit
package local:demo;

world my-world {
    import host: interface {
      log: func(param: string);
    }

    export run: func();
}
```

Following wasm-tools convention, world level import has `$root` as namespace like `(import "$root#host" ...)`. World level exports has just a function name like `(export "run" ...)`