### PR TITLE
WIT resource class representation be final class 

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -138,8 +138,8 @@ jobs:
         uses: taiki-e/install-action@v2
         with:
           tool: wasmtime@44.0.2,wasm-tools,wac-cli,cargo-component
-      - name: Install wit-bindgen from scala-wasm/wit-bindgen scala-wasm-wasm.4 tag
-        run: cargo install --git https://github.com/scala-wasm/wit-bindgen --tag scala-wasm-wasm.4 wit-bindgen-cli
+      - name: Install wit-bindgen-scala
+        run: cargo install wit-bindgen-scala --version 0.1.0-rc.1
       - name: helloworldWASI${{ matrix.suffix }}/run
         run: sbt "$SBT_SET_COMMAND" helloworldWASI${{ matrix.suffix }}/run
       - name: Build rust-exports
@@ -204,8 +204,8 @@ jobs:
         uses: taiki-e/install-action@v2
         with:
           tool: wasmtime@44.0.2,wasm-tools,wac-cli
-      - name: Install wit-bindgen from scala-wasm/wit-bindgen scala-wasm-wasm.4 tag
-        run: cargo install --git https://github.com/scala-wasm/wit-bindgen --tag scala-wasm-wasm.4 wit-bindgen-cli
+      - name: Install wit-bindgen-scala
+        run: cargo install wit-bindgen-scala --version 0.1.0-rc.1
       - name: sbtPlugin2_12/scripted
         run: sbt sbtPlugin2_12/scripted
       - name: sbtPlugin3/scripted

--- a/README.md
+++ b/README.md
@@ -17,11 +17,11 @@ addSbtPlugin("io.github.scala-wasm" % "sbt-scalajs" % "1.21.1-wasm.4")
 ## Prerequisites
 - [wasm-tools](https://github.com/bytecodealliance/wasm-tools)
 - [wasmtime](https://github.com/bytecodealliance/wasmtime)
-- [wit-bindgen](https://github.com/scala-wasm/wit-bindgen) with scala-wasm support:
+- [wit-bindgen-scala](https://github.com/scala-wasm/wit-bindgen-scala):
 
-  ```sh
-  cargo install --git https://github.com/scala-wasm/wit-bindgen --tag scala-wasm-wasm.4 wit-bindgen-cli
-  ```
+```sh
+cargo install wit-bindgen-scala --version 0.1.0-rc.1
+```
 
 - (optional) [wkg](https://github.com/bytecodealliance/wasm-pkg-tools)
   - Required if you want to add Wasm Component Model dependencies.

--- a/compiler/src/main/scala/org/scalajs/nscplugin/GenJSCode.scala
+++ b/compiler/src/main/scala/org/scalajs/nscplugin/GenJSCode.scala
@@ -489,9 +489,6 @@ abstract class GenJSCode[G <: Global with Singleton](val global: G)
                 }
               } else if (isWasmWitRecordClass(sym)) {
                 genClass(cd)
-              } else if (isWasmWitResourceType(sym)) {
-                genWasmComponentResourceClassData(cd)
-                // TODO: export resource?
               } else if (sym.isTraitOrInterface) {
                 genInterface(cd)
               } else {
@@ -675,9 +672,25 @@ abstract class GenJSCode[G <: Global with Singleton](val global: G)
       val jsNativeMembersBuilder = List.newBuilder[js.JSNativeMemberDef]
       val witNativeMembersBuilder = List.newBuilder[js.WitNativeMemberDef]
       val witExportDefsBuilder = List.newBuilder[js.WitExportDef]
+      val isWitResourceClass = isWasmWitResourceType(sym)
 
       for (dd <- collectDefDefs(cd.impl)) {
-        if (dd.symbol.hasAnnotation(WitImportAnnotation)) {
+        if (isWitResourceClass && (dd.symbol.hasAnnotation(WitResourceMethodAnnotation) ||
+              dd.symbol.hasAnnotation(WitResourceDropAnnotation))) {
+          val annot = sym.getAnnotation(WitResourceImportAnnotation).get
+          val moduleName = annot.stringArg(0).get
+          val resourceName = annot.stringArg(1).get
+          val flags = js.MemberFlags.empty.withNamespace(js.MemberNamespace.Public)
+          if (dd.symbol.hasAnnotation(WitResourceMethodAnnotation)) {
+            val methodAnnot = dd.symbol.getAnnotation(WitResourceMethodAnnotation).get
+            val functionName = methodAnnot.stringArg(0).get
+            witNativeMembersBuilder += genWitNativeMemberDef(flags, dd, moduleName,
+                js.WitFunctionName.ResourceMethod(functionName, resourceName))
+          } else {
+            witNativeMembersBuilder += genWitNativeMemberDef(flags, dd, moduleName,
+                js.WitFunctionName.ResourceDrop(resourceName))
+          }
+        } else if (dd.symbol.hasAnnotation(WitImportAnnotation)) {
           val annot = dd.symbol.getAnnotation(WitImportAnnotation).get
           val moduleName = annot.stringArg(0).get
           val functionName = annot.stringArg(1).get
@@ -802,6 +815,7 @@ abstract class GenJSCode[G <: Global with Singleton](val global: G)
       // The complete class definition
       val kind = {
         if (isStaticModule(sym)) ClassKind.ModuleClass
+        else if (isWitResourceClass) ClassKind.WasmComponentResourceClass
         else if (isHijacked) ClassKind.HijackedClass
         else ClassKind.Class
       }
@@ -3474,8 +3488,6 @@ abstract class GenJSCode[G <: Global with Singleton](val global: G)
             genNewArray(arr, args.map(genExpr))
           case prim: jstpe.PrimRef =>
             abort(s"unexpected primitive type $prim in New at $pos")
-          case jstpe.WitResourceTypeRef(_) =>
-            abort(s"unexpected component resource type in New at $pos")
           case typeRef: jstpe.TransientTypeRef =>
             abort(s"unexpected special type ref $typeRef in New at $pos")
         }

--- a/compiler/src/main/scala/org/scalajs/nscplugin/GenWitInterop.scala
+++ b/compiler/src/main/scala/org/scalajs/nscplugin/GenWitInterop.scala
@@ -34,7 +34,7 @@ trait GenWitInterop[G <: Global with Singleton] extends SubComponent {
   import jsDefinitions._
 
   // - annotated with @WitResourceMethod
-  // - owner is a companion object of @WitResourceImport annotated trait
+  // - owner is a companion object of @WitResourceImport annotated class
   def isWasmWitResourceStaticMethod(sym: Symbol): Boolean = {
     sym.hasAnnotation(WitResourceStaticMethodAnnotation) &&
     sym.owner.isModuleClass &&
@@ -70,13 +70,6 @@ trait GenWitInterop[G <: Global with Singleton] extends SubComponent {
       val Apply(Select(qual, _), args) = tree
       implicit val pos = tree.pos
       val methodIdent = encodeMethodSym(method)
-
-      // Not using encodeClassName(method.owner)
-      // The method.owner of `close` methods will be `component.Resource` instead of the specific resource class that extends the Resource trait.
-      // `component.Resource` defines a `final def close`, preventing users from overriding the close implementation.
-      // However, the actual `close` methods to be called are automatically generated for all resource classes.
-      // val className = encodeClassName(qual.symbol.tpe.typeSymbol)
-
       val className = encodeClassName(method.owner)
       js.WitFunctionApply(
         receiver.map(genExpr(_)),
@@ -84,48 +77,6 @@ trait GenWitInterop[G <: Global with Singleton] extends SubComponent {
         methodIdent,
         args.map(genExpr(_)) // genActualArgs?
       )(toIRType(tree.tpe))
-    }
-
-    def genWasmComponentResourceClassData(cd: ClassDef): js.ClassDef = {
-      val sym = cd.symbol
-      implicit val pos = sym.pos
-
-      val classIdent = encodeClassNameIdent(sym)
-      val kind = ClassKind.NativeWasmComponentResourceClass
-
-      val annot = sym.getAnnotation(WitResourceImportAnnotation).get
-      val moduleName = annot.stringArg(0).get
-      val resourceName = annot.stringArg(1).get
-
-      val flags = js.MemberFlags.empty.withNamespace(js.MemberNamespace.Public)
-      val witNativeMembersBuilder = List.newBuilder[js.WitNativeMemberDef]
-      for (stat <- cd.impl.body) {
-        stat match {
-          case dd: DefDef if dd.symbol.hasAnnotation(WitResourceMethodAnnotation) =>
-            for {
-              annot <- dd.symbol.getAnnotation(WitResourceMethodAnnotation)
-              functionName <- annot.stringArg(0)
-            } {
-              witNativeMembersBuilder +=
-                genWitNativeMemberDef(flags, dd, moduleName,
-                    js.WitFunctionName.ResourceMethod(functionName, resourceName))
-            }
-
-          case dd: DefDef if dd.symbol.hasAnnotation(WitResourceDropAnnotation) =>
-            for {
-              annot <- dd.symbol.getAnnotation(WitResourceDropAnnotation)
-            } {
-              witNativeMembersBuilder +=
-                genWitNativeMemberDef(flags, dd, moduleName,
-                    js.WitFunctionName.ResourceDrop(resourceName))
-            }
-          case _ =>
-        }
-      }
-      js.ClassDef(classIdent, originalNameOfClass(sym), kind, None, superClass = None,
-          interfaces = Nil, None, None,
-          Nil, Nil, None, Nil, Nil, witNativeMembersBuilder.result(), Nil)(
-          js.OptimizerHints.empty)
     }
   }
 

--- a/compiler/src/main/scala/org/scalajs/nscplugin/JSEncoding.scala
+++ b/compiler/src/main/scala/org/scalajs/nscplugin/JSEncoding.scala
@@ -290,7 +290,6 @@ trait JSEncoding[G <: Global with Singleton] extends SubComponent {
   def encodeClassType(sym: Symbol): jstpe.Type = {
     if (sym == definitions.ObjectClass) jstpe.AnyType
     else if (isJSType(sym)) jstpe.AnyType
-    else if (isWasmWitResourceType(sym)) jstpe.WitResourceType(encodeClassName(sym))
     else {
       assert(sym != definitions.ArrayClass,
           "encodeClassType() cannot be called with ArrayClass")

--- a/compiler/src/main/scala/org/scalajs/nscplugin/PrepJSInterop.scala
+++ b/compiler/src/main/scala/org/scalajs/nscplugin/PrepJSInterop.scala
@@ -796,17 +796,16 @@ abstract class PrepJSInterop[G <: Global with Singleton](val global: G)
           val isDrop = annot.symbol == WitResourceDropAnnotation
 
           if ((isResourceMethod || isDrop) && (
-                !sym.owner.isTraitOrInterface ||
-                  !sym.owner.hasAnnotation(WitResourceImportAnnotation))) {
+                !sym.owner.isClass || !sym.owner.hasAnnotation(WitResourceImportAnnotation))) {
             reporter.error(pos,
-                s"$annot is allowed in trait annotated with @WitResourceImport")
+                s"$annot is allowed in final class annotated with @WitResourceImport")
           } else if ((isStaticMethod || isConstructor) && (
                 !sym.owner.isModuleClass ||
                   sym.owner.companionClass == NoSymbol ||
-                  !sym.owner.companionClass.isTraitOrInterface ||
+                  !sym.owner.companionClass.isClass || sym.owner.companionClass.isTrait ||
                   !sym.owner.companionClass.hasAnnotation(WitResourceImportAnnotation))) {
             reporter.error(pos,
-                s"$annot is allowed in companion object of trait annotated with @WitResourceImport")
+                s"$annot is allowed in companion object of class annotated with @WitResourceImport")
           }
         }
       }
@@ -862,21 +861,43 @@ abstract class PrepJSInterop[G <: Global with Singleton](val global: G)
             reporter.error(pos,
                 s"Return type '${returnType}' is not compatible with Component Model")
           }
+
         }
       }
     }
 
     private def checkWasmWitResourceImport(pos: Position, sym: Symbol): Unit = {
-      if (!sym.isTrait) {
+      if (!sym.isClass || sym.isTrait || sym.isModuleClass || !sym.isFinal) {
         reporter.error(pos,
-            "@WitResourceImport is allowed for traits")
+            "@WitResourceImport is allowed for final classes")
         return
       }
 
-      // Resource imports should not be sealed
       if (sym.isSealed) {
         reporter.error(pos,
-            "@WitResourceImport traits cannot be sealed")
+            "@WitResourceImport classes cannot be sealed")
+        return
+      }
+
+      val primaryCtor = sym.primaryConstructor
+      if (primaryCtor == NoSymbol) {
+        reporter.error(pos,
+            "@WitResourceImport class must have a primary constructor")
+        return
+      }
+
+      val ctorParams =
+        if (primaryCtor.info.paramss.isEmpty) Nil else primaryCtor.info.paramss.head
+      if (!primaryCtor.isPrivate || ctorParams.nonEmpty) {
+        reporter.error(pos,
+            "@WitResourceImport class must have a private parameterless primary constructor")
+        return
+      }
+
+      val nonObjectParents = sym.info.parents.map(_.typeSymbol).filter(_ != definitions.ObjectClass)
+      if (nonObjectParents.nonEmpty) {
+        reporter.error(pos,
+            "@WitResourceImport class may only extend java.lang.Object")
         return
       }
 
@@ -888,7 +909,7 @@ abstract class PrepJSInterop[G <: Global with Singleton](val global: G)
           val hasResourceConstructor = member.hasAnnotation(WitResourceConstructorAnnotation)
           val hasResourceStaticMethod = member.hasAnnotation(WitResourceStaticMethodAnnotation)
 
-          // @WitResourceConstructor and @WitResourceStaticMethod are not allowed in trait
+          // @WitResourceConstructor and @WitResourceStaticMethod are not allowed in class
           if (hasResourceConstructor) {
             reporter.error(member.pos,
                 "@WitResourceConstructor can only be used on apply method in companion object")
@@ -901,7 +922,7 @@ abstract class PrepJSInterop[G <: Global with Singleton](val global: G)
           val hasResourceMethodAnnotation = hasResourceMethod || hasResourceDrop
           if (!hasResourceMethodAnnotation) {
             reporter.error(member.pos,
-                s"Method '${member.name}' in @WitResourceImport trait must be " +
+                s"Method '${member.name}' in @WitResourceImport class must be " +
                 "annotated with @WitResourceMethod or @WitResourceDrop")
           }
 
@@ -947,13 +968,14 @@ abstract class PrepJSInterop[G <: Global with Singleton](val global: G)
                   overridden.fullName)
             }
           }
