### PR TITLE
Use ArrayBuffer instead of WrappedArray for Buffer in pure Wasm

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,7 +77,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        suffix: [2_12] # TODO: test with 2_13 too
+        suffix: [2_12, 2_13]
         esVersion: [ES2015, ES2021] # Some javalib features depend on the target ES version
         eh-support: [true, false]
     env:
@@ -107,7 +107,12 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        suffix: [2_12] # TODO: test with 2_13 too
+        suffix: [2_12, 2_13]
+        include:
+          - suffix: 2_12
+            scalaVersion: "2.12"
+          - suffix: 2_13
+            scalaVersion: "2.13"
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-java@v4
@@ -137,13 +142,8 @@ jobs:
         working-directory: examples/test-component-model/rust-run
       - name: testComponentModel${{ matrix.suffix }}/fastLinkJS
         run: sbt 'set Global/enableWasmEverywhere := true' testComponentModel${{ matrix.suffix }}/fastLinkJS
-      - name: Compose
-        run: |
-          wac plug --plug rust-exports/target/wasm32-wasip1/release/rust_exports.wasm .2.12/target/scala-2.12/testing-module-for-component-model-fastopt/main.wasm -o scala.wasm
-          wac plug --plug scala.wasm rust-run/target/wasm32-wasip1/release/rust_run.wasm -o out.wasm
-        working-directory: examples/test-component-model
-      - name: Run tests
-        run: wasmtime -W function-references,gc,exceptions out.wasm
+      - name: Compose and run tests
+        run: make run SCALA_VERSION=${{ matrix.scalaVersion }}
         working-directory: examples/test-component-model
 
       # echoserver test, check at least it links

--- a/examples/echo-server/Makefile
+++ b/examples/echo-server/Makefile
@@ -1,5 +1,8 @@
+# Scala version: 2.12 or 2.13 (default: 2.13)
+SCALA_VERSION ?= 2.13
+
 run:
-	wasmtime serve -W function-references,gc,exceptions .2.12/target/scala-2.12/echo-fastopt/main.wasm
+	wasmtime serve -W function-references,gc,exceptions .$(SCALA_VERSION)/target/scala-$(SCALA_VERSION)/echo-fastopt/main.wasm
 
 clean:
 	rm -f main.wasm main.wasm

--- a/examples/helloworld-component-model/Makefile
+++ b/examples/helloworld-component-model/Makefile
@@ -1,4 +1,7 @@
-SCALA_MODULE := .2.12/target/scala-2.12/helloworld-component-model-fastopt/main.wasm
+# Scala version: 2.12 or 2.13 (default: 2.13)
+SCALA_VERSION ?= 2.13
+
+SCALA_MODULE := .$(SCALA_VERSION)/target/scala-$(SCALA_VERSION)/helloworld-component-model-fastopt/main.wasm
 RUST_MODULE := rust-greeter/target/wasm32-wasip1/release/rust_greeter.wasm
 OUT := out.wasm
 

--- a/examples/helloworld-wasi/Makefile
+++ b/examples/helloworld-wasi/Makefile
@@ -1,11 +1,14 @@
+# Scala version: 2.12 or 2.13 (default: 2.13)
+SCALA_VERSION ?= 2.13
+
 fetch:
 	wkg wit fetch
 
 opt:
-	wasm-opt .2.12/target/scala-2.12/helloworld-wasi-fastopt/main.wasm --enable-tail-call --enable-multivalue --enable-gc --enable-reference-types --enable-exception-handling --enable-bulk-memory --enable-nontrapping-float-to-int --closed-world --inline-functions-with-loops --traps-never-happen --fast-math --type-ssa -O3 -O3 --gufa -O3 --type-merging -O3 -Oz -o main.wasm
+	wasm-opt .$(SCALA_VERSION)/target/scala-$(SCALA_VERSION)/helloworld-wasi-fastopt/main.wasm --enable-tail-call --enable-multivalue --enable-gc --enable-reference-types --enable-exception-handling --enable-bulk-memory --enable-nontrapping-float-to-int --closed-world --inline-functions-with-loops --traps-never-happen --fast-math --type-ssa -O3 -O3 --gufa -O3 --type-merging -O3 -Oz -o main.wasm
 
 run:
-	wasmtime run -W function-references,gc,exceptions .2.12/target/scala-2.12/helloworld-wasi-fastopt/main.wasm
+	wasmtime run -W function-references,gc,exceptions .$(SCALA_VERSION)/target/scala-$(SCALA_VERSION)/helloworld-wasi-fastopt/main.wasm
 
 run-opt: opt
 	wasmtime run -W function-references,gc,exceptions main.wasm

--- a/examples/test-component-model/Makefile
+++ b/examples/test-component-model/Makefile
@@ -1,3 +1,6 @@
+# Scala version: 2.12 or 2.13 (default: 2.13)
+SCALA_VERSION ?= 2.13
+
 fetch:
 	wkg wit fetch
 
