### PR TITLE
Fix Object method invocation on WIT Resource instances

### DIFF
--- a/examples/test-component-model/src/main/scala/componentmodel/TestImportsImpl.scala
+++ b/examples/test-component-model/src/main/scala/componentmodel/TestImportsImpl.scala
@@ -149,12 +149,66 @@ object TestImportsImpl extends TestImports {
 
       // val s2 = Counter.sum(c1, c2)
       // assert(s1.valueOf() == s2.valueOf())
-
-      // use c1 multiple times fails with
-      // unknown handle index 1 (?)
+      assert(100 == s1.valueOf())
       // assert(100 == Counter.sum(c1, c2).valueOf())
     }
+
+    // Test Object methods on imported resources
+    TestFunctions.testResourceObjectMethods()
+
     val end = System.currentTimeMillis()
     println(s"elapsed: ${(end - start).toInt} ms")
+  }
+}
+
+object TestFunctions {
+  def testResourceObjectMethods(): Unit = {
+    val c1 = Counter(42)
+    val c2 = Counter(100)
+    val c3 = c1 // same reference
+
+    // Test toString - should return "resource<ClassName>@hashcode"
+    val str1 = c1.toString()
+    assert(str1.startsWith("resource<componentmodel.component.testing.countable.package$Counter>@"))
+    val str2 = c2.toString()
+    val str3 = c3.toString()
+    assert(str1 == str3)
+    assert(str1 != str2)
+    val str4 = s"$c1 + x" // test toStringForConcat
+    assert(str4.startsWith("resource<componentmodel.component.testing.countable.package$Counter>@"))
+
+    // Test hashCode - should be based on handle value
+    val hash1 = c1.hashCode()
+    val hash2 = c2.hashCode()
+    val hash3 = c3.hashCode()
+    assert(hash1 == hash3)
+    assert(hash1 != hash2)
+
+    // Test equals - should use handle-based equality
+    assert(c1.equals(c1))
+    assert(c1.equals(c3))
+    assert(c3.equals(c1))
+    assert(!c1.equals(c2))
+    assert(!c2.equals(c1))
+    assert(!c1.equals(null))
+    assert(!c1.equals("not a counter"))
+    assert(!c1.equals(42))
+
+    assert(c1 == c3)
+    assert(c1 != c2)
+    assert(c2 != c1)
+
+    assert(c1 eq c3)
+    assert(c1 ne c2)
+    assert(c2 ne c1)
+    assert(!(c1 eq c2))
+    assert(!(c1 ne c3))
+
+    val cls1 = c1.getClass()
+    val cls2 = c2.getClass()
+    val cls3 = c3.getClass()
+    assert(cls1 == cls2)
+    assert(cls1 == cls3)
+    assert(cls2 == cls3)
   }
 }

--- a/ir/shared/src/main/scala/org/scalajs/ir/Types.scala
+++ b/ir/shared/src/main/scala/org/scalajs/ir/Types.scala
@@ -516,6 +516,11 @@ object Types {
         isSubnullable(lhsNullable, rhsNullable) &&
         AncestorsOfPseudoArrayClass.contains(className)
 
+      case (WitResourceType(_), ClassType(className, rhsNullable)) =>
+        // WitResourceType is always non-nullable and subtype of ObjectClass.
+        isSubnullable(false, rhsNullable) &&
+        className == ObjectClass
+
       case _ =>
         false
     })

--- a/linker/shared/src/main/scala/org/scalajs/linker/analyzer/Analyzer.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/analyzer/Analyzer.scala
@@ -629,8 +629,12 @@ private class AnalyzerRun(config: CommonPhaseConfig, initial: Boolean,
           }
 
         case NativeWasmComponentResourceClass =>
-          assert(superClass.isEmpty)
-          None
+          superClass match {
+            case Some(superCl) =>
+              _errors ::= InvalidSuperClass(superCl, this, from)
+            case None =>
+          }
+          Some(objectClassInfo)
       }
     }
 

