### PR TITLE
Insert missing cast for `genUnbox(StringType)` in pure Wasm

### DIFF
--- a/linker/shared/src/main/scala/org/scalajs/linker/backend/wasmemitter/FunctionEmitter.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/backend/wasmemitter/FunctionEmitter.scala
@@ -2760,6 +2760,7 @@ private class FunctionEmitter private (
 
       case StringType =>
         if (targetPureWasm) {
+          fb += wa.RefCast(watpe.RefType.nullable(genTypeID.wasmString))
           val sig = watpe.FunctionType(List(watpe.RefType.nullable(genTypeID.wasmString)),
               List(watpe.RefType(genTypeID.wasmString)))
           fb.block(sig) { nonNullLabel =>

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/compiler/RegressionTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/compiler/RegressionTest.scala
@@ -183,6 +183,16 @@ class RegressionTest {
     assertEquals(null, ref)
   }
 
+  @Test def unboxStringPureWasm(): Unit = {
+    // copied from https://github.com/scala/scala/blob/4d415e3a1b81655b7809581d2e955cb4d882459d/src/library/scala/util/hashing/MurmurHash3.scala#L87
+    def testHashCode(x: Product, seed: Int, caseClassName: String): Int =
+      (if (caseClassName != null) caseClassName else x.productPrefix).hashCode()
+    final case class Mini(value: Int)
+    val h1 = testHashCode(Mini(1), seed = 123, caseClassName = null)
+    val h2 = testHashCode(Mini(1), seed = 123, caseClassName = null)
+    assertEquals(h1, h2)
+  }
+
   @Test def paramDefsInTailrecMethodsAreMutable_Issue825(): Unit = {
     @tailrec
     def foo(x: Int, y: Int): Unit = {


### PR DESCRIPTION
In pure Wasm, `genUnbox(StringType)` was missing the cast from anyref to `(ref null $wasmString)`. (while JS has `extern.convert_any` on unboxing).

As a result, for example in `MurmurHash3.caseClassHash` https://github.com/scala/scala/blob/4d415e3a1b81655b7809581d2e955cb4d882459d/src/library/scala/util/hashing/MurmurHash3.scala#L87 generates invalid Wasm code failed with

```
[CompileError: WebAssembly.instantiate(): Compiling function #13047:"f.scala.util.hashing.MurmurHash3.caseClassHash;..." failed: block[0] expected type (ref null 14), found br_on_null of type (ref any) @+3274141]
```

(where 14 is `$wasmString`)

Thanks @Florian3k for reporting!