### PR TITLE
Fix array of resource

### DIFF
--- a/examples/test-component-model/src/main/scala/componentmodel/TestImportsImpl.scala
+++ b/examples/test-component-model/src/main/scala/componentmodel/TestImportsImpl.scala
@@ -17,6 +17,8 @@ import java.util.Optional
 @WitImplementation
 object TestImportsImpl extends TestImports {
   override def run(): Unit = {
+    def newCounterArray(size: Int): Array[Counter] =
+      new Array[Counter](size)
 
     val start = System.currentTimeMillis()
 
@@ -61,6 +63,15 @@ object TestImportsImpl extends TestImports {
 
     val arr3 = Array[C1](C1.A(0), C1.B(3))
     assert(arr3.sameElements(roundtripListVariant(arr3)))
+
+    val counter1 = Counter(1)
+    val counter2 = Counter(2)
+    val counterArr = newCounterArray(2)
+    assert(counterArr.length == 2)
+    counterArr(0) = counter1
+    counterArr(1) = counter2
+    assert(counterArr(0).valueOf() == 1)
+    assert(counterArr(1).valueOf() == 2)
 
     assert("foo" == roundtripString("foo"))
     assert("" == roundtripString(""))

--- a/ir/shared/src/main/scala/org/scalajs/ir/Types.scala
+++ b/ir/shared/src/main/scala/org/scalajs/ir/Types.scala
@@ -548,6 +548,8 @@ object Types {
                  * Object in their ancestors.
                  */
                 rhsBaseName == ObjectClass || isSubclass(lhsBaseName, rhsBaseName)
+              case (WitResourceTypeRef(lhsBaseName), WitResourceTypeRef(rhsBaseName)) =>
+                lhsBaseName == rhsBaseName
               case _ =>
                 lhsBase eq rhsBase
             }

--- a/linker/shared/src/main/scala/org/scalajs/linker/backend/wasmemitter/ClassEmitter.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/backend/wasmemitter/ClassEmitter.scala
@@ -592,7 +592,7 @@ class ClassEmitter(coreSpec: CoreSpec) {
       ) ::: (
         strictAncestorsTypeData // strictAncestors
       ) ::: List(
-        wa.GlobalGet(genGlobalID.forVTable(baseTypeRef)), // componentType
+        wa.GlobalGet(nonArrayTypeDataGlobalID(baseTypeRef)), // componentType
         wa.RefNull(watpe.HeapType.None), // classOf
         wa.RefNull(watpe.HeapType.None), // arrayOf
         wa.RefFunc(genFunctionID.cloneArray(baseTypeRef)), // clone

--- a/linker/shared/src/main/scala/org/scalajs/linker/backend/wasmemitter/SWasmGen.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/backend/wasmemitter/SWasmGen.scala
@@ -25,6 +25,14 @@ import org.scalajs.linker.backend.webassembly.Identitities.LocalID
 /** Scala.js-specific Wasm generators that are used across the board. */
 object SWasmGen {
 
+  def nonArrayTypeDataGlobalID(typeRef: NonArrayTypeRef) = typeRef match {
+    case WitResourceTypeRef(className) =>
+      // Resource classes currently share the class-backed typeData/vtable global.
+      genGlobalID.forVTable(className)
+    case _ =>
+      genGlobalID.forVTable(typeRef)
+  }
+
   def genZeroOf(tpe: Type)(implicit ctx: WasmContext): List[Instr] = {
     tpe match {
       case WitResourceType(className) =>
@@ -83,7 +91,7 @@ object SWasmGen {
   }
 
   def genLoadNonArrayTypeData(fb: FunctionBuilder, typeRef: NonArrayTypeRef): Unit =
-    fb += GlobalGet(genGlobalID.forVTable(typeRef))
+    fb += GlobalGet(nonArrayTypeDataGlobalID(typeRef))
 
   def genLoadArrayTypeData(fb: FunctionBuilder, arrayTypeRef: ArrayTypeRef): Unit = {
     val ArrayTypeRef(base, dimensions) = arrayTypeRef


### PR DESCRIPTION
fix https://github.com/scala-wasm/scala-wasm/issues/198

Fix the remaining special-case handling needed for `Array[resource]` in the Wasm backend so the component-model example can allocate and use arrays of resource values.

This is a kind of monkey patch. `WitResourceTypeRef` still does not behave enough like a normal class type, so we need a resource-specific branch in the array subtype / type-data path for now.

The real fix is to make resource types behave more like regular classes. (make resourcs `final class` with some restrictions in class hierarchy, and make it `ClassType` and `ClassRef`).
Once we do that, this special-case logic should become unnecessary and can be removed.