### PR TITLE
Add JitPack deployment configuration for temporary releases

### DIFF
--- a/jitpack.yml
+++ b/jitpack.yml
@@ -1,0 +1,14 @@
+# JitPack configuration for scala-wasm
+# See: https://jitpack.io/docs/BUILDING/
+
+jdk:
+  - openjdk11
+
+before_install:
+  - npm install
+
+install:
+  - ./scripts/publish-jitpack.sh
+
+env:
+  SBT_OPTS: "-Xmx4G -Xss8M -XX:+UseG1GC"

--- a/scripts/publish-jitpack.sh
+++ b/scripts/publish-jitpack.sh
@@ -1,0 +1,45 @@
+#!/bin/bash
+set -e
+
+# Only publish for the last 2 Scala 2.12 versions to keep build time reasonable
+SCALA_VERSIONS="2.12.20 2.12.21"
+
+JAVA_LIBS="javalibintf javalib"
+FULL_SCALA_LIBS="compiler jUnitPlugin scalalib"
+JS_LIBS="library irJS linkerInterfaceJS linkerJS testInterface testBridge jUnitRuntime"
+JVM_LIBS="ir linkerInterface linker testAdapter"
+SCALA_LIBS="$JS_LIBS $JVM_LIBS"
+
+SBT_CMD="sbt"
+
+ARGS=""
+for p in $JAVA_LIBS; do
+    if [ -z "$ARGS" ]; then
+        ARGS="$p/publishM2"
+    else
+        ARGS="$ARGS; $p/publishM2"
+    fi
+done
+$SBT_CMD "$ARGS"
+
+# Build for each specific Scala version (2.12.20 and 2.12.21)
+for scala_ver in $SCALA_VERSIONS; do
+    ARGS="++$scala_ver"
+    for p in $FULL_SCALA_LIBS; do
+        ARGS="$ARGS; ${p}2_12/publishM2"
+    done
+    $SBT_CMD "$ARGS"
+done
+
+ARGS=""
+for p in $SCALA_LIBS; do
+    if [ -z "$ARGS" ]; then
+        ARGS="${p}2_12/publishM2"
+    else
+        ARGS="$ARGS; ${p}2_12/publishM2"
+    fi
+done
+$SBT_CMD "$ARGS"
+
+$SBT_CMD "sbtPlugin/publishM2"
+


### PR DESCRIPTION
This commit adds JitPack support for deploying scala-wasm artifacts directly from Github commits/branches.

We can now use scala-wasm from JitPack without local publishing:

```scala
// project/plugins.sbt
// (Replace `<branch>-SNAPSHOT` with any git tag, commit hash).
resolvers += "jitpack" at "https://jitpack.io"
addSbtPlugin("com.github.scala-wasm.scala-wasm" % "sbt-scalajs" % "<branch>-SNAPSHOT")
```

It takes around 4-5 min for the first build. We can check the build logs at https://jitpack.io/#scala-wasm/scala-wasm

This is a temporary deployment solution while the project is under active development. Eventually, we will publish to Maven Central under somewhere like `io.github.scala-wasm` organization for a "stable" releases.