### PR TITLE
Implement URI for pure Wasm (#151)

### DIFF
--- a/javalib/src/main/scala/java/net/URI.scala
+++ b/javalib/src/main/scala/java/net/URI.scala
@@ -12,14 +12,13 @@
 
 package java.net
 
-import scala.scalajs.js.RegExp
-import scala.scalajs.js
-
 import scala.annotation.tailrec
 
-import java.lang.Utils._
 import java.nio._
 import java.nio.charset.{CodingErrorAction, StandardCharsets}
+import java.{util => ju}
+import java.util.ScalaOps._
+import java.util.regex.RegExpImpl
 
 final class URI(origStr: String) extends Serializable with Comparable[URI] {
 
@@ -32,14 +31,14 @@ final class URI(origStr: String) extends Serializable with Comparable[URI] {
    *  This is a local val for the primary constructor. It is a val,
    *  since we'll set it to null after initializing all fields.
    */
-  private[this] var _fld: RegExp.ExecResult = URI.uriRe.exec(origStr)
-  if (_fld == null)
+  private[this] var _fld = RegExpImpl.impl.exec(URI.uriRe, origStr)
+  if (!RegExpImpl.impl.matches(_fld))
     throw new URISyntaxException(origStr, "Malformed URI")
 
-  private val _isAbsolute = undefOrIsDefined(_fld(AbsScheme))
-  private val _isOpaque = undefOrIsDefined(_fld(AbsOpaquePart))
+  private val _isAbsolute = RegExpImpl.impl.exists(_fld, AbsScheme)
+  private val _isOpaque = RegExpImpl.impl.exists(_fld, AbsOpaquePart)
 
-  @inline private def fld(idx: Int): String = undefOrGetOrNull(_fld(idx))
+  @inline private def fld(idx: Int): String = RegExpImpl.impl.getOrElse(_fld, idx, null)
 
   @inline private def fld(absIdx: Int, relIdx: Int): String =
     if (_isAbsolute) fld(absIdx) else fld(relIdx)
@@ -93,7 +92,7 @@ final class URI(origStr: String) extends Serializable with Comparable[URI] {
   private val _fragment = fld(Fragment)
 
   // End of default ctor. Unset helper field
-  _fld = null
+  _fld = null.asInstanceOf[RegExpImpl.impl.Repr]
 
   def this(scheme: String, ssp: String, fragment: String) =
     this(URI.uriStr(scheme, ssp, fragment))
@@ -217,11 +216,9 @@ final class URI(origStr: String) extends Serializable with Comparable[URI] {
 
   def normalize(): URI = if (_isOpaque || _path == null) this
   else {
-    import js.JSStringOps._
-
     val origPath = _path
 
-    val segments = origPath.jsSplit("/")
+    val segments = origPath.split("/", -1)
 
     // Step 1: Remove all "." segments
     // Step 2: Remove ".." segments preceded by non ".." segment until no
@@ -279,17 +276,13 @@ final class URI(origStr: String) extends Serializable with Comparable[URI] {
       }
     }
 
-    // Truncate `segments` at `outIdx`
-    segments.length = outIdx
-
     // Step 3: If path is relative and first segment contains ":", prepend "."
     // segment (according to JavaDoc). If the path is absolute, the first
     // segment is "" so the `contains(':')` returns false.
-    if (outIdx != 0 && segments(0).contains(":"))
-      segments.unshift(".")
-
-    // Now add all the segments from step 1, 2 and 3
-    val newPath = segments.join("/")
+    val prependDot = outIdx != 0 && segments(0).contains(":")
+    val normalized =
+      ju.Arrays.asList(segments).subList(0, outIdx).scalaOps.mkString("", "/", "")
+    val newPath = if (prependDot) "./" + normalized else normalized
 
     // Only create new instance if anything changed
     if (newPath == origPath)
@@ -437,7 +430,8 @@ object URI {
     // (25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9])           # 2001:db8:3:4::192.0.2.33  64:ff9b::192.0.2.33 (IPv4-Embedded IPv6 Address)
   }
 
-  private val ipv6Re = new RegExp("^" + ipv6address + "$", "i")
+  private val ipv6Re =
+    RegExpImpl.impl.compile("^" + ipv6address + "$", RegExpImpl.Flags.CaseInsensitive)
 
   // URI syntax parser. Based on RFC2396, RFC2732 and adaptations according to
   // JavaDoc.
@@ -586,7 +580,7 @@ object URI {
     // URI-reference = [ absoluteURI | relativeURI ] [ "#" fragment ]
     val uriRef = "^(?:" + absoluteURI + "|" + relativeURI + ")(?:#" + fragment + ")?$"
 
-    new RegExp(uriRef, "i")
+    RegExpImpl.impl.compile(uriRef, RegExpImpl.Flags.CaseInsensitive)
   }
 
   private object Fields {
@@ -643,7 +637,7 @@ object URI {
       resStr += quoteUserInfo(userInfo) + "@"
 
     if (host != null) {
-      if (URI.ipv6Re.test(host))
+      if (RegExpImpl.impl.matches(RegExpImpl.impl.exec(URI.ipv6Re, host)))
         resStr += "[" + host + "]"
       else
         resStr += host
@@ -753,7 +747,8 @@ object URI {
     }
   }
 
-  private val quoteStr: js.Function1[String, String] = { (str: String) =>
+  /** Encode a matched string as percent-encoded UTF-8 bytes. */
+  private def quoteStrFn(str: String): String = {
     val buf = StandardCharsets.UTF_8.encode(str)
 
     var res = ""
@@ -765,39 +760,41 @@ object URI {
     res
   }
 
+  private object QuoteStrMapper extends ju.function.Function[String, String] {
+    def apply(t: String): String = quoteStrFn(t)
+  }
+
   /** matches any character not in unreserved, punct, escaped or other */
-  private val userInfoQuoteRe = new RegExp(
-      // !other = [\u0000-\u00a0\u1680\u2000-\u200a\u202f\u205f\u3000\u2028\u2029]
-      // Char class is: [:!other:^a-z0-9-_.!~*'(),;:$&+=%]
-      "[\u0000- \"#/<>?@\\[-\\^`{-}" +
-      "\u007f-\u00a0\u1680\u2000-\u200a\u202f\u205f\u3000\u2028\u2029]|" +
-      "%(?![0-9a-f]{2})",
-      "ig")
+  private val userInfoQuoteRe = RegExpImpl.impl.compile(
+    // !other = [\u0000-\u00a0\u1680\u2000-\u200a\u202f\u205f\u3000\u2028\u2029]
+    // Char class is: [:!other:^a-z0-9-_.!~*'(),;:$&+=%]
+    "[\u0000- \"#/<>?@\\[-\\^`{-}" +
+    "\u007f-\u00a0\u1680\u2000-\u200a\u202f\u205f\u3000\u2028\u2029]|" +
+    "%(?![0-9a-f]{2})",
+    RegExpImpl.Flags.Global | RegExpImpl.Flags.CaseInsensitive
+  )
 
   /** Quote any character not in unreserved, punct, escaped or other */
-  private def quoteUserInfo(str: String) = {
-    import js.JSStringOps._
-    str.jsReplace(userInfoQuoteRe, quoteStr)
-  }
+  private def quoteUserInfo(str: String): String =
+    RegExpImpl.impl.replaceAll(userInfoQuoteRe, str, QuoteStrMapper)
 
   /** matches any character not in unreserved, punct, escaped, other or equal
    *  to '/' or '@'
    */
-  private val pathQuoteRe = new RegExp(
-      // !other = [\u0000-\u00a0\u1680\u2000-\u200a\u202f\u205f\u3000\u2028\u2029]
-      // Char class is: [:!other:^a-z0-9-_.!~*'(),;:$&+=%@/]
-      "[\u0000- \"#<>?\\[-\\^`{-}" +
-      "\u007f-\u00a0\u1680\u2000-\u200a\u202f\u205f\u3000\u2028\u2029]|" +
-      "%(?![0-9a-f]{2})",
-      "ig")
+  private val pathQuoteRe = RegExpImpl.impl.compile(
+    // !other = [\u0000-\u00a0\u1680\u2000-\u200a\u202f\u205f\u3000\u2028\u2029]
+    // Char class is: [:!other:^a-z0-9-_.!~*'(),;:$&+=%@/]
+    "[\u0000- \"#<>?\\[-\\^`{-}" +
+    "\u007f-\u00a0\u1680\u2000-\u200a\u202f\u205f\u3000\u2028\u2029]|" +
+    "%(?![0-9a-f]{2})",
+    RegExpImpl.Flags.Global | RegExpImpl.Flags.CaseInsensitive
+  )
 
   /** Quote any character not in unreserved, punct, escaped, other or equal
    *  to '/' or '@'
    */
-  private def quotePath(str: String) = {
-    import js.JSStringOps._
-    str.jsReplace(pathQuoteRe, quoteStr)
-  }
+  private def quotePath(str: String): String =
+    RegExpImpl.impl.replaceAll(pathQuoteRe, str, QuoteStrMapper)
 
   /** matches any character not in unreserved, punct, escaped, other or equal
    *  to '@', '[' or ']'
@@ -806,48 +803,45 @@ object URI {
    *  in IPv6 addresses, but technically speaking they are in reserved
    *  due to RFC2732).
    */
-  private val authorityQuoteRe = new RegExp(
-      // !other = [\u0000-\u00a0\u1680\u2000-\u200a\u202f\u205f\u3000\u2028\u2029]
-      // Char class is: [:!other:^a-z0-9-_.!~*'(),;:$&+=%@\[\]]
-      "[\u0000- \"#/<>?\\^`{-}" +
-      "\u007f-\u00a0\u1680\u2000-\u200a\u202f\u205f\u3000\u2028\u2029]|" +
-      "%(?![0-9a-f]{2})",
-      "ig")
+  private[this] lazy val authorityQuoteRe = RegExpImpl.impl.compile(
+    // !other = [\u0000-\u00a0\u1680\u2000-\u200a\u202f\u205f\u3000\u2028\u2029]
+    // Char class is: [:!other:^a-z0-9-_.!~*'(),;:$&+=%@\[\]]
+    "[\u0000- \"#/<>?\\^`{-}" +
+    "\u007f-\u00a0\u1680\u2000-\u200a\u202f\u205f\u3000\u2028\u2029]|" +
+    "%(?![0-9a-f]{2})",
+    RegExpImpl.Flags.Global | RegExpImpl.Flags.CaseInsensitive
+  )
 
   /** Quote any character not in unreserved, punct, escaped, other or equal
    *  to '@'
    */
-  private def quoteAuthority(str: String) = {
-    import js.JSStringOps._
-    str.jsReplace(authorityQuoteRe, quoteStr)
-  }
+  private def quoteAuthority(str: String): String =
+    RegExpImpl.impl.replaceAll(authorityQuoteRe, str, QuoteStrMapper)
 
   /** matches any character not in unreserved, reserved, escaped or other */
-  private val illegalQuoteRe = new RegExp(
-      // !other = [\u0000-\u00a0\u1680\u2000-\u200a\u202f\u205f\u3000\u2028\u2029]
-      // Char class is: [:!other:^a-z0-9-_.!~*'(),;:$&+=?/\\[\\]%]
-      "[\u0000- \"#<>@\\^`{-}" +
-      "\u007f-\u00a0\u1680\u2000-\u200a\u202f\u205f\u3000\u2028\u2029]|" +
-      "%(?![0-9a-f]{2})",
-      "ig")
+  private val illegalQuoteRe = RegExpImpl.impl.compile(
+    // !other = [\u0000-\u00a0\u1680\u2000-\u200a\u202f\u205f\u3000\u2028\u2029]
+    // Char class is: [:!other:^a-z0-9-_.!~*'(),;:$&+=?/\\[\\]%]
+    "[\u0000- \"#<>@\\^`{-}" +
+    "\u007f-\u00a0\u1680\u2000-\u200a\u202f\u205f\u3000\u2028\u2029]|" +
+    "%(?![0-9a-f]{2})",
+    RegExpImpl.Flags.Global | RegExpImpl.Flags.CaseInsensitive
+  )
 
   /** Quote any character not in unreserved, reserved, escaped or other */
-  private def quoteIllegal(str: String) = {
-    import js.JSStringOps._
-    str.jsReplace(illegalQuoteRe, quoteStr)
-  }
+  private def quoteIllegal(str: String): String =
+    RegExpImpl.impl.replaceAll(illegalQuoteRe, str, QuoteStrMapper)
 
   /** matches characters not in ASCII
    *
    *  Note: It is important that the match is maximal, since we might encounter
    *  surrogates that need to be encoded in one shot.
    */
-  private val nonASCIIQuoteRe = new RegExp("[^\u0000-\u007F]+", "g")
+  private val nonASCIIQuoteRe =
+    RegExpImpl.impl.compile("[^\u0000-\u007F]+", RegExpImpl.Flags.Global)
 
-  private def quoteNonASCII(str: String) = {
-    import js.JSStringOps._
-    str.jsReplace(nonASCIIQuoteRe, quoteStr)
-  }
+  private def quoteNonASCII(str: String): String =
+    RegExpImpl.impl.replaceAll(nonASCIIQuoteRe, str, QuoteStrMapper)
 
   /** Case-insensitive comparison that accepts `null` values.
    *

--- a/javalib/src/main/scala/java/util/regex/RegExpImpl.scala
+++ b/javalib/src/main/scala/java/util/regex/RegExpImpl.scala
@@ -29,6 +29,7 @@ private[java] sealed abstract class RegExpImpl {
 
   def compile(patternStr: String): PatRepr
   def compile(patternStr: String, global: Boolean): PatRepr
+  def compile(patternStr: String, flags: Int): PatRepr
   def exec(pattern: PatRepr, string: String): Repr
   def matches(r: Repr): Boolean
   def exists(r: Repr, index: Int): Boolean
@@ -37,9 +38,20 @@ private[java] sealed abstract class RegExpImpl {
   def execFrom(pattern: PatRepr, string: String, startPos: Int): Repr
   def matchStart(r: Repr): Int
   def matchEnd(pattern: PatRepr, r: Repr): Int
+
+  def replaceAll(
+      pattern: PatRepr,
+      string: String,
+      replacer: java.util.function.Function[String, String]
+  ): String
 }
 
 private[java] object RegExpImpl {
+  object Flags {
+    final val Global = 0x01
+    final val CaseInsensitive = 0x02
+  }
+
   val impl = LinkingInfo.linkTimeIf[RegExpImpl](
       moduleKind == MinimalWasmModule || moduleKind == WasmComponent) {
     JavaRegExpImpl
@@ -59,6 +71,14 @@ private[java] object RegExpImpl {
     def compile(patternStr: String, global: Boolean): PatRepr = {
       if (global) new js.RegExp(patternStr, "g")
       else new js.RegExp(patternStr)
+    }
+
+    def compile(patternStr: String, flags: Int): PatRepr = {
+      val jsFlags = {
+        (if ((flags & Flags.Global) != 0) "g" else "") +
+        (if ((flags & Flags.CaseInsensitive) != 0) "i" else "")
+      }
+      new js.RegExp(patternStr, jsFlags)
     }
 
     def exec(pattern: PatRepr, string: String): Repr = pattern.exec(string)
@@ -83,6 +103,20 @@ private[java] object RegExpImpl {
       if (r == null) -1
       else pattern.lastIndex
     }
+
+    def replaceAll(
+        pattern: PatRepr,
+        string: String,
+        replacer: java.util.function.Function[String, String]
+    ): String = {
+      import js.JSStringOps._
+      if (!pattern.global)
+        throw new IllegalArgumentException("replaceAll requires a global pattern")
+      val jsFunc: js.Function1[String, String] = { (matched: String) =>
+        replacer.apply(matched)
+      }
+      string.jsReplace(pattern, jsFunc)
+    }
   }
 
   private object JavaRegExpImpl extends RegExpImpl {
@@ -91,6 +125,14 @@ private[java] object RegExpImpl {
 
     def compile(patternStr: String): PatRepr = Pattern.compile(patternStr)
     def compile(patternStr: String, global: Boolean): PatRepr = Pattern.compile(patternStr)
+
+    def compile(patternStr: String, flags: Int): PatRepr = {
+      var patFlags = 0
+      if ((flags & Flags.CaseInsensitive) != 0)
+        patFlags |= Pattern.CASE_INSENSITIVE
+      Pattern.compile(patternStr, patFlags)
+    }
+
     def exec(pattern: PatRepr, string: String): Repr = pattern.matcher(string)
     def matches(r: Repr): Boolean = r.matches()
     def exists(r: Repr, index: Int): Boolean = r.group(index) != null
@@ -114,6 +156,16 @@ private[java] object RegExpImpl {
     def matchEnd(pattern: PatRepr, r: Repr): Int = {
       if (r == null) -1
       else r.end()
+    }
+
+    def replaceAll(
+        pattern: PatRepr,
+        string: String,
+        replacer: java.util.function.Function[String, String]
+    ): String = {
+      pattern.matcher(string).replaceAll(new java.util.function.Function[MatchResult, String] {
+        def apply(result: MatchResult): String = replacer.apply(result.group())
+      })
     }
   }
 }

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -2361,10 +2361,8 @@ object Build {
               contains(f, "/shared/src/test/scala/org/scalajs/testsuite/") && (
                 // javalib/util
                 !endsWith(f, "/DateTest.scala") && // js.Date
-                !endsWith(f, "/PropertiesTest.scala") && // Date.toString
+                !endsWith(f, "/PropertiesTest.scala") // Date.toString
 
-                // javalib/net
-                !endsWith(f, "/net/URITest.scala") // URI.normalize
               ) ||
               contains(f, "/js/src/test/scala/org/scalajs/testsuite/") && (
                 // compiler

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/net/URITest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/net/URITest.scala
@@ -474,4 +474,55 @@ class URITest {
     assertTrue("SSP case-sensitive", new URI("mailto:john") != new URI("mailto:JOHN"))
     assertTrue(new URI("mailto:john") != new URI("MAILTO:jim"))
   }
+
+  // Tests for multi-component constructors, normalize edge cases, and
+  // non-ASCII quoting. These exercise quoting/parsing code paths that
+  // were previously not covered by the test suite.
+
+  @Test def multiComponentConstructorQuoting(): Unit = {
+    // 7-arg constructor exercises quoteUserInfo, quotePath, quoteAuthority
+    val uri = new URI("http", "us er", "example.com", 80, "/a path", "q=1 2", "frag ment")
+    assertEquals("http", uri.getScheme())
+    assertEquals("example.com", uri.getHost())
+    assertEquals(80, uri.getPort())
+    assertEquals("/a path", uri.getPath())
+    assertEquals("q=1 2", uri.getQuery())
+    assertEquals("frag ment", uri.getFragment())
+    assertEquals("us er", uri.getUserInfo())
+    // Raw forms should have spaces percent-encoded
+    assertEquals("/a%20path", uri.getRawPath())
+    assertEquals("q=1%202", uri.getRawQuery())
+    assertEquals("frag%20ment", uri.getRawFragment())
+    assertEquals("us%20er", uri.getRawUserInfo())
+  }
+
+  @Test def multiComponentConstructorWithIPv6Host(): Unit = { // exercises IPv6 detection
+    val uri = new URI("http", null, "::1", 8080, "/path", null, null)
+    assertEquals("[::1]", uri.getHost())
+    assertEquals(8080, uri.getPort())
+    assertEquals("/path", uri.getPath())
+    assertTrue(uri.toString().contains("[::1]"))
+  }
+
+  @Test def threeArgConstructorQuoting(): Unit = { // exercises quoteIllegal
+    val uri = new URI("foo", "hello world", "frag ment")
+    assertEquals("foo", uri.getScheme())
+    assertEquals("hello world", uri.getSchemeSpecificPart())
+    assertEquals("frag ment", uri.getFragment())
+    assertEquals("hello%20world", uri.getRawSchemeSpecificPart())
+    assertEquals("frag%20ment", uri.getRawFragment())
+  }
+
+  @Test def normalizeDotOnlyPaths(): Unit = {
+    // Dot-only relative paths (not covered by RFC resolve examples above)
+    assertEquals("", new URI(".").normalize().getPath())
+    assertEquals("", new URI("./").normalize().getPath())
+    assertEquals("..", new URI("..").normalize().getPath())
+    assertEquals("../", new URI("../").normalize().getPath())
+  }
+
+  @Test def normalizeEmptySegments(): Unit = {
+    // Multiple consecutive slashes produce empty segments
+    assertEquals("/a/b", new URI("/a///b").normalize().getPath())
+  }
 }


### PR DESCRIPTION
Add linkTimeIf branches for all JS-dependent operations in URI:
- URI parsing: js.RegExp.exec() → java.util.regex.Pattern
- Path normalization: js.Array + .join() → Scala Array + StringBuilder
- IPv6 detection: js.RegExp.test() → java.util.regex.Pattern
- Quoting (5 functions): jsReplace(regex, callback) → quoteWithPattern()
- UTF-8 percent-encoding: pure Scala via StandardCharsets.UTF_8

Remove top-level vals with JS types (RegExp, js.Function1) to avoid linker errors; inline them into linkTimeIf JS branches instead.

Unblock URITest in pure Wasm test suite. Add 6 new tests covering multi-component quoting, IPv6, normalize edge cases, and non-ASCII.