### PR TITLE
Implement java.util.Formatter without JS interop for pure Wasm

### DIFF
--- a/project/Build.scala
+++ b/project/Build.scala
@@ -2362,13 +2362,8 @@ object Build {
                 !endsWith(f, "/lang/ClassValueTest.scala") && // js.Map in ClassValue
 
                 // javalib/util
-                !endsWith(f, "/FormatterTest.scala") &&
                 !endsWith(f, "/DateTest.scala") && // js.Date
                 !endsWith(f, "/PropertiesTest.scala") && // Date.toString
-
-                // javalib/io
-                !endsWith(f, "/io/PrintWriterTest.scala") && // Formatter
-                !endsWith(f, "/io/PrintStreamTest.scala") && // Formatter
 
                 // javalib/net
                 !endsWith(f, "/net/URITest.scala") // URI.normalize

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/lang/StringTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/lang/StringTest.scala
@@ -527,19 +527,16 @@ class StringTest {
   }
 
   @Test def format(): Unit = {
-    assumeFalse("String#format", executingInPureWebAssembly)
-    LinkingInfo.linkTimeIf(!LinkingInfo.targetPureWasm) {
-      assertEquals("5", String.format("%d", new Integer(5)))
-      assertEquals("00005", String.format("%05d", new Integer(5)))
-      assertEquals("0x005", String.format("%0#5x", new Integer(5)))
-      assertEquals("  0x5", String.format("%#5x", new Integer(5)))
-      assertEquals("  0X5", String.format("%#5X", new Integer(5)))
-      assertEquals("  -10", String.format("%5d", new Integer(-10)))
-      assertEquals("-0010", String.format("%05d", new Integer(-10)))
-      assertEquals("fffffffd", String.format("%x", new Integer(-3)))
-      if (!executingInJVM)
-        assertEquals("fffffffc", String.format("%x", new java.lang.Byte(-4.toByte)))
-    } {}
+    assertEquals("5", String.format("%d", new Integer(5)))
+    assertEquals("00005", String.format("%05d", new Integer(5)))
+    assertEquals("0x005", String.format("%0#5x", new Integer(5)))
+    assertEquals("  0x5", String.format("%#5x", new Integer(5)))
+    assertEquals("  0X5", String.format("%#5X", new Integer(5)))
+    assertEquals("  -10", String.format("%5d", new Integer(-10)))
+    assertEquals("-0010", String.format("%05d", new Integer(-10)))
+    assertEquals("fffffffd", String.format("%x", new Integer(-3)))
+    if (!executingInJVM)
+      assertEquals("fffffffc", String.format("%x", new java.lang.Byte(-4.toByte)))
   }
 
   @Test def getBytes(): Unit = {


### PR DESCRIPTION
based on https://github.com/scala-wasm/scala-wasm/pull/164

close https://github.com/scala-wasm/scala-wasm/issues/77

The actual change is https://github.com/scala-wasm/scala-wasm/commit/1a15f3df704788de5dea5e89e0bf5bef4ba612dc

---

This commit removes all JavaScript interop from java.util.Formatter.

- Extended RegExpImpl with position-tracking methods.
- Refactored Formatter to use RegExpImpl to abstract js.RegExp away
- Wrapped sendToDest methods with linkTimeIf
- Replaced js.Dynamic.parseInt with java.lang.Long.parseLong for pure Wasm