### PR TITLE
Don't use js.Map in ClassValue when targeting pure Wasm

### DIFF
--- a/javalib/src/main/scala/java/lang/ClassValue.scala
+++ b/javalib/src/main/scala/java/lang/ClassValue.scala
@@ -17,16 +17,24 @@ import java.util.HashMap
 import scala.scalajs.js
 import scala.scalajs.js.annotation._
 import scala.scalajs.LinkingInfo
-import scala.scalajs.LinkingInfo.ESVersion
+import scala.scalajs.LinkingInfo.{ESVersion, moduleKind}
+import scala.scalajs.LinkingInfo.ModuleKind.{MinimalWasmModule, WasmComponent}
 
 import Utils._
 
 abstract class ClassValue[T] protected () {
   private val jsMap: js.Map[Class[_], T] = {
-    if (LinkingInfo.esVersion >= ESVersion.ES2015 || js.typeOf(js.Dynamic.global.Map) != "undefined")
-      new js.Map()
-    else
+    LinkingInfo.linkTimeIf[js.Map[Class[_], T]](
+        moduleKind == MinimalWasmModule || moduleKind == WasmComponent) {
       null
+    } {
+      if (LinkingInfo.esVersion >= ESVersion.ES2015 ||
+          js.typeOf(js.Dynamic.global.Map) != "undefined") {
+        new js.Map()
+      } else {
+        null
+      }
+    }
   }
 
   @inline
@@ -35,7 +43,11 @@ abstract class ClassValue[T] protected () {
      * emitting ES 2015 code, which allows to dead-code-eliminate the branches
      * using `HashMap`s, and therefore `HashMap` itself.
      */
-    LinkingInfo.esVersion >= ESVersion.ES2015 || jsMap != null
+    LinkingInfo.linkTimeIf(moduleKind == MinimalWasmModule || moduleKind == WasmComponent) {
+      false
+    } {
+      LinkingInfo.esVersion >= ESVersion.ES2015 || jsMap != null
+    }
   }
 
   /* We use a HashMap instead of an IdentityHashMap because the latter is
@@ -49,35 +61,47 @@ abstract class ClassValue[T] protected () {
   protected def computeValue(`type`: Class[_]): T
 
   def get(`type`: Class[_]): T = {
-    if (useJSMap) {
-      mapGetOrElseUpdate(jsMap, `type`)(() => computeValue(`type`))
-    } else {
-      /* We first perform `get`, and if the result is null, we use
-       * `containsKey` to disambiguate a present null from an absent key.
-       * Since the purpose of ClassValue is to be used a cache indexed by Class
-       * values, the expected use case will have more hits than misses, and so
-       * this ordering should be faster on average than first performing `has`
-       * then `get`.
-       */
-      javaMap.get(`type`) match {
-        case null =>
-          if (javaMap.containsKey(`type`)) {
-            null.asInstanceOf[T]
-          } else {
-            val newValue = computeValue(`type`)
-            javaMap.put(`type`, newValue)
-            newValue
-          }
-        case value =>
-          value
+    LinkingInfo.linkTimeIf(moduleKind == MinimalWasmModule || moduleKind == WasmComponent) {
+      getJavaMap(`type`)
+    } {
+      if (useJSMap) {
+        mapGetOrElseUpdate(jsMap, `type`)(() => computeValue(`type`))
+      } else {
+        getJavaMap(`type`)
       }
     }
   }
 
+  private def getJavaMap(`type`: Class[_]): T = {
+    /* We first perform `get`, and if the result is null, we use
+     * `containsKey` to disambiguate a present null from an absent key.
+     * Since the purpose of ClassValue is to be used a cache indexed by Class
+     * values, the expected use case will have more hits than misses, and so
+     * this ordering should be faster on average than first performing `has`
+     * then `get`.
+     */
+    javaMap.get(`type`) match {
+      case null =>
+        if (javaMap.containsKey(`type`)) {
+          null.asInstanceOf[T]
+        } else {
+          val newValue = computeValue(`type`)
+          javaMap.put(`type`, newValue)
+          newValue
+        }
+      case value =>
+        value
+    }
+  }
+
   def remove(`type`: Class[_]): Unit = {
-    if (useJSMap)
-      jsMap.delete(`type`)
-    else
+    LinkingInfo.linkTimeIf[Unit](moduleKind == MinimalWasmModule || moduleKind == WasmComponent) {
       javaMap.remove(`type`)
+    } {
+      if (useJSMap)
+        jsMap.delete(`type`)
+      else
+        javaMap.remove(`type`)
+    }
   }
 }

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -2359,9 +2359,6 @@ object Build {
               contains(f, "/shared/src/test/scala-old-collections/") ||
               contains(f, "/shared/src/test/require-scala2/") ||
               contains(f, "/shared/src/test/scala/org/scalajs/testsuite/") && (
-                // javalib/lang
-                !endsWith(f, "/lang/ClassValueTest.scala") && // js.Map in ClassValue
-
                 // javalib/util
                 !endsWith(f, "/DateTest.scala") && // js.Date
                 !endsWith(f, "/PropertiesTest.scala") && // Date.toString


### PR DESCRIPTION
Add LinkingInfo.targetPureWasm guards to ClassValue so the linker can dead-code-eliminate the js.Map branch for pure Wasm builds, always using HashMap instead.

Enable ClassValueTest in pure Wasm test suite.

Fixes scala-wasm/scala-wasm#147