@@ -6,7 +9,7 @@ build:
 	cd rust-run; cargo component build --target wasm32-wasip2 -r
 
 compose:
-	wac plug --plug rust-exports/target/wasm32-wasip1/release/rust_exports.wasm .2.12/target/scala-2.12/testing-module-for-component-model-fastopt/main.wasm -o scala.wasm
+	wac plug --plug rust-exports/target/wasm32-wasip1/release/rust_exports.wasm .$(SCALA_VERSION)/target/scala-$(SCALA_VERSION)/testing-module-for-component-model-fastopt/main.wasm -o scala.wasm
 	wac plug --plug scala.wasm rust-run/target/wasm32-wasip1/release/rust_run.wasm -o out.wasm
 
 run: compose

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -1027,7 +1027,9 @@ object Build {
             javalibInternal, javalib, scalalibInternal, libraryAux, scalalib, library,
             testInterface, jUnitRuntime, testBridge, jUnitPlugin, jUnitAsyncJS,
             jUnitAsyncJVM, jUnitTestOutputsJS, jUnitTestOutputsJVM,
-            helloworld, reversi, testingExample, testSuite, testSuiteJVM,
+            helloworld, helloworldWasm, helloworldWASI, helloworldComponentModel,
+            echoserver, testComponentModel,
+            reversi, testingExample, testSuite, testSuiteJVM,
             javalibExtDummies, testSuiteEx, testSuiteExJVM, testSuiteLinker,
             partest, partestSuite,
             scalaTestSuite

--- a/scalalib/overrides-2.12/scala/collection/mutable/Buffer.scala
+++ b/scalalib/overrides-2.12/scala/collection/mutable/Buffer.scala
@@ -15,6 +15,8 @@ package mutable
 import generic._
 
 import scala.scalajs.js
+import scala.scalajs.LinkingInfo
+import scala.scalajs.LinkingInfo.linkTimeIf
 
 /** Buffers are used to create sequences of elements incrementally by
  *  appending, prepending, or inserting new elements. It is also
@@ -44,7 +46,12 @@ trait Buffer[A] extends Seq[A]
  */
 object Buffer extends SeqFactory[Buffer] {
   implicit def canBuildFrom[A]: CanBuildFrom[Coll, A, Buffer[A]] = ReusableCBF.asInstanceOf[GenericCanBuildFrom[A]]
-  def newBuilder[A]: Builder[A, Buffer[A]] = new js.WrappedArray
+  def newBuilder[A]: Builder[A, Buffer[A]] =
+    linkTimeIf[Builder[A, Buffer[A]]](LinkingInfo.targetPureWasm) {
+      ArrayBuffer.newBuilder[A]
+    } {
+      new js.WrappedArray[A]
+    }
 }
 
 /** Explicit instantiation of the `Buffer` trait to reduce class file size in subclasses. */

--- a/scalalib/overrides-2.13/scala/collection/mutable/Buffer.scala
+++ b/scalalib/overrides-2.13/scala/collection/mutable/Buffer.scala
@@ -14,6 +14,8 @@ package scala.collection
 package mutable
 
 import scala.scalajs.js
+import scala.scalajs.LinkingInfo
+import scala.scalajs.LinkingInfo.linkTimeIf
 
 /** A `Buffer` is a growable and shrinkable `Seq`. */
 trait Buffer[A]
@@ -223,10 +225,22 @@ trait IndexedBuffer[A] extends IndexedSeq[A]
 }
 
 @SerialVersionUID(3L)
-object Buffer extends SeqFactory.Delegate[Buffer](js.WrappedArray)
+object Buffer extends SeqFactory.Delegate[Buffer](
+  linkTimeIf[SeqFactory[Buffer]](LinkingInfo.targetPureWasm) {
+    ArrayBuffer
+  } {
+    js.WrappedArray
+  }
+)
 
 @SerialVersionUID(3L)
-object IndexedBuffer extends SeqFactory.Delegate[IndexedBuffer](js.WrappedArray)
+object IndexedBuffer extends SeqFactory.Delegate[IndexedBuffer](
+  linkTimeIf[SeqFactory[IndexedBuffer]](LinkingInfo.targetPureWasm) {
+    ArrayBuffer
+  } {
+    js.WrappedArray
+  }
+)
 
 /** Explicit instantiation of the `Buffer` trait to reduce class file size in subclasses. */
 @SerialVersionUID(3L)


### PR DESCRIPTION

`Buffer` and `IndexedBuffer` were delegating to `js.WrappedArray`, which uses JS interop.
In pure Wasm, delegate to `ArrayBuffer` instead using linkTimeIf.

This change should enable the 2.13 build.