### PR TITLE
Prepare publishing to io.github.scala-wasm (`1.21.0-wasm.xx`)

### DIFF
--- a/ir/shared/src/main/scala/org/scalajs/ir/ScalaJSVersions.scala
+++ b/ir/shared/src/main/scala/org/scalajs/ir/ScalaJSVersions.scala
@@ -17,9 +17,11 @@ import java.util.concurrent.ConcurrentHashMap
 import scala.util.matching.Regex
 
 object ScalaJSVersions extends VersionChecks(
-      current = "1.21.0-SNAPSHOT",
+      current = "1.21.0-wasm.2-SNAPSHOT",
       binaryEmitted = "1.20"
-    )
+    ) {
+  final val organization = "io.github.scala-wasm"
+}
 
 /** Helper class to allow for testing of logic. */
 class VersionChecks private[ir] (

--- a/library/src/main/scala/scala/scalajs/WitUtils.scala
+++ b/library/src/main/scala/scala/scalajs/WitUtils.scala
@@ -21,7 +21,7 @@ object WitUtils {
   }
 
   def toOption[A, B](opt: java.util.Optional[A]): Option[A] = {
-    if (opt.isEmpty()) None
-    else Some(opt.get())
+    if (opt.isPresent()) Some(opt.get())
+    else None
   }
 }

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -497,16 +497,16 @@ object Build {
   }
 
   val publishConfigSettings = Seq(
-      organization := "org.scala-js",
+      organization := ir.ScalaJSVersions.organization,
       version := scalaJSVersion,
 
       homepage := Some(url("https://www.scala-js.org/")),
       startYear := Some(2013),
       licenses += (("Apache-2.0", url("https://www.apache.org/licenses/LICENSE-2.0"))),
       scmInfo := Some(ScmInfo(
-          url("https://github.com/scala-js/scala-js"),
-          "scm:git:git@github.com:scala-js/scala-js.git",
-          Some("scm:git:git@github.com:scala-js/scala-js.git"))),
+          url("https://github.com/scala-wasm/scala-wasm"),
+          "scm:git:git@github.com:scala-wasm/scala-wasm.git",
+          Some("scm:git:git@github.com:scala-wasm/scala-wasm.git"))),
 
       publishTo := {
         val centralSnapshots = "https://central.sonatype.com/repository/maven-snapshots/"

--- a/sbt-plugin/src/main/scala/org/scalajs/sbtplugin/ScalaJSJUnitPlugin.scala
+++ b/sbt-plugin/src/main/scala/org/scalajs/sbtplugin/ScalaJSJUnitPlugin.scala
@@ -35,13 +35,13 @@ object ScalaJSJUnitPlugin extends AutoPlugin {
     libraryDependencies ++= {
       if (scalaVersion.value.startsWith("3.")) {
         Seq(
-          "org.scala-js" % "scalajs-junit-test-runtime_2.13" % scalaJSVersion % "test"
+          scalaJSOrganization % "scalajs-junit-test-runtime_2.13" % scalaJSVersion % "test"
         )
       } else {
         Seq(
-          "org.scala-js" % "scalajs-junit-test-plugin" % scalaJSVersion %
+          scalaJSOrganization % "scalajs-junit-test-plugin" % scalaJSVersion %
           "scala-js-test-plugin" cross CrossVersion.full,
-          "org.scala-js" %% "scalajs-junit-test-runtime" % scalaJSVersion % "test"
+          scalaJSOrganization %% "scalajs-junit-test-runtime" % scalaJSVersion % "test"
         )
       }
     },

--- a/sbt-plugin/src/main/scala/org/scalajs/sbtplugin/ScalaJSPlugin.scala
+++ b/sbt-plugin/src/main/scala/org/scalajs/sbtplugin/ScalaJSPlugin.scala
@@ -42,6 +42,8 @@ object ScalaJSPlugin extends AutoPlugin {
     /** The current version of the Scala.js sbt plugin and tool chain. */
     val scalaJSVersion = ScalaJSVersions.current
 
+    val scalaJSOrganization = ScalaJSVersions.organization
+
     /** Declares `Tag`s which may be used to limit the concurrency of build
      *  tasks.
      *
@@ -369,7 +371,7 @@ object ScalaJSPlugin extends AutoPlugin {
           val retrieveDir = s.cacheDirectory / "scalajs-linker" / scalaJSVersion
           val lm = (scalaJSLinkerImpl / dependencyResolution).value
           lm.retrieve(
-              "org.scala-js" % "scalajs-linker_2.12" % scalaJSVersion,
+              scalaJSOrganization % "scalajs-linker_2.12" % scalaJSVersion,
               scalaModuleInfo = None, retrieveDir, log)
             .fold(w => throw w.resolveException, Attributed.blankSeq(_))
         },

--- a/sbt-plugin/src/main/scala/org/scalajs/sbtplugin/ScalaJSPluginInternal.scala
+++ b/sbt-plugin/src/main/scala/org/scalajs/sbtplugin/ScalaJSPluginInternal.scala
@@ -895,21 +895,21 @@ private[sbtplugin] object ScalaJSPluginInternal {
                * (It will also depend on some version of scalajs-scalalib_2.13,
                * but we do not have to worry about that here.)
                */
-              "org.scala-js" % "scalajs-library_2.13" % scalaJSVersion,
-              "org.scala-js" % "scalajs-test-bridge_2.13" % scalaJSVersion % "test"
+              scalaJSOrganization % "scalajs-library_2.13" % scalaJSVersion,
+              scalaJSOrganization % "scalajs-test-bridge_2.13" % scalaJSVersion % "test"
           )
         } else {
           prev ++ Seq(
               compilerPlugin(
-                  "org.scala-js" % "scalajs-compiler" % scalaJSVersion cross CrossVersion.full),
-              "org.scala-js" %% "scalajs-library" % scalaJSVersion,
+                  scalaJSOrganization % "scalajs-compiler" % scalaJSVersion cross CrossVersion.full),
+              scalaJSOrganization %% "scalajs-library" % scalaJSVersion,
               /* scalajs-library depends on some version of scalajs-scalalib,
                * but we want to make sure to bump it to be at least the one
                * of our own `scalaVersion` (which would have back-published in
                * the meantime).
                */
-              "org.scala-js" %% "scalajs-scalalib" % s"$scalaV+$scalaJSVersion",
-              "org.scala-js" %% "scalajs-test-bridge" % scalaJSVersion % "test"
+              scalaJSOrganization %% "scalajs-scalalib" % s"$scalaV+$scalaJSVersion",
+              scalaJSOrganization %% "scalajs-test-bridge" % scalaJSVersion % "test"
           )
         }
       },


### PR DESCRIPTION
Publishing artifacts to Maven so that we can play `scala-wasm` without building from source. Versioning uses pre-release identifier like: `<upstream Scala.js version>-wasm.<digits>`

```scala
resolvers += "Sonatype Central Snapshots" at "https://central.sonatype.com/repository/maven-snapshots/"
addSbtPlugin("io.github.scala-wasm" % "sbt-scalajs" % "1.21.0-wasm.2-SNAPSHOT")
```

Currently publishing from local environment using `./scripts/publish.sh`