### PR TITLE
Improve JS interop error message for targetPureWasm mode

### DIFF
--- a/linker/shared/src/main/scala/org/scalajs/linker/analyzer/Analyzer.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/analyzer/Analyzer.scala
@@ -1428,6 +1428,8 @@ private class AnalyzerRun(config: CommonPhaseConfig, initial: Boolean,
     private val usedJSInPureWasm: Boolean =
       (data.globalFlags & ReachabilityInfo.FlagUsedJSInPureWasm) != 0
 
+    private val jsInteropUsages: Array[(ir.Position, String)] = data.jsInteropUsages
+
     /** Throws MatchError if `!isDefaultBridge`. */
     def defaultBridgeTarget: ClassName = (syntheticKind: @unchecked) match {
       case MethodSyntheticKind.DefaultBridge(target) => target
@@ -1442,7 +1444,7 @@ private class AnalyzerRun(config: CommonPhaseConfig, initial: Boolean,
       _calledFrom ::= from
       if (!_isReachable.getAndSet(true)) {
         if (usedJSInPureWasm)
-          _errors ::= JSInteropInPureWasm(from)
+          _errors ::= JSInteropInPureWasm(jsInteropUsages, from)
 
         _isAbstractReachable.set(true)
         doReach()
@@ -1454,7 +1456,7 @@ private class AnalyzerRun(config: CommonPhaseConfig, initial: Boolean,
 
       if (!_isAbstractReachable.getAndSet(true)) {
         if (usedJSInPureWasm)
-          _errors ::= JSInteropInPureWasm(from)
+          _errors ::= JSInteropInPureWasm(jsInteropUsages, from)
 
         checkExistent()
         _calledFrom ::= from
@@ -1476,7 +1478,7 @@ private class AnalyzerRun(config: CommonPhaseConfig, initial: Boolean,
 
       if (!_isReachable.getAndSet(true)) {
         if (usedJSInPureWasm)
-          _errors ::= JSInteropInPureWasm(from)
+          _errors ::= JSInteropInPureWasm(jsInteropUsages, from)
 
         _isAbstractReachable.set(true)
         doReach()


### PR DESCRIPTION
Previously, when we hit JS interop with targetPureWasm = true, analyzer just says `Uses JS interop with targetPureWasm = true` with the stacktrace. However, there's no information about which JS interop we hit in the message.

Now, when JS interop is used with targetPureWasm = true, the error message now shows the source position and pretty-printed IR of each JS interop usage.

```
Uses JS interop with targetPureWasm = true:
  at file:/.../scala-wasm/library/src/main/scala-old-collections/scala/scalajs/js/WrappedArray.scala:41:35: this.scala$scalajs$js$WrappedArray$$array;Lscala.scalajs.js.Array()["length"]
  dispatched from scala.collection.SeqLike.length()int
  called from scala.collection.SeqLike.size()int
  ...
```

This should make it easier to find what we need to do to support prue Wasm.