### PR TITLE
Grow linear memory in malloc if required

### DIFF
--- a/linker/shared/src/main/scala/org/scalajs/linker/backend/wasmemitter/CoreWasmLib.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/backend/wasmemitter/CoreWasmLib.scala
@@ -973,6 +973,9 @@ final class CoreWasmLib(coreSpec: CoreSpec, globalInfo: LinkedGlobalInfo) {
       val alignment = 8 // max alignment?
 
       val base = fb.addLocal("base", Int32)
+      val requiredEnd = fb.addLocal("requiredEnd", Int32)
+      val currentMemEnd = fb.addLocal("currentMemEnd", Int32)
+      val pagesToGrow = fb.addLocal("pagesToGrow", Int32)
 
       fb += GlobalGet(genGlobalID.stackPointer)
 
@@ -988,9 +991,40 @@ final class CoreWasmLib(coreSpec: CoreSpec, globalInfo: LinkedGlobalInfo) {
       fb += I32Mul
       fb += LocalTee(base)
 
-      fb += LocalGet(nbytes) // newPtr = stackPointer + nbytes
+      fb += LocalGet(nbytes)
       fb += I32Add
+      fb += LocalSet(requiredEnd)
 
+      // Grow linear memory on demand.
+      fb += MemorySize(genMemoryID.memory)
+      fb += I32Const(16)
+      fb += I32Shl // pages -> bytes
+      fb += LocalSet(currentMemEnd)
+
+      fb += LocalGet(requiredEnd)
+      fb += LocalGet(currentMemEnd)
+      fb += I32GtU
+      fb.ifThen() {
+        // ceil((requiredEnd - currentMemEnd) / 65536)
+        fb += LocalGet(requiredEnd)
+        fb += LocalGet(currentMemEnd)
+        fb += I32Sub
+        fb += I32Const(65535)
+        fb += I32Add
+        fb += I32Const(65536)
+        fb += I32DivU
+        fb += LocalSet(pagesToGrow)
+
+        fb += LocalGet(pagesToGrow)
+        fb += MemoryGrow(genMemoryID.memory)
+        fb += I32Const(-1)
+        fb += I32Eq
+        fb.ifThen() {
+          fb += Unreachable
+        }
+      }
+
+      fb += LocalGet(requiredEnd)
       fb += GlobalSet(genGlobalID.stackPointer)
 
       fb += LocalGet(base)

--- a/linker/shared/src/main/scala/org/scalajs/linker/backend/webassembly/BinaryWriter.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/backend/webassembly/BinaryWriter.scala
@@ -579,6 +579,10 @@ private sealed class BinaryWriter(module: Module, emitDebugInfo: Boolean) {
       case MemoryCopy(src, dst) =>
         writeMemoryIdx(src)
         writeMemoryIdx(dst)
+      case MemorySize(memory) =>
+        writeMemoryIdx(memory)
+      case MemoryGrow(memory) =>
+        writeMemoryIdx(memory)
 
       case PositionMark(pos) =>
         throw new AssertionError(s"Unexpected $instr")

--- a/linker/shared/src/main/scala/org/scalajs/linker/backend/webassembly/Instructions.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/backend/webassembly/Instructions.scala
@@ -228,6 +228,8 @@ object Instructions {
   case class I64tore8(arg: MemoryArg = MemoryArg()) extends LoadStoreInstr("i64.store8", 0x3c, arg)
   case class I64tore16(arg: MemoryArg = MemoryArg()) extends LoadStoreInstr("i64.store16", 0x3d, arg)
   case class I64tore32(arg: MemoryArg = MemoryArg()) extends LoadStoreInstr("i64.store32", 0x3e, arg)
+  final case class MemorySize(i: MemoryID) extends Instr("memory.size", 0x3f)
+  final case class MemoryGrow(i: MemoryID) extends Instr("memory.grow", 0x40)
 
   // Literals of primitive numeric types
 

--- a/linker/shared/src/main/scala/org/scalajs/linker/backend/webassembly/TextWriter.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/backend/webassembly/TextWriter.scala
@@ -537,6 +537,10 @@ private class TextWriter(module: Module) {
       case MemoryCopy(src, dst) =>
         appendName(src)
         appendName(dst)
+      case MemorySize(memory) =>
+        appendName(memory)
+      case MemoryGrow(memory) =>
+        appendName(memory)
 
       case PositionMark(_) =>
         throw new AssertionError(s"Unexpected $instr")


### PR DESCRIPTION
Otherwise, when we call a bunch of external functions, it fails due to lack of memory