### PR TITLE
Refactor: retrieve WIT type information from symbols in `exitingPhase(typerPhase)`

### DIFF
--- a/compiler/src/main/scala/org/scalajs/nscplugin/GenJSCode.scala
+++ b/compiler/src/main/scala/org/scalajs/nscplugin/GenJSCode.scala
@@ -696,7 +696,7 @@ abstract class GenJSCode[G <: Global with Singleton](val global: G)
           val info = jsInterop.witExportOf(dd.symbol).get
           for (method <- genMethod(dd)) {
             methodsBuilder += method
-            witExportDefsBuilder += genWitExportDef(info, method)
+            witExportDefsBuilder += genWitExportDef(info, dd.symbol, method)
           }
         } else {
           methodsBuilder ++= genMethod(dd)

--- a/compiler/src/main/scala/org/scalajs/nscplugin/GenWitInterop.scala
+++ b/compiler/src/main/scala/org/scalajs/nscplugin/GenWitInterop.scala
@@ -134,8 +134,8 @@ trait GenWitInterop[G <: Global with Singleton] extends SubComponent {
     implicit val pos = tree.pos
     val sym = tree.symbol
     withNewLocalNameScope {
-      val funcType = jsInterop.witFunctionTypeOf(sym)
-      val baseParams = funcType.params.map(toWIT(_))
+      val (paramTypes, resultType) = witMethodSignatureOf(sym)
+      val baseParams = paramTypes.map(toWIT(_))
       val params = name match {
         case _:js.WitFunctionName.Function |
             _:js.WitFunctionName.ResourceConstructor |
@@ -146,7 +146,7 @@ trait GenWitInterop[G <: Global with Singleton] extends SubComponent {
       }
       val witFuncType = wit.FuncType(
         params,
-        toResultWIT(funcType.resultType)
+        toResultWIT(resultType)
       )
       js.WitNativeMemberDef(flags, moduleName, name,
           encodeMethodSym(sym), witFuncType)
@@ -158,8 +158,7 @@ trait GenWitInterop[G <: Global with Singleton] extends SubComponent {
     val sym = tree.symbol
 
     val flags = js.MemberFlags.empty.withNamespace(js.MemberNamespace.PublicStatic)
-    val funcType = jsInterop.witFunctionTypeOf(sym)
-
+    val (paramTypes, resultType) = witMethodSignatureOf(sym)
     for {
       methodAnnot <- sym.getAnnotation(WitResourceStaticMethodAnnotation)
       resourceAnnot <- sym.owner.companionClass.getAnnotation(WitResourceImportAnnotation)
@@ -170,8 +169,8 @@ trait GenWitInterop[G <: Global with Singleton] extends SubComponent {
       val name = js.WitFunctionName.ResourceStaticMethod(
           func = methodName, resource = resourceName)
       withNewLocalNameScope {
-        val params = funcType.params.map(p => toWIT(p))
-        val ft = wit.FuncType(params, toResultWIT(funcType.resultType))
+        val params = paramTypes.map(toWIT(_))
+        val ft = wit.FuncType(params, toResultWIT(resultType))
         js.WitNativeMemberDef(flags, moduleName, name, encodeMethodSym(sym), ft)
       }
     }
@@ -182,7 +181,7 @@ trait GenWitInterop[G <: Global with Singleton] extends SubComponent {
     val sym = tree.symbol
 
     val flags = js.MemberFlags.empty.withNamespace(js.MemberNamespace.PublicStatic)
-    val funcType = jsInterop.witFunctionTypeOf(sym)
+    val (paramTypes, resultType) = witMethodSignatureOf(sym)
 
     for {
       methodAnnot <- sym.getAnnotation(WitResourceConstructorAnnotation)
@@ -192,19 +191,20 @@ trait GenWitInterop[G <: Global with Singleton] extends SubComponent {
     } yield {
       val name = js.WitFunctionName.ResourceConstructor(resourceName)
       withNewLocalNameScope {
-        val params = funcType.params.map(p => toWIT(p))
-        val ft = wit.FuncType(params, toResultWIT(funcType.resultType))
+        val params = paramTypes.map(toWIT(_))
+        val ft = wit.FuncType(params, toResultWIT(resultType))
         js.WitNativeMemberDef(flags, moduleName, name, encodeMethodSym(sym), ft)
       }
     }
   }
 
-  def genWitExportDef(info: jsInterop.WitExportInfo,
+  def genWitExportDef(info: jsInterop.WitExportInfo, sym: Symbol,
       methodDef: js.MethodDef): js.WitExportDef = {
     withNewLocalNameScope {
+      val (paramTypes, resultType) = witMethodSignatureOf(sym)
       val signature = wit.FuncType(
-        info.signature.params.map(toWIT(_)),
-        toResultWIT(info.signature.resultType)
+        paramTypes.map(toWIT(_)),
+        toResultWIT(resultType)
       )
       js.WitExportDef(
         info.moduleName,
@@ -215,15 +215,46 @@ trait GenWitInterop[G <: Global with Singleton] extends SubComponent {
     }
   }
 
+  private def witMethodSignatureOf(sym: Symbol): (List[Type], Type) = {
+    exitingPhase(currentRun.typerPhase) {
+      val methodType = sym.tpe
+      val params =
+        if (methodType.paramss.isEmpty) Nil
+        else methodType.paramss.head.map(_.tpe)
+      (params, methodType.resultType)
+    }
+  }
+
+  private def witVariantValueTypeOf(sym: Symbol): Type = {
+    exitingPhase(currentRun.typerPhase) {
+      if (sym.isModuleClass) {
+        UnitTpe
+      } else if (sym.isClass && sym.isFinal && !sym.isTrait) {
+        sym.primaryConstructor.paramss.flatten match {
+          case Nil =>
+            UnitTpe
+          case param :: Nil =>
+            param.tpe
+          case _ =>
+            throw new AssertionError(s"Invalid WIT variant case shape for $sym")
+        }
+      } else {
+        throw new AssertionError(s"Invalid WIT variant case symbol $sym")
+      }
+    }
+  }
+
   private def toWIT(tpe: Type): wit.ValType = {
-    unsigned2WIT.get(tpe.typeSymbolDirect).orElse {
-      toWITMaybeArray(tpe.dealiasWiden)
+    val widenedTpe = exitingPhase(currentRun.typerPhase)(tpe.dealiasWiden)
+
+    unsigned2WIT.get(widenedTpe.typeSymbolDirect).orElse {
+      toWITMaybeArray(widenedTpe)
     }.orElse {
-      primitiveIRWIT.get(toIRType(tpe.dealiasWiden))
+      primitiveIRWIT.get(toIRType(widenedTpe))
     }.getOrElse {
-      tpe.dealiasWiden.typeSymbol match {
+      widenedTpe.typeSymbol match {
         case tsym if isWasmComponentTupleClass(tsym) =>
-          wit.TupleType(tpe.typeArgs.map(toWIT(_)))
+          wit.TupleType(widenedTpe.baseType(tsym).typeArgs.map(toWIT(_)))
 
         case tsym if tsym.hasAnnotation(WitFlagsAnnotation) =>
           // Read numFlags from annotation parameter
@@ -236,26 +267,26 @@ trait GenWitInterop[G <: Global with Singleton] extends SubComponent {
           wit.FlagsType(className, numFlags)
 
         case tsym if isWasmWitRecordClass(tsym) =>
-          // TODO: it needs to be sorted by the order of record in wit definition
           val className = encodeClassName(tsym)
-          val fields: List[wit.FieldType] = tsym.info.decls.collect {
-            case f if f.isField =>
-              val label = encodeFieldSym(f)(f.pos).name
-              val fieldType = jsInterop.witVariantValueTypeOf(f)
-              val valueType = toWIT(fieldType)
-              wit.FieldType(label, valueType)
-          }.toList
+          val fields = exitingPhase(currentRun.typerPhase) {
+            tsym.primaryConstructor.paramss.flatten.map { param =>
+              (param.name.dropLocal.toString(), param.tpe)
+            }
+          }.map { case (fieldName, fieldType) =>
+            val label = Names.FieldName(className, Names.SimpleFieldName(fieldName))
+            wit.FieldType(label, toWIT(fieldType))
+          }
           wit.RecordType(className, fields)
 
         case tsym if isWasmWitResourceType(tsym) =>
           wit.ResourceType(encodeClassName(tsym))
 
         case tsym if tsym.isSubClass(ComponentResultClass) && tsym.isSealed =>
-          val List(ok, err) = tpe.typeArgs
+          val List(ok, err) = widenedTpe.baseType(ComponentResultClass).typeArgs
           wit.ResultType(toResultWIT(ok), toResultWIT(err))
 
         case tsym if tsym.fullName == "java.util.Optional" =>
-          val List(t) = tpe.dealiasWiden.typeArgs
+          val List(t) = widenedTpe.baseType(tsym).typeArgs
           wit.OptionType(toWIT(t))
 
         case tsym if tsym.hasAnnotation(WitVariantAnnotation) && tsym.isSealed =>
@@ -266,7 +297,7 @@ trait GenWitInterop[G <: Global with Singleton] extends SubComponent {
           val cases = tsym.sealedChildren.toList.sortBy(_.pos.line) map { child =>
             // assert(child.isFinal)
             // assert(child.isClass)
-            val valueType = jsInterop.witVariantValueTypeOf(child)
+            val valueType = witVariantValueTypeOf(child)
             val caseTyp = if (toIRType(valueType) == jstpe.VoidType) {
               None
             } else {

--- a/compiler/src/main/scala/org/scalajs/nscplugin/JSGlobalAddons.scala
+++ b/compiler/src/main/scala/org/scalajs/nscplugin/JSGlobalAddons.scala
@@ -103,12 +103,6 @@ trait JSGlobalAddons extends JSDefinitions with CompatComponent {
     private val jsNativeLoadSpecs =
       mutable.Map.empty[Symbol, JSNativeLoadSpec]
 
-    private val componentFunctionTypes =
-      mutable.Map.empty[Symbol, WitFunctionType]
-
-    private val WitVariantValueTypes =
-      mutable.Map.empty[Symbol, Type]
-
     private val exportPrefix = "$js$exported$"
     private val methodExportPrefix = exportPrefix + "meth$"
     private val propExportPrefix = exportPrefix + "prop$"
@@ -125,15 +119,9 @@ trait JSGlobalAddons extends JSDefinitions with CompatComponent {
         val pos: Position)
         extends ExportInfo
 
-    case class WitExportInfo(moduleName: String, name: String,
-        signature: WitFunctionType)(
+    case class WitExportInfo(moduleName: String, name: String)(
         val pos: Position)
         extends ExportInfo
-
-    case class WitFunctionType(
-        params: List[Type],
-        resultType: Type
-    )
 
     case class StaticExportInfo(jsName: String)(val pos: Position) extends ExportInfo
 
@@ -420,17 +408,6 @@ trait JSGlobalAddons extends JSDefinitions with CompatComponent {
     def jsNativeLoadSpecOfOption(sym: Symbol): Option[JSNativeLoadSpec] =
       jsNativeLoadSpecs.get(sym)
 
-    def storeWitVariantValueType(sym: Symbol, valueType: Type): Unit =
-      WitVariantValueTypes(sym) = valueType
-
-    def witVariantValueTypeOf(sym: Symbol): Type =
-      WitVariantValueTypes(sym)
-
-    def storeWitFunctionType(sym: Symbol, funcType: WitFunctionType): Unit =
-      componentFunctionTypes(sym) = funcType
-
-    def witFunctionTypeOf(sym: Symbol): WitFunctionType =
-      componentFunctionTypes(sym)
   }
 
 }

--- a/compiler/src/main/scala/org/scalajs/nscplugin/PrepJSExports.scala
+++ b/compiler/src/main/scala/org/scalajs/nscplugin/PrepJSExports.scala
@@ -140,11 +140,7 @@ trait PrepJSExports[G <: Global with Singleton] { this: PrepJSInterop[G] =>
 
     val wasmComponent = exports.collect {
       case info @ ExportInfo(moduleName, ExportDestination.WasmComponent(name)) =>
-        val signature = jsInterop.WitFunctionType(
-          (if (sym.tpe.paramss.isEmpty) Nil else sym.tpe.paramss.head).map(_.tpe),
-          sym.tpe.resultType
-        )
-        jsInterop.WitExportInfo(moduleName, name, signature)(info.pos)
+        jsInterop.WitExportInfo(moduleName, name)(info.pos)
     }
 
     if (sym.isMethod && wasmComponent.nonEmpty) {

--- a/compiler/src/main/scala/org/scalajs/nscplugin/PrepJSInterop.scala
+++ b/compiler/src/main/scala/org/scalajs/nscplugin/PrepJSInterop.scala
@@ -862,12 +862,6 @@ abstract class PrepJSInterop[G <: Global with Singleton](val global: G)
             reporter.error(pos,
                 s"Return type '${returnType}' is not compatible with Component Model")
           }
-
-          val funcType = jsInterop.WitFunctionType(
-            (if (sym.tpe.paramss.isEmpty) Nil else sym.tpe.paramss.head).map(_.tpe),
-            sym.tpe.resultType
-          )
-          jsInterop.storeWitFunctionType(sym, funcType)
         }
       }
     }
@@ -953,12 +947,6 @@ abstract class PrepJSInterop[G <: Global with Singleton](val global: G)
                   overridden.fullName)
             }
           }
-
-          val funcType = jsInterop.WitFunctionType(
-            (if (member.tpe.paramss.isEmpty) Nil else member.tpe.paramss.head).map(_.tpe),
-            member.tpe.resultType
-          )
-          jsInterop.storeWitFunctionType(member, funcType)
         }
       }
 
@@ -991,12 +979,6 @@ abstract class PrepJSInterop[G <: Global with Singleton](val global: G)
                   s"Public method '${member.name}' in companion object of @WitResourceImport trait must be " +
                   "annotated with @WitResourceConstructor or @WitResourceStaticMethod")
             }
-
-            val funcType = jsInterop.WitFunctionType(
-              (if (member.tpe.paramss.isEmpty) Nil else member.tpe.paramss.head).map(_.tpe),
-              member.tpe.resultType
-            )
-            jsInterop.storeWitFunctionType(member, funcType)
           }
         }
       }
@@ -1024,7 +1006,6 @@ abstract class PrepJSInterop[G <: Global with Singleton](val global: G)
     private def validateWitVariantCase(caseSym: Symbol): Unit = {
       if (caseSym.isModuleClass) {
         // Regular object (enum case without payload)
-        jsInterop.storeWitVariantValueType(caseSym, definitions.UnitTpe)
       } else if (caseSym.isClass && caseSym.isFinal && !caseSym.isTrait) {
         // Final class (variant case with payload)
         val primaryCtor = caseSym.primaryConstructor
@@ -1051,12 +1032,9 @@ abstract class PrepJSInterop[G <: Global with Singleton](val global: G)
           } else if (!isComponentModelCompatible(fieldType)) {
             reporter.error(param.pos,
                 s"Field '${param.name}' has type '${fieldType}' which is not compatible with Component Model. ")
-          } else {
-            jsInterop.storeWitVariantValueType(caseSym, fieldType)
           }
         } else {
           // Zero parameters - enum case defined as a class
-          jsInterop.storeWitVariantValueType(caseSym, definitions.UnitTpe)
         }
       } else {
         reporter.error(caseSym.pos,
@@ -1120,13 +1098,6 @@ abstract class PrepJSInterop[G <: Global with Singleton](val global: G)
             reporter.error(param.pos,
                 s"Field '${param.name}' has type '${fieldType}' which is not compatible with Component Model")
           }
-        }
-        // Store field types for code generation
-        for {
-          f <- sym.info.decls
-          if !f.isMethod && f.isField
-        } {
-          jsInterop.storeWitVariantValueType(f, f.tpe)
         }
       }
     }


### PR DESCRIPTION

Remove `WitFunctionType` and `WitVariantValueTypes` maps from `JSGlobalAddons` that were stored during `PrepJSInterop`. Instead, query the compiler's symbol table directly using `exitingPhase(currentRun.typerPhase)` during JS code generation.

This eliminates the store/retrieve pattern across compiler phases and simplifies WitExportInfo by removing its signature field.