### PR TITLE
Support Symbol for pure Wasm support

### DIFF
--- a/project/Build.scala
+++ b/project/Build.scala
@@ -2353,13 +2353,8 @@ object Build {
           originalSources
             .filter(f =>
               contains(f, "/shared/src/test/scala-old-collections/") ||
-              contains(f, "/shared/src/test/require-scala2/") && (
-                !endsWith(f, "/scalalib/SymbolTestScala2.scala") // Symbol#JSUniquenessCache
-              ) ||
+              contains(f, "/shared/src/test/require-scala2/") ||
               contains(f, "/shared/src/test/scala/org/scalajs/testsuite/") && (
-                // scalalib
-                !endsWith(f, "/scalalib/SymbolTest.scala") && // Symbol#JSUniquenessCache
-
                 // javalib/lang
                 !endsWith(f, "/lang/ClassValueTest.scala") && // js.Map in ClassValue
 


### PR DESCRIPTION
Use `js.Dictionary` for JS target and `java.util.HashMap` for pure Wasm target in `JSUniquenessCache`

Fixes https://github.com/scala-wasm/scala-wasm/issues/145