### PR TITLE
Support System properties in pure Wasm using HashMap

### DIFF
--- a/project/Build.scala
+++ b/project/Build.scala
@@ -2363,7 +2363,6 @@ object Build {
 
                 // javalib/lang
                 !endsWith(f, "/lang/ClassValueTest.scala") && // js.Map in ClassValue
-                !endsWith(f, "/lang/SystemPropertiesTest.scala") && // dictionary in SystemProperties
 
                 // javalib/util
                 !endsWith(f, "/FormatterTest.scala") &&


### PR DESCRIPTION
close https://github.com/scala-wasm/scala-wasm/issues/148
towards https://github.com/scala-wasm/scala-wasm/issues/149

Refactor SystemProperties to use platform-specific storage implementations same pattern as PriorityQueue and etc.

- JS target: continues using js.Dictionary
- Wasm target: uses java.util.HashMap instead