--- a/linker/shared/src/main/scala/org/scalajs/linker/analyzer/Infos.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/analyzer/Infos.scala
@@ -248,8 +248,13 @@ object Infos {
           addMethodCalledStatically(ObjectClass,
               NamespacedMethodName(MemberNamespace.Public, method))
 
-        case WitResourceType(className) =>
-          addMethodCalled(className, method)
+        case WitResourceType(_) =>
+          /* WIT resource types are opaque external types that do not define
+           * standard Java methods themselves. They are all inherited from
+           * j.l.Object, so we handle them the same way as Arrays.
+           */
+          addMethodCalledStatically(ObjectClass,
+              NamespacedMethodName(MemberNamespace.Public, method))
 
         case NullType | NothingType =>
           // Nothing to do

--- a/linker/shared/src/main/scala/org/scalajs/linker/backend/wasmemitter/SWasmGen.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/backend/wasmemitter/SWasmGen.scala
@@ -28,7 +28,11 @@ object SWasmGen {
   def genZeroOf(tpe: Type)(implicit ctx: WasmContext): List[Instr] = {
     tpe match {
       case WitResourceType(className) =>
-        List(I32Const(0), StructNew(genTypeID.forResourceClass(className)))
+        List(
+          GlobalGet(genGlobalID.forVTable(className)), // vtable
+          I32Const(0), // idHashCode (unused, needed for subtyping)
+          I32Const(0), // handle (zero value)
+          StructNew(genTypeID.forResourceClass(className)))
       case _ =>
         List(genZeroOf0(tpe))
     }

--- a/linker/shared/src/main/scala/org/scalajs/linker/backend/wasmemitter/canonicalabi/CABIToScalaJS.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/backend/wasmemitter/canonicalabi/CABIToScalaJS.scala
@@ -145,7 +145,12 @@ object CABIToScalaJS {
 
       case wit.ResourceType(className) =>
         val resourceStructID = genTypeID.forResourceClass(className)
+        val handleLocal = fb.addLocal(NoOriginalName, watpe.Int32)
         fb += wa.I32Load()
+        fb += wa.LocalSet(handleLocal)
+        fb += wa.GlobalGet(genGlobalID.forVTable(className))  // vtable
+        fb += wa.I32Const(0) // idHashCode
+        fb += wa.LocalGet(handleLocal) // handle
         fb += wa.StructNew(resourceStructID)
 
       case variant @ wit.VariantType(className, cases) =>
@@ -224,7 +229,9 @@ object CABIToScalaJS {
         }
 
       case wit.ResourceType(className) =>
-        vi.next(watpe.Int32)
+        fb += wa.GlobalGet(genGlobalID.forVTable(className))  // vtable
+        fb += wa.I32Const(0) // idHashCode
+        vi.next(watpe.Int32) // handle
         fb += wa.StructNew(genTypeID.forResourceClass(className))
 
       case wit.TupleType(fields) =>

--- a/linker/shared/src/main/scala/org/scalajs/linker/backend/wasmemitter/canonicalabi/ScalaJSToCABI.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/backend/wasmemitter/canonicalabi/ScalaJSToCABI.scala
@@ -203,6 +203,7 @@ object ScalaJSToCABI {
 
       case wit.ResourceType(className) =>
         val resourceStructID = genTypeID.forResourceClass(className)
+        fb += wa.RefCast(watpe.RefType(resourceStructID))
         fb += wa.StructGet(resourceStructID, genFieldID.handle)
         fb += wa.I32Store()
 
@@ -225,6 +226,7 @@ object ScalaJSToCABI {
       case wit.ResourceType(className) =>
         // Unwrap: Extract i32 handle from resource struct for stack
         val resourceStructID = genTypeID.forResourceClass(className)
+        fb += wa.RefCast(watpe.RefType(resourceStructID))
         fb += wa.StructGet(resourceStructID, genFieldID.handle)
 
       case tpe: wit.ListType =>

--- a/linker/shared/src/main/scala/org/scalajs/linker/frontend/optimizer/OptimizerCore.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/frontend/optimizer/OptimizerCore.scala
@@ -2235,8 +2235,9 @@ private[optimizer] abstract class OptimizerCore(
             case RefinedType(_: ClassType, exact)         => exact
             case RefinedType(_:PrimType | _:ArrayType, _) => true
             case RefinedType(AnyType | AnyNotNullType, _) => false
+            case RefinedType(_: WitResourceType, _)       => true
 
-            case RefinedType(_:ClosureType | _:RecordType | WitResourceType(_), _) =>
+            case RefinedType(_:ClosureType | _:RecordType, _) =>
               throw new AssertionError(s"Invalid receiver type ${treceiver.tpe} at $pos")
           }
 
@@ -2416,7 +2417,7 @@ private[optimizer] abstract class OptimizerCore(
   private def boxedClassForType(tpe: Type): ClassName = (tpe: @unchecked) match {
     case ClassType(className, _) =>
       className
-    case AnyType | AnyNotNullType | _:ArrayType =>
+    case AnyType | AnyNotNullType | _:ArrayType | _:WitResourceType =>
       ObjectClass
     case tpe: PrimType =>
       PrimTypeToBoxedClass(tpe)

--- a/project/JavalibIRCleaner.scala
+++ b/project/JavalibIRCleaner.scala
@@ -561,6 +561,8 @@ final class JavalibIRCleaner(baseDirectoryURI: URI) {
             ArrayTypeRef(ClassRef(ObjectClass), typeRef.dimensions)
           else
             ArrayTypeRef(ClassRef(transformClassName(baseClassName)), typeRef.dimensions)
+        case WitResourceTypeRef(className) =>
+          ArrayTypeRef(WitResourceTypeRef(transformClassName(className)), typeRef.dimensions)
       }
     }
 


### PR DESCRIPTION
Towards https://github.com/scala-wasm/scala-wasm/issues/156

Resources now use the kinda same Wasm representation as Array instances, it is now subtype of `j.l.Object` that supports Object methods such as `toString`, `hashCode`, `equals`, which didn't work previously.

Component Model resource types were previously represented as simple structs that has only an `i32` handle field. And, as a result:

- Resources could not invoke Object methods (toString, hashCode, equals, etc.)
- Resources were not proper subtypes of j.l.Object at Wasm level
- String concatenation and collections (HashMap, HashSet) didn't work

Resources now extend ObjectStruct at Wasm level using the same Wasm representation as Array instances:

```
Resource struct layout:
  { vtable: ref ObjectVTable, idHashCode: i32, handle: i32 }

Array struct layout:
  { vtable: ref ObjectVTable, idHashCode: i32, underlying: anyref }
```

While most `j.l.Object` methods on resource will be statically dispatched to `j.l.Object` methods, resrouces use custom `hashCode` and `equals` implementations:

- `hashCode` returns the i32 handle value directly.
- `equals` compares handle values, instead of object identity using `idHashCode` field

to ensure Component Model resource semantics, and linker will statically resolve those custom methods on resource instance vtable.