### PR TITLE
Run wasm components with `sbt run` / ModuleKind.WasmComponent

### DIFF
--- a/linker-interface/shared/src/main/scala/org/scalajs/linker/interface/StandardConfig.scala
+++ b/linker-interface/shared/src/main/scala/org/scalajs/linker/interface/StandardConfig.scala
@@ -203,7 +203,7 @@ final class StandardConfig private (
    *
    *  When using this setting, the following properties must also hold:
    *
-   *  - `moduleKind == ModuleKind.ESModule`
+   *  - `moduleKind == ModuleKind.ESModule || moduleKind == ModuleKind.MinimalWasmModule || moduleKind == ModuleKind.WasmComponent`
    *  - `esFeatures.useECMAScript2015Semantics == true` (true by default)
    *
    *  We may lift these restrictions in the future, although we do not expect

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -408,6 +408,8 @@ object Build {
 
   val previousBinaryCrossVersion = CrossVersion.binaryWith("sjs1_", "")
 
+  val scalaJSJSEnvsVersion: String = "1.4.0-wasmcomponent-SNAPSHOT"
+
   val newScalaBinaryVersionsInThisRelease: Set[String] =
     Set()
 
@@ -1356,8 +1358,8 @@ object Build {
       libraryDependencies ++= Seq(
           "com.google.javascript" % "closure-compiler" % "v20220202",
           "com.google.jimfs" % "jimfs" % "1.1" % "test",
-          "org.scala-js" %% "scalajs-env-nodejs" % "1.4.0" % "test",
-          "org.scala-js" %% "scalajs-js-envs-test-kit" % "1.4.0" % "test"
+          "org.scala-js" %% "scalajs-env-nodejs" % scalaJSJSEnvsVersion % "test",
+          "org.scala-js" %% "scalajs-js-envs-test-kit" % scalaJSJSEnvsVersion % "test"
       ) ++ (
           parallelCollectionsDependencies(scalaVersion.value)
       ),
@@ -1429,7 +1431,7 @@ object Build {
       name := "Scala.js sbt test adapter",
       libraryDependencies ++= Seq(
           "org.scala-sbt" % "test-interface" % "1.0",
-          "org.scala-js" %% "scalajs-js-envs" % "1.4.0",
+          "org.scala-js" %% "scalajs-js-envs" % scalaJSJSEnvsVersion,
           "com.google.jimfs" % "jimfs" % "1.1" % "test",
       ),
       libraryDependencies ++= JUnitDeps,
@@ -1457,8 +1459,9 @@ object Build {
       mimaBinaryIssueFilters ++= BinaryIncompatibilities.SbtPlugin,
 
       addSbtPlugin("org.portable-scala" % "sbt-platform-deps" % "1.0.2"),
-      libraryDependencies += "org.scala-js" %% "scalajs-js-envs" % "1.4.0",
-      libraryDependencies += "org.scala-js" %% "scalajs-env-nodejs" % "1.4.0",
+      libraryDependencies += "org.scala-js" %% "scalajs-js-envs" % scalaJSJSEnvsVersion,
+      libraryDependencies += "org.scala-js" %% "scalajs-env-nodejs" % scalaJSJSEnvsVersion,
+      libraryDependencies += "org.scala-js" %% "scalajs-env-wasmtime" % scalaJSJSEnvsVersion,
 
       scriptedLaunchOpts += "-Dplugin.version=" + version.value,
 
@@ -2860,7 +2863,7 @@ object Build {
 
       resolvers += Resolver.typesafeIvyRepo("releases"),
 
-      libraryDependencies += "org.scala-js" %% "scalajs-env-nodejs" % "1.4.0",
+      libraryDependencies += "org.scala-js" %% "scalajs-env-nodejs" % scalaJSJSEnvsVersion,
 
       fetchScalaSource / artifactPath :=
         baseDirectory.value.getParentFile / "fetchedSources" / scalaVersion.value,

--- a/project/build.sbt
+++ b/project/build.sbt
@@ -14,8 +14,9 @@ libraryDependencies += "com.google.jimfs" % "jimfs" % "1.1"
 
 libraryDependencies += "org.eclipse.jgit" % "org.eclipse.jgit.pgm" % "3.2.0.201312181205-r"
 
-libraryDependencies += "org.scala-js" %% "scalajs-js-envs" % "1.4.0"
-libraryDependencies += "org.scala-js" %% "scalajs-env-nodejs" % "1.4.0"
+libraryDependencies += "org.scala-js" %% "scalajs-js-envs" % "1.4.0-wasmcomponent-SNAPSHOT"
+libraryDependencies += "org.scala-js" %% "scalajs-env-nodejs" % "1.4.0-wasmcomponent-SNAPSHOT"
+libraryDependencies += "org.scala-js" %% "scalajs-env-wasmtime" % "1.4.0-wasmcomponent-SNAPSHOT"
 
 Compile / unmanagedSourceDirectories ++= {
   val root = baseDirectory.value.getParentFile

--- a/sbt-plugin/src/main/scala/org/scalajs/sbtplugin/ScalaJSPlugin.scala
+++ b/sbt-plugin/src/main/scala/org/scalajs/sbtplugin/ScalaJSPlugin.scala
@@ -32,6 +32,7 @@ import org.scalajs.linker.interface._
 
 import org.scalajs.jsenv.{Input, JSEnv}
 import org.scalajs.jsenv.nodejs.NodeJSEnv
+import org.scalajs.jsenv.wasmtime.WasmtimeEnv
 
 object ScalaJSPlugin extends AutoPlugin {
   override def requires: Plugins = plugins.JvmPlugin
@@ -275,6 +276,10 @@ object ScalaJSPlugin extends AutoPlugin {
         "The JavaScript environment in which to run and test Scala.js applications.",
         AMinusTask)
 
+    val wasmEnv = TaskKey[JSEnv]("wasmEnv",
+        "The WebAssembly environment in which to run no-JS Wasm Scala.js applications.",
+        AMinusTask)
+
     /** All Scala.js class names on the fullClasspath, used by scalajsp. */
     val scalaJSClassNamesOnClasspath = TaskKey[Seq[String]]("scalaJSClassNamesOnClasspath",
         "All Scala.js class names on the fullClasspath, used by scalajsp",
@@ -407,6 +412,18 @@ object ScalaJSPlugin extends AutoPlugin {
         },
 
         jsEnv := new NodeJSEnv(),
+
+        wasmEnv := {
+          val configuredEnvVars = envVars.value
+          val config = WasmtimeEnv.Config()
+            .withArgs(List(
+                "run",
+                "-W", "gc,function-references,exceptions",
+                "-S", "cli,inherit-env,inherit-network,tcp"
+            ))
+            .withEnv(configuredEnvVars)
+          new WasmtimeEnv(config)
+        },
 
         scalaJSLoggerFactory := Loggers.sbtLogger2ToolsLogger _,
 

--- a/sbt-plugin/src/main/scala/org/scalajs/sbtplugin/ScalaJSPluginInternal.scala
+++ b/sbt-plugin/src/main/scala/org/scalajs/sbtplugin/ScalaJSPluginInternal.scala
@@ -564,9 +564,11 @@ private[sbtplugin] object ScalaJSPluginInternal {
           case ModuleKind.ESModule       => Input.ESModule(path)
           case ModuleKind.CommonJSModule => Input.CommonJSModule(path)
 
-          case ModuleKind.MinimalWasmModule | ModuleKind.WasmComponent =>
+          case ModuleKind.MinimalWasmModule =>
             // Pretend that we are an ES module for now
             Input.ESModule(path)
+          case ModuleKind.WasmComponent =>
+            Input.WasmComponent((linkerOutputDir / s"${mainModule.moduleID}.wasm").toPath)
         }
       },
 
@@ -609,15 +611,25 @@ private[sbtplugin] object ScalaJSPluginInternal {
       },
 
       run := {
-        if (!scalaJSUseMainModuleInitializer.value) {
+        val linkerConfig = scalaJSLinkerConfig.value
+        val isWasmComponent = linkerConfig.moduleKind == ModuleKind.WasmComponent
+        // Currently, `run` is supported for Wasm Component when it implements `wasi:cli/run`.
+        // We might want to automatiacally implement `wasi:cli/run` that invokes
+        // `scalaJSMainModuleInitializer.value` in future?
+        if (!scalaJSUseMainModuleInitializer.value && !isWasmComponent) {
           throw new MessageOnlyException("`run` is only supported with " +
             "scalaJSUseMainModuleInitializer := true")
         }
-
         val log = streams.value.log
-        val env = jsEnv.value
+        val env = if (isWasmComponent) {
+          wasmEnv.value
+        } else {
+          jsEnv.value
+        }
 
-        val className = mainClass.value.getOrElse("<unknown class>")
+        val className =
+          if (isWasmComponent) "wasi:cli/run"
+          else mainClass.value.getOrElse("<unknown class>")
         log.info(s"Running $className.")
         log.debug(s"with JSEnv ${env.name}")
 


### PR DESCRIPTION
Based on https://github.com/scala-wasm/scala-js-js-envs/pull/1 that adds `WasmtimeEnv` and `Input.WasmComponent`.

We add a new task `wasmEnv` that returns WebAssembly environment to run non-JS Wasm binary. Currently, it returns `WasmtimeEnv` instance by default. `run` task checks if we set `wasmFeatures.targetPureWasm` and `ModuleKind.WasmComponent`, and if they are, we automatically load `wasmEnv` and runs the `Input.WasmComponent`. ComSupport isn't yet supported.

This also removes the `wasmFeatures.componentModel` in favor of `ModuleKind.WasmComponent`.

(BTW, in future, we might want to have another `ModuleKind` for `targetPureWasm` but not targeting Component Model).