+
         }
       }
 
       // Ensure there is at most one drop method
       if (dropMethodCount > 1) {
         reporter.error(pos,
-            s"@WitResourceImport trait can have at most one @WitResourceDrop method, found $dropMethodCount")
+            s"@WitResourceImport class can have at most one @WitResourceDrop method, found $dropMethodCount")
       }
 
       // Check companion object if it exists
@@ -976,9 +998,10 @@ abstract class PrepJSInterop[G <: Global with Singleton](val global: G)
                 !hasStaticMethodAnnot &&
                 !member.isSynthetic) {
               reporter.error(member.pos,
-                  s"Public method '${member.name}' in companion object of @WitResourceImport trait must be " +
+                  s"Public method '${member.name}' in companion object of @WitResourceImport class must be " +
                   "annotated with @WitResourceConstructor or @WitResourceStaticMethod")
             }
+
           }
         }
       }

--- a/compiler/src/main/scala/org/scalajs/nscplugin/TypeConversions.scala
+++ b/compiler/src/main/scala/org/scalajs/nscplugin/TypeConversions.scala
@@ -68,7 +68,7 @@ trait TypeConversions[G <: Global with Singleton] extends SubComponent {
   def toTypeRef(t: Type): Types.TypeRef = {
     val (base, arrayDepth) = convert(t)
     if (arrayDepth == 0)
-      makeNonArrayTypeRef(base)
+      primitiveRefMap.getOrElse(base, Types.ClassRef(encodeClassName(base)))
     else
       makeArrayTypeRef(base, arrayDepth)
   }
@@ -108,17 +108,11 @@ trait TypeConversions[G <: Global with Singleton] extends SubComponent {
     WitUnsigned_ULong -> wit.U64Type
   )
 
-  private def makeNonArrayTypeRef(sym: Symbol): Types.NonArrayTypeRef = {
-    primitiveRefMap.getOrElse(sym, {
-      if (isWasmWitResourceType(sym))
-        Types.WitResourceTypeRef(encodeClassName(sym))
-      else
-        Types.ClassRef(encodeClassName(sym))
-    })
+  private def makeArrayTypeRef(base: Symbol, depth: Int): Types.ArrayTypeRef = {
+    Types.ArrayTypeRef(
+        primitiveRefMap.getOrElse(base, Types.ClassRef(encodeClassName(base))),
+        depth)
   }
-
-  private def makeArrayTypeRef(base: Symbol, depth: Int): Types.ArrayTypeRef =
-    Types.ArrayTypeRef(makeNonArrayTypeRef(base), depth)
 
   // The following code was modeled after backend.icode.TypeKinds.toTypeKind
 

--- a/ir/shared/src/main/scala/org/scalajs/ir/ClassKind.scala
+++ b/ir/shared/src/main/scala/org/scalajs/ir/ClassKind.scala
@@ -18,8 +18,8 @@ sealed abstract class ClassKind {
   import ClassKind._
 
   def isClass: Boolean = this match {
-    case Class | ModuleClass => true
-    case _                   => false
+    case Class | ModuleClass | WasmComponentResourceClass => true
+    case _                                                => false
   }
 
   def isJSClass: Boolean = this match {
@@ -46,8 +46,11 @@ sealed abstract class ClassKind {
   }
 
   def isAnyNonNativeClass: Boolean = this match {
-    case Class | ModuleClass | JSClass | JSModuleClass => true
-    case _                                             => false
+    case Class | ModuleClass | JSClass | JSModuleClass |
+        WasmComponentResourceClass =>
+      true
+    case _ =>
+      false
   }
 
   @deprecated("not a meaningful operation", since = "1.13.2")
@@ -69,19 +72,19 @@ object ClassKind {
   case object JSModuleClass extends ClassKind
   case object NativeJSClass extends ClassKind
   case object NativeJSModuleClass extends ClassKind
-  case object NativeWasmComponentResourceClass extends ClassKind
+  case object WasmComponentResourceClass extends ClassKind
 
   private[ir] def toByte(kind: ClassKind): Byte = kind match {
-    case ClassKind.Class                            => 1
-    case ClassKind.ModuleClass                      => 2
-    case ClassKind.Interface                        => 3
-    case ClassKind.AbstractJSType                   => 4
-    case ClassKind.HijackedClass                    => 5
-    case ClassKind.JSClass                          => 6
-    case ClassKind.JSModuleClass                    => 7
-    case ClassKind.NativeJSClass                    => 8
-    case ClassKind.NativeJSModuleClass              => 9
-    case ClassKind.NativeWasmComponentResourceClass => 10
+    case ClassKind.Class                      => 1
+    case ClassKind.ModuleClass                => 2
+    case ClassKind.Interface                  => 3
+    case ClassKind.AbstractJSType             => 4
+    case ClassKind.HijackedClass              => 5
+    case ClassKind.JSClass                    => 6
+    case ClassKind.JSModuleClass              => 7
+    case ClassKind.NativeJSClass              => 8
+    case ClassKind.NativeJSModuleClass        => 9
+    case ClassKind.WasmComponentResourceClass => 10
   }
 
   private[ir] def fromByte(b: Byte): ClassKind = (b: @switch) match {
@@ -94,6 +97,6 @@ object ClassKind {
     case 7  => ClassKind.JSModuleClass
     case 8  => ClassKind.NativeJSClass
     case 9  => ClassKind.NativeJSModuleClass
-    case 10 => ClassKind.NativeWasmComponentResourceClass
+    case 10 => ClassKind.WasmComponentResourceClass
   }
 }

--- a/ir/shared/src/main/scala/org/scalajs/ir/Hashers.scala
+++ b/ir/shared/src/main/scala/org/scalajs/ir/Hashers.scala
@@ -619,9 +619,6 @@ object Hashers {
       case ClassRef(className) =>
         mixTag(TagClassRef)
         mixName(className)
-      case WitResourceTypeRef(className) =>
-        mixTag(TagWitResourceTypeRef)
-        mixName(className)
       case typeRef: ArrayTypeRef =>
         mixTag(TagArrayTypeRef)
         mixArrayTypeRef(typeRef)
@@ -661,10 +658,6 @@ object Hashers {
           case (false, false) => TagNonNullClassType
         }
         mixTag(tag)
-        mixName(className)
-
-      case WitResourceType(className) =>
-        mixTag(TagWitResourceType)
         mixName(className)
 
       case ArrayType(arrayTypeRef, nullable, exact) =>

--- a/ir/shared/src/main/scala/org/scalajs/ir/Names.scala
+++ b/ir/shared/src/main/scala/org/scalajs/ir/Names.scala
@@ -428,8 +428,6 @@ object Names {
           }
         case ClassRef(className) =>
           builder.append('L').append(className.nameString)
-        case WitResourceTypeRef(className) =>
-          builder.append('L').append(className.nameString)
         case ArrayTypeRef(base, dimensions) =>
           var i = 0
           while (i != dimensions) {

--- a/ir/shared/src/main/scala/org/scalajs/ir/Printers.scala
+++ b/ir/shared/src/main/scala/org/scalajs/ir/Printers.scala
@@ -1002,16 +1002,16 @@ object Printers {
       }
       print(classDef.optimizerHints)
       kind match {
-        case ClassKind.Class                            => print("class ")
-        case ClassKind.ModuleClass                      => print("module class ")
-        case ClassKind.Interface                        => print("interface ")
-        case ClassKind.AbstractJSType                   => print("abstract js type ")
-        case ClassKind.HijackedClass                    => print("hijacked class ")
-        case ClassKind.JSClass                          => print("js class ")
-        case ClassKind.JSModuleClass                    => print("js module class ")
-        case ClassKind.NativeJSClass                    => print("native js class ")
-        case ClassKind.NativeJSModuleClass              => print("native js module class ")
-        case ClassKind.NativeWasmComponentResourceClass => print("native wasm resource class ")
+        case ClassKind.Class                      => print("class ")
+        case ClassKind.ModuleClass                => print("module class ")
+        case ClassKind.Interface                  => print("interface ")
+        case ClassKind.AbstractJSType             => print("abstract js type ")
+        case ClassKind.HijackedClass              => print("hijacked class ")
+        case ClassKind.JSClass                    => print("js class ")
+        case ClassKind.JSModuleClass              => print("js module class ")
+        case ClassKind.NativeJSClass              => print("native js class ")
+        case ClassKind.NativeJSModuleClass        => print("native js module class ")
+        case ClassKind.WasmComponentResourceClass => print("wasm component resource class ")
       }
       print(name)
       print(originalName)
@@ -1179,10 +1179,6 @@ object Printers {
         print(tpe)
       case ClassRef(className) =>
         print(className)
-      case WitResourceTypeRef(className) =>
-        print("resource<")
-        print(className)
-        print(">")
       case ArrayTypeRef(base, dims) =>
         print(base)
         for (i <- 1 to dims)
@@ -1214,11 +1210,6 @@ object Printers {
         print(className)
         if (!nullable)
           print("!")
-
-      case WitResourceType(className) =>
-        print("resource<")
-        print(className)
-        print(">")
 
       case ArrayType(arrayTypeRef, nullable, exact) =>
         if (exact)

--- a/ir/shared/src/main/scala/org/scalajs/ir/Serializers.scala
+++ b/ir/shared/src/main/scala/org/scalajs/ir/Serializers.scala
@@ -167,8 +167,6 @@ object Serializers {
             // nothing to do
           case ClassRef(className) =>
             encodedNameToIndex(className.encoded)
-          case WitResourceTypeRef(className) =>
-            encodedNameToIndex(className.encoded)
           case ArrayTypeRef(base, _) =>
             reserveTypeRef(base)
           case typeRef: TransientTypeRef =>
@@ -237,9 +235,6 @@ object Serializers {
           }
         case ClassRef(className) =>
           s.writeByte(TagClassRef)
-          s.writeInt(encodedNameIndexMap(new EncodedNameKey(className.encoded)))
-        case WitResourceTypeRef(className) =>
-          s.writeByte(TagWitResourceTypeRef)
           s.writeInt(encodedNameIndexMap(new EncodedNameKey(className.encoded)))
         case ArrayTypeRef(base, dimensions) =>
           s.writeByte(TagArrayTypeRef)
@@ -964,10 +959,6 @@ object Serializers {
           buffer.write(tag)
           writeName(className)
 
-        case WitResourceType(className) =>
-          buffer.write(TagWitResourceType)
-          writeName(className)
-
         case ArrayType(arrayTypeRef, nullable, exact) =>
           val tag = (exact, nullable) match {
             case (true, true)   => TagExactArrayType
@@ -1091,9 +1082,6 @@ object Serializers {
         }
       case ClassRef(className) =>
         buffer.writeByte(TagClassRef)
-        writeName(className)
-      case WitResourceTypeRef(className) =>
-        buffer.writeByte(TagWitResourceTypeRef)
         writeName(className)
       case typeRef: ArrayTypeRef =>
         buffer.writeByte(TagArrayTypeRef)
@@ -2837,8 +2825,6 @@ object Serializers {
         case TagExactNonNullArrayType =>
           ArrayType(readArrayTypeRef(), nullable = false, exact = true)
 
-        case TagWitResourceType => WitResourceType(readClassName())
-
         case TagClosureType | TagNonNullClosureType =>
           val paramTypes = readTypes()
           val resultType = readType()
@@ -2860,20 +2846,19 @@ object Serializers {
 
     def readTypeRef(): TypeRef = {
       readByte() match {
-        case TagVoidRef            => VoidRef
-        case TagBooleanRef         => BooleanRef
-        case TagCharRef            => CharRef
-        case TagByteRef            => ByteRef
-        case TagShortRef           => ShortRef
-        case TagIntRef             => IntRef
-        case TagLongRef            => LongRef
-        case TagFloatRef           => FloatRef
-        case TagDoubleRef          => DoubleRef
-        case TagNullRef            => NullRef
-        case TagNothingRef         => NothingRef
-        case TagClassRef           => ClassRef(readClassName())
-        case TagWitResourceTypeRef => WitResourceTypeRef(readClassName())
-        case TagArrayTypeRef       => readArrayTypeRef()
+        case TagVoidRef      => VoidRef
+        case TagBooleanRef   => BooleanRef
+        case TagCharRef      => CharRef
+        case TagByteRef      => ByteRef
+        case TagShortRef     => ShortRef
+        case TagIntRef       => IntRef
+        case TagLongRef      => LongRef
+        case TagFloatRef     => FloatRef
+        case TagDoubleRef    => DoubleRef
+        case TagNullRef      => NullRef
+        case TagNothingRef   => NothingRef
+        case TagClassRef     => ClassRef(readClassName())
+        case TagArrayTypeRef => readArrayTypeRef()
       }
     }
 

--- a/ir/shared/src/main/scala/org/scalajs/ir/Tags.scala
+++ b/ir/shared/src/main/scala/org/scalajs/ir/Tags.scala
@@ -208,10 +208,6 @@ private[ir] object Tags {
   final val TagExactArrayType = TagExactNonNullClassType + 1
   final val TagExactNonNullArrayType = TagExactArrayType + 1
 
-  // New in Component Model support
-
-  final val TagWitResourceType = TagExactNonNullArrayType + 1
-
   // Tags for TypeRefs
 
   final val TagVoidRef = 1
@@ -231,10 +227,6 @@ private[ir] object Tags {
   // New in 1.19
 
   final val TagTransientTypeRefHashingOnly = TagArrayTypeRef + 1
-
-  // New in Component Model support
-
-  final val TagWitResourceTypeRef = TagTransientTypeRefHashingOnly + 1
 
   // Tags for JS native loading specs
 

--- a/ir/shared/src/main/scala/org/scalajs/ir/Types.scala
+++ b/ir/shared/src/main/scala/org/scalajs/ir/Types.scala
@@ -41,7 +41,6 @@ object Types {
       case ClassType(_, nullable, _)   => nullable
       case ArrayType(_, nullable, _)   => nullable
       case ClosureType(_, _, nullable) => nullable
-      case WitResourceType(_)          => false
       case _                           => false
     }
 
@@ -270,15 +269,6 @@ object Types {
         tpe: Type, mutable: Boolean)
   }
 
-  /** WebAssembly Component Model resource type.
-   *
-   *  This represents a handle to a resource in the WebAssembly Component Model.
-   *  Resources are represented as i32 handles at the Wasm level.
-   */
-  final case class WitResourceType(className: ClassName) extends Type {
-    def toNonNullable: this.type = this
-  }
-
   /** Void type, the top of type of our type system. */
   case object VoidType extends PrimTypeWithRef('V', "void")
 
@@ -312,12 +302,6 @@ object Types {
           case that: ClassRef => thiz.className.compareTo(that.className)
           case _: PrimRef     => 1
           case _              => -1
-        }
-      case thiz: WitResourceTypeRef =>
-        that match {
-          case that: WitResourceTypeRef => thiz.className.compareTo(that.className)
-          case _:PrimRef | _:ClassRef   => 1
-          case _                        => -1
         }
       case thiz: ArrayTypeRef =>
         that match {
@@ -407,15 +391,6 @@ object Types {
     def displayName: String = className.nameString
   }
 
-  /** WebAssembly Component Model resource type reference.
-   *
-   *  This represents a reference to a component resource type in method signatures.
-   *  Component resources are opaque handles represented as i32 at the Wasm level.
-   */
-  final case class WitResourceTypeRef(className: ClassName) extends NonArrayTypeRef {
-    def displayName: String = "resource<" + className.nameString + ">"
-  }
-
   /** Array type. */
   final case class ArrayTypeRef(base: NonArrayTypeRef, dimensions: Int) extends TypeRef {
 
@@ -467,7 +442,7 @@ object Types {
       RecordValue(tpe, tpe.fields.map(f => zeroOf(f.tpe)))
 
     case NothingType | VoidType | ClassType(_, false, _) | ArrayType(_, false, _) |
-        ClosureType(_, _, false) | AnyNotNullType | WitResourceType(_) =>
+        ClosureType(_, _, false) | AnyNotNullType =>
       throw new IllegalArgumentException(s"cannot generate a zero for $tpe")
   }
 
@@ -548,8 +523,6 @@ object Types {
                  * Object in their ancestors.
                  */
                 rhsBaseName == ObjectClass || isSubclass(lhsBaseName, rhsBaseName)
-              case (WitResourceTypeRef(lhsBaseName), WitResourceTypeRef(rhsBaseName)) =>
-                lhsBaseName == rhsBaseName
               case _ =>
                 lhsBase eq rhsBase
             }
@@ -559,11 +532,6 @@ object Types {
       case (ArrayType(_, lhsNullable, _), ClassType(className, rhsNullable, false)) =>
         isSubnullable(lhsNullable, rhsNullable) &&
         AncestorsOfPseudoArrayClass.contains(className)
-
-      case (WitResourceType(_), ClassType(className, rhsNullable, _)) =>
-        // WitResourceType is always non-nullable and subtype of ObjectClass.
-        isSubnullable(false, rhsNullable) &&
-        className == ObjectClass
 
       case _ =>
         false

--- a/ir/shared/src/main/scala/org/scalajs/ir/WasmInterfaceTypes.scala
+++ b/ir/shared/src/main/scala/org/scalajs/ir/WasmInterfaceTypes.scala
@@ -134,7 +134,7 @@ object WasmInterfaceTypes {
   }
 
   final case class ResourceType(className: ClassName) extends FundamentalType {
-    def toIRType(): jstpe.Type = jstpe.WitResourceType(className)
+    def toIRType(): jstpe.Type = jstpe.ClassType(className, nullable = true, exact = false)
   }
 
   // ExternTypes
@@ -162,7 +162,7 @@ object WasmInterfaceTypes {
     case EnumType(labels)              => ???
     case OptionType(tpe)               => jstpe.ClassRef(ClassName("java.util.Optional"))
     case FlagsType(className, _)       => jstpe.ClassRef(className)
-    case ResourceType(className)       => jstpe.WitResourceTypeRef(className)
+    case ResourceType(className)       => jstpe.ClassRef(className)
   }
 
   def makeCtorName(tpe: Option[ValType]): MethodName = {

--- a/library/src/main/scala/scala/scalajs/wasi/cli/terminal_input.scala
+++ b/library/src/main/scala/scala/scalajs/wasi/cli/terminal_input.scala
@@ -5,7 +5,7 @@ package object terminal_input {
   // Resources
   /** The input side of a terminal. */
   @scala.scalajs.wit.annotation.WitResourceImport("wasi:cli/terminal-input@0.2.0", "terminal-input")
-  trait TerminalInput {
+  final class TerminalInput private () extends Object {
     @scala.scalajs.wit.annotation.WitResourceDrop
     def close(): Unit = scala.scalajs.wit.native
   }

--- a/library/src/main/scala/scala/scalajs/wasi/cli/terminal_output.scala
+++ b/library/src/main/scala/scala/scalajs/wasi/cli/terminal_output.scala
@@ -6,7 +6,7 @@ package object terminal_output {
   /** The output side of a terminal. */
   @scala.scalajs.wit.annotation.WitResourceImport(
       "wasi:cli/terminal-output@0.2.0", "terminal-output")
-  trait TerminalOutput {
+  final class TerminalOutput private () extends Object {
     @scala.scalajs.wit.annotation.WitResourceDrop
     def close(): Unit = scala.scalajs.wit.native
   }

--- a/library/src/main/scala/scala/scalajs/wasi/filesystem/types.scala
+++ b/library/src/main/scala/scala/scalajs/wasi/filesystem/types.scala
@@ -464,7 +464,7 @@ package object types {
    *  calls may be made.
    */
   @scala.scalajs.wit.annotation.WitResourceImport("wasi:filesystem/types@0.2.0", "descriptor")
-  trait Descriptor {
+  final class Descriptor private () extends Object {
 
     /** Return a stream for reading from a file, if available.
      *
@@ -804,7 +804,7 @@ package object types {
   /** A stream of directory entries. */
   @scala.scalajs.wit.annotation.WitResourceImport(
       "wasi:filesystem/types@0.2.0", "directory-entry-stream")
-  trait DirectoryEntryStream {
+  final class DirectoryEntryStream private () extends Object {
 
     /** Read a single directory entry from a `directory-entry-stream`. */
     @scala.scalajs.wit.annotation.WitResourceMethod("read-directory-entry")

--- a/library/src/main/scala/scala/scalajs/wasi/http/types.scala
+++ b/library/src/main/scala/scala/scalajs/wasi/http/types.scala
@@ -600,7 +600,7 @@ package object types {
    *  operations will fail with `header-error.immutable`.
    */
   @scala.scalajs.wit.annotation.WitResourceImport("wasi:http/types@0.2.0", "fields")
-  trait Fields {
+  final class Fields private () extends Object {
 
     /** Get all of the values corresponding to a key. If the key is not present
      *  in this `fields`, an empty list is returned. However, if the key is
@@ -699,7 +699,7 @@ package object types {
 
   /** Represents an incoming HTTP Request. */
   @scala.scalajs.wit.annotation.WitResourceImport("wasi:http/types@0.2.0", "incoming-request")
-  trait IncomingRequest {
+  final class IncomingRequest private () extends Object {
 
     /** Returns the method of the incoming request. */
     @scala.scalajs.wit.annotation.WitResourceMethod("method")
@@ -743,7 +743,7 @@ package object types {
 
   /** Represents an outgoing HTTP Request. */
   @scala.scalajs.wit.annotation.WitResourceImport("wasi:http/types@0.2.0", "outgoing-request")
-  trait OutgoingRequest {
+  final class OutgoingRequest private () extends Object {
 
     /** Returns the resource corresponding to the outgoing Body for this
      *  Request.
@@ -852,7 +852,7 @@ package object types {
    *  blocking call to `wasi:io/poll.poll`.
    */
   @scala.scalajs.wit.annotation.WitResourceImport("wasi:http/types@0.2.0", "request-options")
-  trait RequestOptions {
+  final class RequestOptions private () extends Object {
 
     /** The timeout for the initial connect to the HTTP Server. */
     @scala.scalajs.wit.annotation.WitResourceMethod("connect-timeout")
@@ -917,7 +917,7 @@ package object types {
    *  other argument to `incoming-handler.handle`.
    */
   @scala.scalajs.wit.annotation.WitResourceImport("wasi:http/types@0.2.0", "response-outparam")
-  trait ResponseOutparam {
+  final class ResponseOutparam private () extends Object {
     @scala.scalajs.wit.annotation.WitResourceDrop
     def close(): Unit = scala.scalajs.wit.native
   }
@@ -943,7 +943,7 @@ package object types {
 
   /** Represents an incoming HTTP Response. */
   @scala.scalajs.wit.annotation.WitResourceImport("wasi:http/types@0.2.0", "incoming-response")
-  trait IncomingResponse {
+  final class IncomingResponse private () extends Object {
 
     /** Returns the status code from the incoming response. */
     @scala.scalajs.wit.annotation.WitResourceMethod("status")
@@ -982,7 +982,7 @@ package object types {
    *  the body contents or waiting on trailers at any given time.
    */
   @scala.scalajs.wit.annotation.WitResourceImport("wasi:http/types@0.2.0", "incoming-body")
-  trait IncomingBody {
+  final class IncomingBody private () extends Object {
 
     /** Returns the contents of the body, as a stream of bytes.
      *
@@ -1023,7 +1023,7 @@ package object types {
    *  complete Request or Response body has been received.
    */
   @scala.scalajs.wit.annotation.WitResourceImport("wasi:http/types@0.2.0", "future-trailers")
-  trait FutureTrailers {
+  final class FutureTrailers private () extends Object {
 
     /** Returns a pollable which becomes ready when either the trailers have
      *  been received, or an error has occured. When this pollable is ready,
@@ -1066,7 +1066,7 @@ package object types {
 
   /** Represents an outgoing HTTP Response. */
   @scala.scalajs.wit.annotation.WitResourceImport("wasi:http/types@0.2.0", "outgoing-response")
-  trait OutgoingResponse {
+  final class OutgoingResponse private () extends Object {
 
     /** Get the HTTP Status Code for the Response. */
     @scala.scalajs.wit.annotation.WitResourceMethod("status-code")
@@ -1136,7 +1136,7 @@ package object types {
    *  Request, or sending a late status code for the Response.
    */
   @scala.scalajs.wit.annotation.WitResourceImport("wasi:http/types@0.2.0", "outgoing-body")
-  trait OutgoingBody {
+  final class OutgoingBody private () extends Object {
 
     /** Returns a stream for writing the body contents.
      *
@@ -1182,7 +1182,7 @@ package object types {
    */
   @scala.scalajs.wit.annotation.WitResourceImport(
       "wasi:http/types@0.2.0", "future-incoming-response")
-  trait FutureIncomingResponse {
+  final class FutureIncomingResponse private () extends Object {
 
     /** Returns a pollable which becomes ready when either the Response has
      *  been received, or an error has occured. When this pollable is ready,

--- a/library/src/main/scala/scala/scalajs/wasi/io/Error.scala
+++ b/library/src/main/scala/scala/scalajs/wasi/io/Error.scala
@@ -24,7 +24,7 @@ package object error {
    *  concrete type is open.
    */
   @scala.scalajs.wit.annotation.WitResourceImport("wasi:io/error@0.2.0", "error")
-  trait Error {
+  final class Error private () extends Object {
 
     /** Returns a string that is suitable to assist humans in debugging
      *  this error.

--- a/library/src/main/scala/scala/scalajs/wasi/io/Streams.scala
+++ b/library/src/main/scala/scala/scalajs/wasi/io/Streams.scala
@@ -44,7 +44,7 @@ package object streams {
    *  for using `wasi:io/poll`.
    */
   @scala.scalajs.wit.annotation.WitResourceImport("wasi:io/streams@0.2.0", "input-stream")
-  trait InputStream {
+  final class InputStream private () extends Object {
 
     /** Perform a non-blocking read from the stream.
      *
@@ -126,7 +126,7 @@ package object streams {
    *  polled for using `wasi:io/poll`.
    */
   @scala.scalajs.wit.annotation.WitResourceImport("wasi:io/streams@0.2.0", "output-stream")
-  trait OutputStream {
+  final class OutputStream private () extends Object {
 
     /** Check readiness for writing. This function never blocks.
      *

--- a/library/src/main/scala/scala/scalajs/wasi/io/poll.scala
+++ b/library/src/main/scala/scala/scalajs/wasi/io/poll.scala
@@ -5,7 +5,7 @@ package object poll {
   // Resources
   /** `pollable` represents a single I/O event which may be ready, or not. */
   @scala.scalajs.wit.annotation.WitResourceImport("wasi:io/poll@0.2.0", "pollable")
-  trait Pollable {
+  final class Pollable private () extends Object {
 
     /** Return the readiness of a pollable. This function never blocks.
      *

--- a/library/src/main/scala/scala/scalajs/wasi/sockets/ip_name_lookup.scala
+++ b/library/src/main/scala/scala/scalajs/wasi/sockets/ip_name_lookup.scala
@@ -14,7 +14,7 @@ package object ip_name_lookup {
   // Resources
   @scala.scalajs.wit.annotation.WitResourceImport(
       "wasi:sockets/ip-name-lookup@0.2.0", "resolve-address-stream")
-  trait ResolveAddressStream {
+  final class ResolveAddressStream private () extends Object {
 
     /** Returns the next address from the resolver.
      *

--- a/library/src/main/scala/scala/scalajs/wasi/sockets/network.scala
+++ b/library/src/main/scala/scala/scalajs/wasi/sockets/network.scala
@@ -291,7 +291,7 @@ package object network {
    *  There is no need for this to map 1:1 to a physical network interface.
    */
   @scala.scalajs.wit.annotation.WitResourceImport("wasi:sockets/network@0.2.0", "network")
-  trait Network {
+  final class Network private () extends Object {
     @scala.scalajs.wit.annotation.WitResourceDrop
     def close(): Unit = scala.scalajs.wit.native
   }

--- a/library/src/main/scala/scala/scalajs/wasi/sockets/tcp.scala
+++ b/library/src/main/scala/scala/scalajs/wasi/sockets/tcp.scala
@@ -60,7 +60,7 @@ package object tcp {
    *  `error(invalid-state)` when in the `closed` state.
    */
   @scala.scalajs.wit.annotation.WitResourceImport("wasi:sockets/tcp@0.2.0", "tcp-socket")
-  trait TcpSocket {
+  final class TcpSocket private () extends Object {
 
     /** Bind the socket to a specific network on the provided IP address and port.
      *

--- a/library/src/main/scala/scala/scalajs/wasi/sockets/udp.scala
+++ b/library/src/main/scala/scala/scalajs/wasi/sockets/udp.scala
@@ -71,7 +71,7 @@ package object udp {
   // Resources
   /** A UDP socket handle. */
   @scala.scalajs.wit.annotation.WitResourceImport("wasi:sockets/udp@0.2.0", "udp-socket")
-  trait UdpSocket {
+  final class UdpSocket private () extends Object {
 
     /** Bind the socket to a specific network on the provided IP address and port.
      *
@@ -258,7 +258,7 @@ package object udp {
 
   @scala.scalajs.wit.annotation.WitResourceImport(
       "wasi:sockets/udp@0.2.0", "incoming-datagram-stream")
-  trait IncomingDatagramStream {
+  final class IncomingDatagramStream private () extends Object {
 
     /** Receive messages on the socket.
      *
@@ -306,7 +306,7 @@ package object udp {
 
   @scala.scalajs.wit.annotation.WitResourceImport(
       "wasi:sockets/udp@0.2.0", "outgoing-datagram-stream")
-  trait OutgoingDatagramStream {
+  final class OutgoingDatagramStream private () extends Object {
 
     /** Check readiness for sending. This function never blocks.
      *

--- a/linker/jvm/src/main/resources/org/scalajs/linker/backend/webassembly/wasi-wit/README.md
+++ b/linker/jvm/src/main/resources/org/scalajs/linker/backend/webassembly/wasi-wit/README.md
@@ -4,12 +4,16 @@ Generated from WIT files in `linker/jvm/src/main/resources/org/scalajs/linker/ba
 
 ## Regenerating bindings
 
-Install `scala-wasm` supported `wit-bindgen` from https://github.com/scala-wasm/wit-bindgen
+Install `wit-bindgen-scala`:
+
+```bash
+cargo install wit-bindgen-scala --version 0.1.0-rc.1
+```
 
 From project root:
 
 ```bash
-wit-bindgen scala linker/jvm/src/main/resources/org/scalajs/linker/backend/webassembly/wasi-wit \
+wit-bindgen-scala linker/jvm/src/main/resources/org/scalajs/linker/backend/webassembly/wasi-wit \
   --world wasi-bindings \
   --out-dir library/src/main/scala \
   --base-package scala.scalajs

--- a/linker/shared/src/main/scala/org/scalajs/linker/analyzer/Analyzer.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/analyzer/Analyzer.scala
@@ -49,7 +49,7 @@ import Platform._
 
 import Analysis._
 import Infos.{NamespacedMethodName, ReachabilityInfo, ReachabilityInfoInClass}
-import org.scalajs.ir.ClassKind.NativeWasmComponentResourceClass
+import org.scalajs.ir.ClassKind.WasmComponentResourceClass
 
 final class Analyzer(config: CommonPhaseConfig, initial: Boolean,
     checkIRFor: Option[CheckingPhase], failOnError: Boolean, irLoader: IRLoader) {
@@ -652,13 +652,16 @@ private class AnalyzerRun(config: CommonPhaseConfig, initial: Boolean,
             }
           }
 
-        case NativeWasmComponentResourceClass =>
+        case WasmComponentResourceClass =>
           superClass match {
+            case Some(superCl) if superCl eq objectClassInfo =>
+              superClass
             case Some(superCl) =>
               _errors ::= InvalidSuperClass(superCl, this, from)
+              Some(objectClassInfo)
             case None =>
+              Some(objectClassInfo)
           }
-          Some(objectClassInfo)
       }
     }
 
@@ -669,7 +672,7 @@ private class AnalyzerRun(config: CommonPhaseConfig, initial: Boolean,
         case ClassKind.Class | ClassKind.ModuleClass |
             ClassKind.HijackedClass | ClassKind.Interface =>
           ClassKind.Interface
-        case ClassKind.NativeWasmComponentResourceClass =>
+        case ClassKind.WasmComponentResourceClass =>
           ClassKind.Interface
         case ClassKind.JSClass | ClassKind.JSModuleClass |
             ClassKind.NativeJSClass | ClassKind.NativeJSModuleClass |

--- a/linker/shared/src/main/scala/org/scalajs/linker/analyzer/Infos.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/analyzer/Infos.scala
@@ -260,14 +260,6 @@ object Infos {
           addMethodCalledStatically(ObjectClass,
               NamespacedMethodName(MemberNamespace.Public, method))
 
-        case WitResourceType(_) =>
-          /* WIT resource types are opaque external types that do not define
-           * standard Java methods themselves. They are all inherited from
-           * j.l.Object, so we handle them the same way as Arrays.
-           */
-          addMethodCalledStatically(ObjectClass,
-              NamespacedMethodName(MemberNamespace.Public, method))
-
         case NullType | NothingType =>
           // Nothing to do
 

--- a/linker/shared/src/main/scala/org/scalajs/linker/backend/emitter/CoreJSLib.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/backend/emitter/CoreJSLib.scala
@@ -1693,8 +1693,6 @@ private[emitter] object CoreJSLib {
               (globalVar(VarField.ah, ObjectClass).prototype := prototypeFor(ArrayClass)) :: Nil
             case _: PrimRef =>
               clsDef
-            case WitResourceTypeRef(_) =>
-              throw new AssertionError(s"Unexpected component resource type in JS backend.")
           }
         }
       }

--- a/linker/shared/src/main/scala/org/scalajs/linker/backend/emitter/NameGen.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/backend/emitter/NameGen.scala
@@ -168,8 +168,6 @@ private[backend] final class NameGen {
             appendTypeRef(base)
           case TransientTypeRef(name) =>
             builder.append('t').append(genName(name))
-          case WitResourceTypeRef(className) =>
-            throw new AssertionError(s"Unexpected component resource type ref in JS backend.")
         }
       }
 

--- a/linker/shared/src/main/scala/org/scalajs/linker/backend/emitter/SJSGen.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/backend/emitter/SJSGen.scala
@@ -483,8 +483,7 @@ private[emitter] final class SJSGen(
       case VoidType | NullType | NothingType | AnyType |
           ClassType(_, true, _) | ClassType(_, _, true) |
           ArrayType(_, true, _) | ArrayType(_, _, true) |
-          _:ClosureType | _:RecordType |
-          _:WitResourceType =>
+          _:ClosureType | _:RecordType =>
         throw new AssertionError(s"Unexpected type $tpe in genIsInstanceOf")
     }
   }
@@ -560,8 +559,7 @@ private[emitter] final class SJSGen(
         case VoidType | NullType | NothingType | AnyNotNullType |
             ClassType(_, false, _) | ClassType(_, _, true) |
             ArrayType(_, false, _) | ArrayType(_, _, true) |
-            _:ClosureType | _:RecordType |
-            _:WitResourceType =>
+            _:ClosureType | _:RecordType =>
           throw new AssertionError(s"Unexpected type $tpe in genAsInstanceOf")
       }
     } else {
@@ -589,8 +587,7 @@ private[emitter] final class SJSGen(
         case VoidType | NullType | NothingType | AnyNotNullType |
             ClassType(_, false, _) | ClassType(_, _, true) |
             ArrayType(_, false, _) | ArrayType(_, _, true) |
-            _:ClosureType | _:RecordType |
-            _:WitResourceType =>
+            _:ClosureType | _:RecordType =>
           throw new AssertionError(s"Unexpected type $tpe in genAsInstanceOf")
       }
 

--- a/linker/shared/src/main/scala/org/scalajs/linker/backend/emitter/VarGen.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/backend/emitter/VarGen.scala
@@ -234,9 +234,6 @@ private[emitter] final class VarGen(jsGen: JSGen, nameGen: NameGen,
       case ClassRef(className) =>
         implicit val classScope: Scope[ClassName] = Scope.ClassScope
         globalVar(field, className)
-
-      case WitResourceTypeRef(_) =>
-        throw new AssertionError(s"Unexpected component resource type in JS backend")
     }
   }
 
@@ -407,13 +404,11 @@ private[emitter] final class VarGen(jsGen: JSGen, nameGen: NameGen,
       def subField(x: NonArrayTypeRef): String = x match {
         case ClassRef(className) => ClassScope.subField(className)
         case x: PrimRef          => PrimRefScope.subField(x)
-        case _: WitResourceTypeRef => throw new AssertionError(s"Unexpected component resource type")
       }
 
       def reprClass(x: Types.NonArrayTypeRef): Names.ClassName = x match {
         case ClassRef(className) => ClassScope.reprClass(className)
         case x: PrimRef          => PrimRefScope.reprClass(x)
-        case _: WitResourceTypeRef => throw new AssertionError(s"Unexpected component resource type")
       }
     }
   }

--- a/linker/shared/src/main/scala/org/scalajs/linker/backend/wasmemitter/ClassEmitter.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/backend/wasmemitter/ClassEmitter.scala
@@ -67,7 +67,7 @@ class ClassEmitter(coreSpec: CoreSpec) {
         origName,
         isMutable = true,
         transformFieldType(ftpe),
-        wa.Expr(genZeroOf(ftpe))
+        wa.Expr(List(genZeroOf(ftpe)))
       )
       ctx.addGlobal(global)
     }
@@ -93,9 +93,10 @@ class ClassEmitter(coreSpec: CoreSpec) {
         genInterface(clazz)
       case ClassKind.JSClass | ClassKind.JSModuleClass =>
         genJSClass(clazz)
-      case ClassKind.NativeWasmComponentResourceClass =>
+      case ClassKind.WasmComponentResourceClass =>
         genResourceStruct(clazz)
-        genResourceCastFunction(clazz)
+        if (clazz.hasInstanceTests && semantics.asInstanceOfs != CheckedBehavior.Unchecked)
+          genResourceCastFunction(clazz)
         genResourceVTable(clazz)
       case ClassKind.HijackedClass | ClassKind.AbstractJSType | ClassKind.NativeJSClass |
           ClassKind.NativeJSModuleClass =>
@@ -248,7 +249,7 @@ class ClassEmitter(coreSpec: CoreSpec) {
             KindClass
           case Interface =>
             KindInterface
-          case NativeWasmComponentResourceClass =>
+          case WasmComponentResourceClass =>
             KindClass // TODO
           case JSClass | JSModuleClass | AbstractJSType | NativeJSClass | NativeJSModuleClass =>
             if (clazz.superClass.isDefined)
@@ -575,9 +576,8 @@ class ClassEmitter(coreSpec: CoreSpec) {
       val vtableGlobalID = genGlobalID.forArrayVTable(baseTypeRef)
 
       val nameStr = baseTypeRef match {
-        case baseTypeRef: PrimRef          => "[" + baseTypeRef.charCode.toString()
-        case ClassRef(className)           => "[L" + runtimeClassNameOf(className) + ";"
-        case WitResourceTypeRef(className) => "[W" + runtimeClassNameOf(className) + ";"
+        case baseTypeRef: PrimRef => "[" + baseTypeRef.charCode.toString()
+        case ClassRef(className)  => "[L" + runtimeClassNameOf(className) + ";"
       }
       val nameValue = if (ctx.hasJSInterop) {
         ctx.stringPool.getConstantStringDataInstr(nameStr)
@@ -592,7 +592,7 @@ class ClassEmitter(coreSpec: CoreSpec) {
       ) ::: (
         strictAncestorsTypeData // strictAncestors
       ) ::: List(
-        wa.GlobalGet(nonArrayTypeDataGlobalID(baseTypeRef)), // componentType
+        wa.GlobalGet(genGlobalID.forVTable(baseTypeRef)), // componentType
         wa.RefNull(watpe.HeapType.None), // classOf
         wa.RefNull(watpe.HeapType.None), // arrayOf
         wa.RefFunc(genFunctionID.cloneArray(baseTypeRef)), // clone
@@ -822,7 +822,7 @@ class ClassEmitter(coreSpec: CoreSpec) {
       fb += wa.I32Const(0)
 
     classInfo.allFieldDefs.foreach { f =>
-      fb ++= genZeroOf(f.ftpe)
+      fb += genZeroOf(f.ftpe)
     }
     for (dataParam <- dataParamOpt)
       fb += wa.LocalGet(dataParam)
@@ -900,33 +900,35 @@ class ClassEmitter(coreSpec: CoreSpec) {
     val objParam = fb.addParam("obj", watpe.RefType.anyref)
     fb.setResultType(resultType)
 
-    fb.block(resultType) { successLabel =>
+    fb.block() { successLabel =>
       fb += wa.LocalGet(objParam)
+      fb += wa.BrOnNull(successLabel)
 
       if (className == SpecialNames.JLNumberClass) {
         /* jl.Number is special, because it is the only non-Object *class*
          * that is an  ancestor of a hijacked class.
          */
-        fb += wa.BrOnCast(successLabel, watpe.RefType.anyref,
-            watpe.RefType.nullable(genTypeID.forClass(SpecialNames.JLNumberClass)))
-
-        /* The `obj` still on the stack will be used for:
-         * a) the result in the true case
-         * b) consistency with non-Number in the false case
-         */
+        fb += wa.RefTest(watpe.RefType(genTypeID.forClass(SpecialNames.JLNumberClass)))
+        fb += wa.BrIf(successLabel)
 
         fb += wa.LocalGet(objParam)
         fb += wa.Call(genFunctionID.typeTest(DoubleRef))
         fb += wa.BrIf(successLabel)
       } else {
-        fb += wa.BrOnCast(successLabel, watpe.RefType.anyref, resultType)
+        fb += wa.RefTest(resultType.toNonNullable)
+        fb += wa.BrIf(successLabel)
       }
 
-      // If we get here, it's a CCE -- `obj` is still on the stack
+      // If we get here, it's a CCE.
+      fb += wa.LocalGet(objParam)
       fb += wa.GlobalGet(genGlobalID.forVTable(className))
       fb += wa.Call(genFunctionID.classCastException)
       SWasmGen.genForwardThrowAlwaysAsReturn(fb, List(wa.RefNull(watpe.HeapType.None)))
     }
+
+    fb += wa.LocalGet(objParam)
+    if (resultType != watpe.RefType.anyref)
+      fb += wa.RefCast(resultType)
 
     fb.buildAndAddToModule()
   }
@@ -1625,7 +1627,7 @@ class ClassEmitter(coreSpec: CoreSpec) {
    */
   private def genResourceStruct(clazz: LinkedClass)(implicit ctx: WasmContext): Unit = {
     val className = clazz.className
-    val structTypeID = genTypeID.forResourceClass(className)
+    val structTypeID = genTypeID.forClass(className)
 
     val vtableField = watpe.StructField(
       genFieldID.objStruct.vtable,
@@ -1668,7 +1670,7 @@ class ClassEmitter(coreSpec: CoreSpec) {
    *  resource name (e.g., "resource<ClassName>") and all Object methods.
    */
   private def genResourceVTable(clazz: LinkedClass)(implicit ctx: WasmContext): Unit = {
-    assert(clazz.kind == ClassKind.NativeWasmComponentResourceClass)
+    assert(clazz.kind == ClassKind.WasmComponentResourceClass)
     val className = clazz.className
     val vtableTypeID = genTypeID.ObjectVTable
     val objectClassInfo = ctx.getClassInfo(ObjectClass)
@@ -1736,18 +1738,33 @@ class ClassEmitter(coreSpec: CoreSpec) {
    */
   private def genResourceCastFunction(clazz: LinkedClass)(implicit ctx: WasmContext): Unit = {
     val className = clazz.className
-    val resourceStructType = TypeTransformer.transformWitResourceType(className)
+    val resourceStructType = watpe.RefType.nullable(genTypeID.forClass(className))
 
     val fb = new FunctionBuilder(
       ctx.moduleBuilder,
-      genFunctionID.asInstance(WitResourceType(className)),
+      genFunctionID.asInstance(ClassType(className, nullable = true, exact = false)),
       makeDebugName(ns.AsInstance, className),
       clazz.pos
     )
     val objParam = fb.addParam("obj", watpe.RefType.anyref)
     fb.setResultType(resourceStructType)
+
+    fb.block() { successLabel =>
+      fb += wa.LocalGet(objParam)
+      fb += wa.BrOnNull(successLabel)
+
+      fb += wa.RefTest(resourceStructType.toNonNullable)
+      fb += wa.BrIf(successLabel)
+
+      fb += wa.LocalGet(objParam)
+      fb += wa.GlobalGet(genGlobalID.forVTable(className))
+      fb += wa.Call(genFunctionID.classCastException)
+      SWasmGen.genForwardThrowAlwaysAsReturn(fb, List(wa.RefNull(watpe.HeapType.None)))
+    }
+
     fb += wa.LocalGet(objParam)
-    fb += wa.RefCast(resourceStructType)
+    if (resourceStructType != watpe.RefType.anyref)
+      fb += wa.RefCast(resourceStructType)
 
     fb.buildAndAddToModule()
   }
@@ -1838,9 +1855,8 @@ class ClassEmitter(coreSpec: CoreSpec) {
 
   private def makeDebugName(namespace: UTF8String, typeRef: NonArrayTypeRef): OriginalName = {
     val encoded = typeRef match {
-      case typeRef: PrimRef              => UTF8String(typeRef.charCode.toString())
-      case ClassRef(className)           => className.encoded
-      case WitResourceTypeRef(className) => UTF8String("W") ++ className.encoded
+      case typeRef: PrimRef    => UTF8String(typeRef.charCode.toString())
+      case ClassRef(className) => className.encoded
     }
     OriginalName(namespace ++ encoded)
   }
@@ -1979,8 +1995,8 @@ object ClassEmitter {
     fb.setFunctionType(ctx.tableFunctionType(methodName))
 
     fb += wa.LocalGet(thisParam)
-    fb += wa.RefCast(watpe.RefType(genTypeID.forResourceClass(className)))
-    fb += wa.StructGet(genTypeID.forResourceClass(className), genFieldID.handle)
+    fb += wa.RefCast(watpe.RefType(genTypeID.forClass(className)))
+    fb += wa.StructGet(genTypeID.forClass(className), genFieldID.handle)
 
     fb.buildAndAddToModule()
     functionID
@@ -2004,31 +2020,28 @@ object ClassEmitter {
     fb.setResultType(watpe.Int32)
     fb.setFunctionType(ctx.tableFunctionType(methodName))
 
-    val resourceStructTypeID = genTypeID.forResourceClass(className)
+    val resourceStructTypeID = genTypeID.forClass(className)
     val thisResourceLocal = fb.addLocal("thisResource", watpe.RefType(resourceStructTypeID))
-    val thatResourceLocal =
-      fb.addLocal("thatResource", watpe.RefType.nullable(watpe.HeapType(resourceStructTypeID)))
+    val thatResourceLocal = fb.addLocal("thatResource", watpe.RefType(resourceStructTypeID))
 
     fb += wa.LocalGet(thisParam)
     fb += wa.RefCast(watpe.RefType(resourceStructTypeID))
     fb += wa.LocalSet(thisResourceLocal)
 
     fb += wa.LocalGet(thatParam)
-    fb += wa.RefCast(watpe.RefType.nullable(watpe.HeapType(resourceStructTypeID)))
-    fb += wa.LocalTee(thatResourceLocal)
-
-    // If cast fails, return false
-    fb += wa.RefIsNull
+    fb += wa.RefTest(watpe.RefType(resourceStructTypeID))
     fb.ifThenElse(watpe.Int32) {
-      fb += wa.I32Const(0)
-    } {
-      // this.handle == that.handle
+      fb += wa.LocalGet(thatParam)
+      fb += wa.RefCast(watpe.RefType(resourceStructTypeID))
+      fb += wa.LocalSet(thatResourceLocal)
+
       fb += wa.LocalGet(thisResourceLocal)
       fb += wa.StructGet(resourceStructTypeID, genFieldID.handle)
       fb += wa.LocalGet(thatResourceLocal)
-      fb += wa.RefAsNonNull
       fb += wa.StructGet(resourceStructTypeID, genFieldID.handle)
       fb += wa.I32Eq
+    } {
+      fb += wa.I32Const(0)
     }
 
     fb.buildAndAddToModule()

--- a/linker/shared/src/main/scala/org/scalajs/linker/backend/wasmemitter/CoreWasmLib.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/backend/wasmemitter/CoreWasmLib.scala
@@ -75,9 +75,8 @@ final class CoreWasmLib(coreSpec: CoreSpec, globalInfo: LinkedGlobalInfo) {
   )
 
   private def charCodeForOriginalName(baseRef: NonArrayTypeRef): Char = baseRef match {
-    case baseRef: PrimRef      => baseRef.charCode
-    case _: ClassRef           => 'O'
-    case WitResourceTypeRef(_) => 'O'
+    case baseRef: PrimRef => baseRef.charCode
+    case _: ClassRef      => 'O'
   }
 
   /** Fields of the `typeData` struct definition.
@@ -1330,7 +1329,7 @@ final class CoreWasmLib(coreSpec: CoreSpec, globalInfo: LinkedGlobalInfo) {
         )
         fb += Br(doneLabel)
       }
-      fb ++= genZeroOf(targetTpe)
+      fb += genZeroOf(targetTpe)
     }
 
     fb.buildAndAddToModule()
@@ -2158,11 +2157,11 @@ final class CoreWasmLib(coreSpec: CoreSpec, globalInfo: LinkedGlobalInfo) {
       // If we get here, it is a CCE
       fb += GlobalGet(genGlobalID.forVTable(PrimTypeToBoxedClass(primType)))
       fb += Call(genFunctionID.classCastException)
-      genForwardThrowAlways(fb, fakeResult = SWasmGen.genZeroOf(targetTpe))
+      genForwardThrowAlways(fb, fakeResult = List(SWasmGen.genZeroOf(targetTpe)))
     }
 
     // obj is null -- load the zero of the target type (which is `null` for boxed classes)
-    fb ++= SWasmGen.genZeroOf(targetTpe)
+    fb += SWasmGen.genZeroOf(targetTpe)
 
     fb.buildAndAddToModule()
   }
@@ -2350,9 +2349,8 @@ final class CoreWasmLib(coreSpec: CoreSpec, globalInfo: LinkedGlobalInfo) {
     val underlyingTypeID = genTypeID.underlyingOf(arrayTypeRef)
 
     val elemWasmType = baseRef match {
-      case PrimRef(tpe)          => transformSingleType(tpe)
-      case ClassRef(_)           => anyref
-      case WitResourceTypeRef(_) => anyref
+      case PrimRef(tpe) => transformSingleType(tpe)
+      case ClassRef(_)  => anyref
     }
 
     val fb = newFunctionBuilder(genFunctionID.arrayGet(baseRef), origName)
@@ -2410,9 +2408,8 @@ final class CoreWasmLib(coreSpec: CoreSpec, globalInfo: LinkedGlobalInfo) {
     val underlyingTypeID = genTypeID.underlyingOf(arrayTypeRef)
 
     val elemWasmType = baseRef match {
-      case PrimRef(tpe)          => transformSingleType(tpe)
-      case ClassRef(_)           => anyref
-      case WitResourceTypeRef(_) => anyref
+      case PrimRef(tpe) => transformSingleType(tpe)
+      case ClassRef(_)  => anyref
     }
 
     val fb = newFunctionBuilder(genFunctionID.arraySet(baseRef), origName)

--- a/linker/shared/src/main/scala/org/scalajs/linker/backend/wasmemitter/FunctionEmitter.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/backend/wasmemitter/FunctionEmitter.scala
@@ -612,7 +612,7 @@ private class FunctionEmitter private (
        * synthesize a fake result.
        */
       if (expectedType != VoidType && expectedType != NothingType)
-        fb ++= SWasmGen.genZeroOf(expectedType)
+        fb += SWasmGen.genZeroOf(expectedType)
     }
 
     currentExceptionHandler = null
@@ -989,7 +989,7 @@ private class FunctionEmitter private (
             PrimTypeToBoxedClass(prim)
           case ClassType(cls, _, _) =>
             cls
-          case AnyType | AnyNotNullType | ArrayType(_, _, _) | WitResourceType(_) =>
+          case AnyType | AnyNotNullType | ArrayType(_, _, _) =>
             ObjectClass
 
           case tpe @ (_:ClosureType | _:RecordType) =>
@@ -1011,7 +1011,6 @@ private class FunctionEmitter private (
         val useStaticDispatch = receiver.tpe match {
           case _ if receiverClassInfo.kind == ClassKind.HijackedClass => true
           case _: ArrayType                                           => true
-          case _: WitResourceType                                     => true
           case ClassType(_, _, exact)                                 => exact
           case _                                                      => false
         }
@@ -2385,9 +2384,6 @@ private class FunctionEmitter private (
       case ArrayType(_, _, _) =>
         genWithDispatch(needHijackedClassDispatch = false)
 
-      case WitResourceType(_) =>
-        genWithDispatch(needHijackedClassDispatch = false)
-
       case tpe @ (_:ClosureType | _:RecordType) =>
         throw new AssertionError(
             s"Invalid type ${tree.tpe} for String_+ at ${tree.pos}: $tree")
@@ -2605,8 +2601,7 @@ private class FunctionEmitter private (
       case AnyType |
           ClassType(_, true, _) | ClassType(_, _, true) |
           ArrayType(_, true, _) | ArrayType(_, _, true) |
-          _:ClosureType | _:RecordType |
-          _:WitResourceType =>
+          _:ClosureType | _:RecordType =>
         throw new AssertionError(s"Illegal type in IsInstanceOf: $testType")
     }
 
@@ -2746,7 +2741,7 @@ private class FunctionEmitter private (
           )
           fb += wa.Br(doneLabel)
         }
-        fb ++= genZeroOf(targetTpe)
+        fb += genZeroOf(targetTpe)
       }
     }
     targetTpe match {

--- a/linker/shared/src/main/scala/org/scalajs/linker/backend/wasmemitter/SWasmGen.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/backend/wasmemitter/SWasmGen.scala
@@ -25,28 +25,7 @@ import org.scalajs.linker.backend.webassembly.Identitities.LocalID
 /** Scala.js-specific Wasm generators that are used across the board. */
 object SWasmGen {
 
-  def nonArrayTypeDataGlobalID(typeRef: NonArrayTypeRef) = typeRef match {
-    case WitResourceTypeRef(className) =>
-      // Resource classes currently share the class-backed typeData/vtable global.
-      genGlobalID.forVTable(className)
-    case _ =>
-      genGlobalID.forVTable(typeRef)
-  }
-
-  def genZeroOf(tpe: Type)(implicit ctx: WasmContext): List[Instr] = {
-    tpe match {
-      case WitResourceType(className) =>
-        List(
-            GlobalGet(genGlobalID.forVTable(className)), // vtable
-            I32Const(0), // idHashCode (unused, needed for subtyping)
-            I32Const(0), // handle (zero value)
-            StructNew(genTypeID.forResourceClass(className)))
-      case _ =>
-        List(genZeroOf0(tpe))
-    }
-  }
-
-  private def genZeroOf0(tpe: Type)(implicit ctx: WasmContext): Instr = {
+  def genZeroOf(tpe: Type)(implicit ctx: WasmContext): Instr = {
     tpe match {
       case BooleanType | CharType | ByteType | ShortType | IntType =>
         I32Const(0)
@@ -68,7 +47,7 @@ object SWasmGen {
         RefNull(Types.HeapType.None)
 
       case NothingType | VoidType | ClassType(_, false, _) | ArrayType(_, false, _) |
-          ClosureType(_, _, false) | AnyNotNullType | _:WitResourceType | _:RecordType =>
+          ClosureType(_, _, false) | AnyNotNullType | _:RecordType =>
         throw new AssertionError(s"Unexpected type for field: ${tpe.show()}")
     }
   }
@@ -91,7 +70,7 @@ object SWasmGen {
   }
 
   def genLoadNonArrayTypeData(fb: FunctionBuilder, typeRef: NonArrayTypeRef): Unit =
-    fb += GlobalGet(nonArrayTypeDataGlobalID(typeRef))
+    fb += GlobalGet(genGlobalID.forVTable(typeRef))
 
   def genLoadArrayTypeData(fb: FunctionBuilder, arrayTypeRef: ArrayTypeRef): Unit = {
     val ArrayTypeRef(base, dimensions) = arrayTypeRef

--- a/linker/shared/src/main/scala/org/scalajs/linker/backend/wasmemitter/TypeTransformer.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/backend/wasmemitter/TypeTransformer.scala
@@ -91,8 +91,6 @@ object TypeTransformer {
       case ClassType(className, nullable, exact) => transformClassType(className, nullable, exact)
       case tpe: PrimType                         => transformPrimType(tpe)
 
-      case WitResourceType(className) => transformWitResourceType(className)
-
       case ArrayType(arrayTypeRef, nullable, _) =>
         watpe.RefType(nullable, genTypeID.forArrayClass(arrayTypeRef))
 
@@ -129,16 +127,6 @@ object TypeTransformer {
     }
 
     watpe.RefType(nullable, heapType)
-  }
-
-  def transformWitResourceType(className: ClassName)(
-      implicit ctx: WasmContext): watpe.RefType = {
-    /* Component resources are represented as simple wrapper structs containing
-     * only an i32 handle field. They are converted to/from i32 handles at
-     * component model boundaries
-     */
-    val heapType = watpe.HeapType(genTypeID.forResourceClass(className))
-    watpe.RefType(nullable = false, heapType)
   }
 
   def transformPrimType(tpe: PrimType)(implicit ctx: WasmContext): watpe.Type = {

--- a/linker/shared/src/main/scala/org/scalajs/linker/backend/wasmemitter/VarGen.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/backend/wasmemitter/VarGen.scala
@@ -495,7 +495,6 @@ object VarGen {
 
   object genTypeID {
     final case class forClass(className: ClassName) extends TypeID
-    final case class forResourceClass(className: ClassName) extends TypeID
     final case class captureData(index: Int) extends TypeID
     final case class forVTable(className: ClassName) extends TypeID
     final case class forITable(className: ClassName) extends TypeID

--- a/linker/shared/src/main/scala/org/scalajs/linker/backend/wasmemitter/WasmContext.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/backend/wasmemitter/WasmContext.scala
@@ -122,8 +122,6 @@ final class WasmContext(
         AnyType
       else
         ClassType(className, nullable = true, exact = false)
-    case WitResourceTypeRef(className) =>
-      WitResourceType(className)
     case typeRef: ArrayTypeRef =>
       ArrayType(typeRef, nullable = true, exact = false)
     case typeRef: TransientTypeRef =>

--- a/linker/shared/src/main/scala/org/scalajs/linker/backend/wasmemitter/canonicalabi/CABIToScalaJS.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/backend/wasmemitter/canonicalabi/CABIToScalaJS.scala
@@ -147,7 +147,7 @@ object CABIToScalaJS {
         // genAlignTo(fb, wit.alignment(tpe), ptr)
 
       case wit.ResourceType(className) =>
-        val resourceStructID = genTypeID.forResourceClass(className)
+        val resourceStructID = genTypeID.forClass(className)
         val handleLocal = fb.addLocal(NoOriginalName, watpe.Int32)
         fb += wa.I32Load()
         fb += wa.LocalSet(handleLocal)
@@ -236,7 +236,7 @@ object CABIToScalaJS {
         fb += wa.GlobalGet(genGlobalID.forVTable(className)) // vtable
         fb += wa.I32Const(0) // idHashCode
         vi.next(watpe.Int32) // handle
-        fb += wa.StructNew(genTypeID.forResourceClass(className))
+        fb += wa.StructNew(genTypeID.forClass(className))
 
       case wit.TupleType(fields) =>
         val ctor = MethodName.constructor(List.fill(fields.size)(ClassRef(ObjectClass)))

--- a/linker/shared/src/main/scala/org/scalajs/linker/backend/wasmemitter/canonicalabi/ScalaJSToCABI.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/backend/wasmemitter/canonicalabi/ScalaJSToCABI.scala
@@ -204,7 +204,7 @@ object ScalaJSToCABI {
         genStoreVariantMemory(fb, cases, (tpe) => { genUnbox(fb, tpe) })
 
       case wit.ResourceType(className) =>
-        val resourceStructID = genTypeID.forResourceClass(className)
+        val resourceStructID = genTypeID.forClass(className)
         fb += wa.RefCast(watpe.RefType(resourceStructID))
         fb += wa.StructGet(resourceStructID, genFieldID.handle)
         fb += wa.I32Store()
@@ -226,7 +226,7 @@ object ScalaJSToCABI {
 
       case wit.ResourceType(className) =>
         // Unwrap: Extract i32 handle from resource struct for stack
-        val resourceStructID = genTypeID.forResourceClass(className)
+        val resourceStructID = genTypeID.forClass(className)
         fb += wa.RefCast(watpe.RefType(resourceStructID))
         fb += wa.StructGet(resourceStructID, genFieldID.handle)
 
@@ -615,7 +615,7 @@ object ScalaJSToCABI {
     targetTpe match {
       case wit.ResourceType(className) =>
         // Cast from anyref (from Result/Option value field) to resource struct type
-        val resourceStructType = watpe.RefType(genTypeID.forResourceClass(className))
+        val resourceStructType = watpe.RefType(genTypeID.forClass(className))
         fb += wa.RefCast(resourceStructType)
       case _ =>
         targetTpe.toIRType() match {

--- a/linker/shared/src/main/scala/org/scalajs/linker/checker/ClassDefChecker.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/checker/ClassDefChecker.scala
@@ -172,9 +172,11 @@ private final class ClassDefChecker(classDef: ClassDef,
         if (classDef.superClass.isDefined)
           reportError("java.lang.Object cannot have a superClass")
 
-      case ClassKind.NativeWasmComponentResourceClass =>
-        if (classDef.superClass.isDefined)
-          reportError("Wasm component resource cannot have a superClass")
+      case ClassKind.WasmComponentResourceClass =>
+        if (classDef.superClass.isEmpty)
+          reportError("missing superClass")
+        else if (classDef.superClass.get.name != ObjectClass)
+          reportError("Wasm component resource must have java.lang.Object as its superClass")
 
       case ClassKind.Class | ClassKind.ModuleClass | ClassKind.HijackedClass |
           ClassKind.JSClass | ClassKind.JSModuleClass |
@@ -289,8 +291,9 @@ private final class ClassDefChecker(classDef: ClassDef,
       case ClassKind.Class | ClassKind.HijackedClass =>
         // all namespaces are allowed (except for class initializers as checked above)
 
-      case ClassKind.NativeWasmComponentResourceClass =>
-        // TODO
+      case ClassKind.WasmComponentResourceClass =>
+        if (isConstructor && name != NoArgConstructorName)
+          reportError("Wasm component resource class must have a parameterless constructor")
 
       case ClassKind.Interface =>
         if (isConstructor)

--- a/linker/shared/src/main/scala/org/scalajs/linker/checker/IRChecker.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/checker/IRChecker.scala
@@ -873,12 +873,6 @@ private final class IRChecker(linkTimeProperties: LinkTimeProperties,
               i"JS type $className is not a valid target type for " +
               "Is/AsInstanceOf")
         }
-        if (kind == ClassKind.NativeWasmComponentResourceClass) {
-          reportError(
-              i"Resource class $className is not a valid target type for " +
-              "Is/AsInstanceOf")
-        }
-
       case _ =>
         // Non ClassTypes are checked by the ClassDef checker.
     }
@@ -895,11 +889,10 @@ private final class IRChecker(linkTimeProperties: LinkTimeProperties,
   private def typeRefToType(typeRef: TypeRef)(
       implicit ctx: ErrorContext): Type = {
     typeRef match {
-      case PrimRef(tpe)                  => tpe
-      case ClassRef(className)           => classNameToType(className)
-      case arrayTypeRef: ArrayTypeRef    => ArrayType(arrayTypeRef, nullable = true, exact = false)
-      case typeRef: TransientTypeRef     => typeRef.tpe
-      case WitResourceTypeRef(className) => WitResourceType(className)
+      case PrimRef(tpe)               => tpe
+      case ClassRef(className)        => classNameToType(className)
+      case arrayTypeRef: ArrayTypeRef => ArrayType(arrayTypeRef, nullable = true, exact = false)
+      case typeRef: TransientTypeRef  => typeRef.tpe
     }
   }
 

--- a/linker/shared/src/main/scala/org/scalajs/linker/frontend/BaseLinker.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/frontend/BaseLinker.scala
@@ -23,6 +23,7 @@ import org.scalajs.linker.checker._
 import org.scalajs.linker.analyzer._
 
 import org.scalajs.ir
+import org.scalajs.ir.ClassKind
 import org.scalajs.ir.Names.ClassName
 import org.scalajs.ir.Trees.{ClassDef, MethodDef}
 import org.scalajs.ir.Version
@@ -177,6 +178,8 @@ private[frontend] object BaseLinker {
     val allMethods = methods ++ syntheticMethodDefs
 
     val ancestors = classInfo.ancestors.map(_.className)
+    val isNativeWasmComponentResource =
+      classDef.kind == ClassKind.WasmComponentResourceClass
 
     val linkedClass = new LinkedClass(
         classDef.name,
@@ -195,8 +198,8 @@ private[frontend] object BaseLinker {
         classDef.optimizerHints,
         classDef.pos,
         ancestors.toList,
-        hasInstances = classInfo.isAnySubclassInstantiated,
-        hasDirectInstances = classInfo.isInstantiated,
+        hasInstances = classInfo.isAnySubclassInstantiated || isNativeWasmComponentResource,
+        hasDirectInstances = classInfo.isInstantiated || isNativeWasmComponentResource,
         hasInstanceTests = classInfo.areInstanceTestsUsed,
         hasRuntimeTypeInfo = classInfo.isDataAccessed,
         fieldsRead = classInfo.fieldsRead.toSet,

--- a/linker/shared/src/main/scala/org/scalajs/linker/frontend/LambdaSynthesizer.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/frontend/LambdaSynthesizer.scala
@@ -75,9 +75,6 @@ private[linker] object LambdaSynthesizer {
       case ClassRef(className) =>
         digestBuilder.update('L'.toByte)
         digestBuilder.updateUTF8String(className.encoded)
-      case WitResourceTypeRef(className) =>
-        digestBuilder.update('W'.toByte)
-        digestBuilder.updateUTF8String(className.encoded)
       case ArrayTypeRef(base, dimensions) =>
         digestBuilder.update('['.toByte)
         updateTypeRef(base)

--- a/linker/shared/src/main/scala/org/scalajs/linker/frontend/optimizer/OptimizerCore.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/frontend/optimizer/OptimizerCore.scala
@@ -329,7 +329,7 @@ private[optimizer] abstract class OptimizerCore(
            * of type tests.
            */
           true
-        case _:ClosureType | _:RecordType | WitResourceType(_) =>
+        case _:ClosureType | _:RecordType =>
           // These types are only subtypes of themselves, modulo nullability
           true
       }
@@ -2274,7 +2274,6 @@ private[optimizer] abstract class OptimizerCore(
             case ClassType(_, _, exact)   => exact
             case _:PrimType | _:ArrayType => true
             case AnyType | AnyNotNullType => false
-            case _: WitResourceType       => true
 
             case _:ClosureType | _:RecordType =>
               throw new AssertionError(s"Invalid receiver type ${treceiver.tpe} at $pos")
@@ -2458,7 +2457,7 @@ private[optimizer] abstract class OptimizerCore(
   private def boxedClassForType(tpe: Type): ClassName = (tpe: @unchecked) match {
     case ClassType(className, _, _) =>
       className
-    case AnyType | AnyNotNullType | _:ArrayType | _:WitResourceType =>
+    case AnyType | AnyNotNullType | _:ArrayType =>
       ObjectClass
     case tpe: PrimType =>
       PrimTypeToBoxedClass(tpe)
@@ -4428,14 +4427,10 @@ private[optimizer] abstract class OptimizerCore(
         primRef.displayName
       case ClassRef(className) =>
         mappedClassName(className)
-      case WitResourceTypeRef(className) =>
-        "resource<" + mappedClassName(className) + ">"
       case ArrayTypeRef(primRef: PrimRef, dimensions) =>
         "[" * dimensions + primRef.charCode
       case ArrayTypeRef(ClassRef(className), dimensions) =>
         "[" * dimensions + "L" + mappedClassName(className) + ";"
-      case ArrayTypeRef(WitResourceTypeRef(className), dimensions) =>
-        "[" * dimensions + "W" + mappedClassName(className) + ";"
       case typeRef: TransientTypeRef =>
         throw new IllegalArgumentException(typeRef.toString())
     }
@@ -6184,9 +6179,6 @@ private[optimizer] abstract class OptimizerCore(
         case ClassRef(className) =>
           if (isJSType(className)) AnyType
           else ClassType(className, nullable = true, exact = false)
-
-        case WitResourceTypeRef(className) =>
-          WitResourceType(className)
       }
     } else {
       ArrayType(ArrayTypeRef(base, dimensions - 1), nullable = true, exact = false)

--- a/linker/shared/src/test/scala/org/scalajs/linker/AnalyzerTest.scala
+++ b/linker/shared/src/test/scala/org/scalajs/linker/AnalyzerTest.scala
@@ -197,7 +197,7 @@ class AnalyzerTest {
         case JSClass | JSModuleClass | NativeJSClass | NativeJSModuleClass |
             AbstractJSType =>
           Seq(Class, Interface, AbstractJSType, JSModuleClass)
-        case NativeWasmComponentResourceClass =>
+        case WasmComponentResourceClass =>
           Seq.empty // TODO
         case HijackedClass =>
           throw new AssertionError("Cannot test HijackedClass because it fails earlier")
@@ -251,7 +251,7 @@ class AnalyzerTest {
             AbstractJSType =>
           Seq(Class, ModuleClass, Interface, JSClass,
               JSModuleClass, NativeJSClass, NativeJSModuleClass)
-        case NativeWasmComponentResourceClass =>
+        case WasmComponentResourceClass =>
           Seq.empty // TODO
         case HijackedClass =>
           throw new AssertionError("Cannot test HijackedClass because it fails earlier")
@@ -1081,7 +1081,7 @@ object AnalyzerTest {
         Some(ObjectClass)
       case JSClass | JSModuleClass =>
         Some(ClassName("scala.scalajs.js.Object"))
-      case NativeWasmComponentResourceClass =>
+      case WasmComponentResourceClass =>
         None // TODO
       case Interface | AbstractJSType =>
         None

--- a/linker/shared/src/test/scala/org/scalajs/linker/frontend/LambdaSynthesizerTest.scala
+++ b/linker/shared/src/test/scala/org/scalajs/linker/frontend/LambdaSynthesizerTest.scala
@@ -28,11 +28,10 @@ class LambdaSynthesizerTest {
 
     // Only for tests; would not work for JS class types
     def typeRefToType(typeRef: TypeRef): Type = typeRef match {
-      case typeRef: PrimRef              => typeRef.tpe
-      case ClassRef(className)           => ClassType(className, nullable = true, exact = false)
-      case WitResourceTypeRef(className) => WitResourceType(className)
-      case typeRef: ArrayTypeRef         => ArrayType(typeRef, nullable = true, exact = false)
-      case typeRef: TransientTypeRef     => typeRef.tpe
+      case typeRef: PrimRef          => typeRef.tpe
+      case ClassRef(className)       => ClassType(className, nullable = true, exact = false)
+      case typeRef: ArrayTypeRef     => ArrayType(typeRef, nullable = true, exact = false)
+      case typeRef: TransientTypeRef => typeRef.tpe
     }
 
     Descriptor(superClass, interfaces,
@@ -75,7 +74,7 @@ class LambdaSynthesizerTest {
       makeDesc(ObjectClass, List("I"), "foo", List(IClass), ArrayTypeRef(IClass, 1)),
       makeDesc(ObjectClass, List("I"), "foo", List(IClass), ArrayTypeRef(I, 3)),
       makeDesc(ObjectClass, List("I"), "foo", List(IClass), ArrayTypeRef(IClass, 3)),
-      makeDesc(ObjectClass, List("I"), "foo", List(IClass), WitResourceTypeRef("R")),
+      makeDesc(ObjectClass, List("I"), "foo", List(IClass), ClassRef("R")),
       makeDesc(ObjectClass, List("I"), "foo", List(IClass), TransientTypeRef(LabelName("I"))(IntType))
     )
 

--- a/project/JavalibIRCleaner.scala
+++ b/project/JavalibIRCleaner.scala
@@ -85,7 +85,7 @@ final class JavalibIRCleaner(baseDirectoryURI: URI) {
         case AbstractJSType | NativeJSClass | NativeJSModuleClass =>
           // discard
 
-        case NativeWasmComponentResourceClass =>
+        case WasmComponentResourceClass =>
           val cleanedTree = cleanTree(tree, jsTypes, errorManager)
           writeIRFile(output, cleanedTree)
           resultBuilder += output
@@ -558,8 +558,6 @@ final class JavalibIRCleaner(baseDirectoryURI: URI) {
             ArrayTypeRef(ClassRef(ObjectClass), typeRef.dimensions)
           else
             ArrayTypeRef(ClassRef(transformClassName(baseClassName)), typeRef.dimensions)
-        case WitResourceTypeRef(className) =>
-          ArrayTypeRef(WitResourceTypeRef(transformClassName(className)), typeRef.dimensions)
       }
     }
 
@@ -567,7 +565,6 @@ final class JavalibIRCleaner(baseDirectoryURI: URI) {
         implicit pos: Position): TypeRef = typeRef match {
       case typeRef: PrimRef                  => typeRef
       case typeRef: ClassRef                 => transformClassRef(typeRef)
-      case WitResourceTypeRef(className) => WitResourceTypeRef(transformClassName(className))
       case typeRef: ArrayTypeRef             => transformArrayTypeRef(typeRef)
       case typeRef: TransientTypeRef         => TransientTypeRef(typeRef.name)(transformType(typeRef.tpe))
     }
@@ -598,8 +595,6 @@ final class JavalibIRCleaner(baseDirectoryURI: URI) {
           ArrayType(transformArrayTypeRef(arrayTypeRef), nullable, exact)
         case ClosureType(paramTypes, resultType, nullable) =>
           ClosureType(paramTypes.map(transformType(_)), transformType(resultType), nullable)
-        case WitResourceType(className) =>
-          WitResourceType(transformClassName(className))
         case AnyType | AnyNotNullType | _:PrimType | _:RecordType =>
           tpe
       }

--- a/sbt-plugin/src/main/scala/org/scalajs/sbtplugin/ScalaJSPlugin.scala
+++ b/sbt-plugin/src/main/scala/org/scalajs/sbtplugin/ScalaJSPlugin.scala
@@ -210,7 +210,7 @@ object ScalaJSPlugin extends AutoPlugin {
 
     val scalaJSGenerateWitBindings = TaskKey[Seq[File]](
         "scalaJSGenerateWitBindings",
-        "Generate Scala bindings from WIT files using wit-bindgen",
+        "Generate Scala bindings from WIT files using wit-bindgen-scala",
         CTask)
 
     val scalaJSModuleInitializers = TaskKey[Seq[ModuleInitializer]]("scalaJSModuleInitializers",
@@ -262,7 +262,7 @@ object ScalaJSPlugin extends AutoPlugin {
 
     val scalaJSWitBindgenWith = SettingKey[Map[String, String]](
         "scalaJSWitBindgenWith",
-        "Mappings for --with option of wit-bindgen to re-use pre-generated bindings (e.g. \"wasi:io\" -> \"scala.scalajs.wasi.io\")",
+        "Mappings for --with option of wit-bindgen-scala to re-use pre-generated bindings (e.g. \"wasi:io\" -> \"scala.scalajs.wasi.io\")",
         CSetting)
 
     val scalaJSStage = SettingKey[Stage]("scalaJSStage",

--- a/sbt-plugin/src/main/scala/org/scalajs/sbtplugin/ScalaJSPluginInternal.scala
+++ b/sbt-plugin/src/main/scala/org/scalajs/sbtplugin/ScalaJSPluginInternal.scala
@@ -184,36 +184,23 @@ private[sbtplugin] object ScalaJSPluginInternal {
     }
   }
 
-  private def checkWitBindgenAvailable(log: Logger): Unit = {
+  private def checkWitBindgenScalaAvailable(log: Logger): Unit = {
     try {
-      // Check if wit-bindgen is installed
-      val checkCmd = Seq("wit-bindgen", "--version")
+      val checkCmd = Seq("wit-bindgen-scala", "--help")
       val exitCode = Process(checkCmd).!(ProcessLogger(_ => (), _ => ()))
       if (exitCode != 0) {
-        throw new MessageOnlyException("wit-bindgen is installed but returned non-zero exit code")
-      }
-
-      // Check if scala subcommand is available
-      val checkScalaCmd = Seq("wit-bindgen", "scala", "--help")
-      val scalaExitCode = Process(checkScalaCmd).!(ProcessLogger(_ => (), _ => ()))
-      if (scalaExitCode != 0) {
         throw new MessageOnlyException(
-            """wit-bindgen is installed but the 'scala' subcommand is not available.
-            |
-            |Please install the Scala-enabled version of wit-bindgen:
-            |  cargo install --git https://github.com/scala-wasm/wit-bindgen --tag scala-wasm-wasm.4 wit-bindgen-cli
-            |""".stripMargin
-        )
+            "wit-bindgen-scala is installed but returned non-zero exit code")
       }
     } catch {
       case e: MessageOnlyException =>
         throw e
       case _: java.io.IOException =>
         throw new MessageOnlyException(
-            """wit-bindgen is not installed or not in PATH.
+            """wit-bindgen-scala is not installed or not in PATH.
             |
-            |Please install the Scala-enabled version of wit-bindgen:
-            |  cargo install --git https://github.com/scala-wasm/wit-bindgen --tag scala-wasm-wasm.4 wit-bindgen-cli
+            |Please install it with:
+            |  cargo install wit-bindgen-scala --version 0.1.0-rc.1
             |""".stripMargin
         )
     }
@@ -801,7 +788,7 @@ private[sbtplugin] object ScalaJSPluginInternal {
         if (linkerConfig.moduleKind != ModuleKind.WasmComponent) {
           Seq.empty[File]
         } else if (!witDir.exists()) {
-          log.debug(s"WIT directory $witDir does not exist, skipping wit-bindgen")
+          log.debug(s"WIT directory $witDir does not exist, skipping wit-bindgen-scala")
           Seq.empty[File]
         } else {
           val witFiles = (witDir ** "*.wit").get().toSet
@@ -810,17 +797,17 @@ private[sbtplugin] object ScalaJSPluginInternal {
             log.debug(s"No WIT files found in $witDir")
             Seq.empty[File]
           } else {
-            checkWitBindgenAvailable(log)
+            checkWitBindgenScalaAvailable(log)
 
-            val cacheDir = s.cacheDirectory / "wit-bindgen"
+            val cacheDir = s.cacheDirectory / "wit-bindgen-scala"
             val generatedFiles = {
               FileFunction.cached(cacheDir, FilesInfo.lastModified, FilesInfo.exists) { _ =>
                 log.info(s"Generating Scala bindings from WIT files in $witDir")
 
                 IO.createDirectory(targetDir)
 
-                val baseCmd = Seq("wit-bindgen", "scala", witDir.absolutePath, "--out-dir",
-                    targetDir.absolutePath)
+                val baseCmd = Seq("wit-bindgen-scala",
+                    witDir.absolutePath, "--out-dir", targetDir.absolutePath)
                 val worldArgs = witWorld.toSeq.flatMap(w => Seq("--world", w))
                 val packageArgs = witPackage.toSeq.flatMap(p => Seq("--base-package", p))
                 val withArgs = witBindgenWith.toSeq.flatMap { case (k, v) => Seq("--with", s"$k=$v") }
@@ -828,9 +815,12 @@ private[sbtplugin] object ScalaJSPluginInternal {
 
                 log.info(s"Running: ${fullCmd.mkString(" ")}")
 
-                val exitCode = Process(fullCmd).!(log)
+                val processLogger = ProcessLogger(log.info(_), log.info(_))
+                val exitCode = Process(fullCmd).!(processLogger)
                 if (exitCode != 0) {
-                  throw new MessageOnlyException(s"wit-bindgen failed with exit code $exitCode")
+                  throw new MessageOnlyException(
+                      s"wit-bindgen-scala failed with exit code $exitCode"
+                  )
                 }
                 (targetDir ** "*.scala").get().toSet
               }(witFiles)


### PR DESCRIPTION
**background**
Previously, WIT resources rere represented as `trait`s in generated Scala and
as a dedicated resource type in the IR.
For example, a WIT resource below:

```wit
resource counter {
  constructor(i: s32);
  sum: static func(a: counter, b: counter) -> counter;
  up: func();
  value-of: func() -> s32;
}
```

it was represented as a `@WitResourceImport` trait, with resource
constructors/static methods in the companion object.

```scala
@WitResourceImport("component:testing/countable", "counter")
trait Counter {
  @WitResourceMethod("up")
  def up(): Unit = native
  @WitResourceMethod("down")
  djs.wit.native
  @WitResourceMethod("value-of")
  def valueOf(): Int = native
  @WitResourceDrop
  def close(): Unit = native
}
object Counter {
  @WitResourceConstructor
  def apply(i: Int): Counter = native
  @WitResourceStaticMethod("sum")
  def sum(a: Counter, b: Counter): Counter = native
}
```

In the IR, values of `counter` had special resource types:

- TypeRef: `WitResourceTypeRef(Counter)`
- Type: `WitResourceType(Counter)`
- Class: `NativeWasmComponentResourceClass`

However, the old trait-based representation was semantically wrong because a
Scala trait means “any Scala object may implement this interface”,
while a WIT resource means “an opaque, nominal handle created by the
component runtime”.

With `trait Counter` Scala can implement user-defined subclasses
that are not real WIT handles, which is validated in `PrepWasmInterop` though.

A WIT (imported) resource should instead behave like a final nominal object
type: not user-instantiable, not subclassable, nullable as a Scala
reference, and backed by a runtime handle wrapper.

**new representation**

This commit introduces new resource representation with final classes.
The same resource is now represented in Scala as:

```scala
@WitResourceImport("component:testing/countable", "counter")
final class Counter private () extends Object {
  @WitResourceMethod("up")
  def up(): Unit = native
  @WitResourceMethod("value-of")
  def valueOf(): Int = native
  @WitResourceDrop
  def close(): Unit = native
}
object Counter {
  @WitResourceConstructor
  def apply(i: Int): Counter = native
  @WitResourceStaticMethod("sum")
  def sum(a: Counter, b: Counter): Counter = native
}
```

The frontend now restrict
- `@WitResourceImport` is only used on final classes
- with a private parameterless primary constructor and
- no parent other than `java.lang.Object`.

In the IR, resource values are now regular class references:

- TypeRef: `ClassRef(Counter)`
- Type:    `ClassType(Counter, nullable = true, exact = false)`
- Class:   `kind = WasmComponentResourceClass, superClass = Some(ObjectClass)`

The Wasm backend represents the runtime value as an opaque component handle wrapper:

```wasm
struct {
  vtable: ref ObjectVTable,
  idHashCode: i32,
  handle: i32
}
```

but that struct now uses the normal class type id and Object vtable,
instead of special handling for Resrouce classes.