### PR TITLE
Enable fullLinkJS in pure Wasm

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -97,6 +97,8 @@ jobs:
         run: npm install
       - name: helloworld-wasm${{ matrix.suffix }}/run
         run: sbt "$SBT_SET_COMMAND" "helloworldWasm${{ matrix.suffix }}/run"
+      - name: helloworld-wasm${{ matrix.suffix }}/fullLinkJS
+        run: sbt "$SBT_SET_COMMAND" "helloworldWasm${{ matrix.suffix }}/fullLinkJS"
       - name: helloworld-wasm${{ matrix.suffix }}/test
         run: sbt "$SBT_SET_COMMAND" "helloworldWasm${{ matrix.suffix }}/test"
       - name: testSuite${{ matrix.suffix }}/test
@@ -142,6 +144,8 @@ jobs:
         working-directory: examples/test-component-model/rust-run
       - name: testComponentModel${{ matrix.suffix }}/fastLinkJS
         run: sbt 'set Global/enableWasmEverywhere := true' testComponentModel${{ matrix.suffix }}/fastLinkJS
+      - name: testComponentModel${{ matrix.suffix }}/fullLinkJS
+        run: sbt 'set Global/enableWasmEverywhere := true' testComponentModel${{ matrix.suffix }}/fullLinkJS
       - name: Compose and run tests
         run: make run SCALA_VERSION=${{ matrix.scalaVersion }}
         working-directory: examples/test-component-model
@@ -149,6 +153,8 @@ jobs:
       # echoserver test, check at least it links
       - name: echoserver${{ matrix.suffix }}/fastLinkJS
         run: sbt 'set Global/enableWasmEverywhere := true' echoserver${{ matrix.suffix }}/fastLinkJS
+      - name: echoserver${{ matrix.suffix }}/fullLinkJS
+        run: sbt 'set Global/enableWasmEverywhere := true' echoserver${{ matrix.suffix }}/fullLinkJS
 
   test-suite-jvm:
     runs-on: ubuntu-latest

--- a/linker/shared/src/main/scala/org/scalajs/linker/backend/wasmemitter/CoreWasmLib.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/backend/wasmemitter/CoreWasmLib.scala
@@ -3837,7 +3837,7 @@ final class CoreWasmLib(coreSpec: CoreSpec, globalInfo: LinkedGlobalInfo) {
     // If we get here, we did not find the method; throw.
 
     if (!hasJSInterop) {
-      genNewScalaClass(fb, ArrayIndexOutOfBoundsExceptionClass,
+      genNewScalaClass(fb, IllegalArgumentExceptionClass,
           SpecialNames.StringArgConstructorName) {
         fb ++= ctx.stringPool.getConstantStringInstr("Method not found")
       }

--- a/linker/shared/src/main/scala/org/scalajs/linker/backend/wasmemitter/Emitter.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/backend/wasmemitter/Emitter.scala
@@ -578,6 +578,15 @@ object Emitter {
       instantiateClass(ClassClass, NoArgConstructorName),
       instantiateClass(JSExceptionClass, AnyArgConstructorName),
       instantiateClass(IllegalArgumentExceptionClass, NoArgConstructorName),
+      /* In pure-Wasm mode, a failed reflective-proxy lookup throws an
+       * IllegalArgumentException with a message. See CoreWasmLib.
+       */
+      cond(
+        coreSpec.moduleKind == ModuleKind.MinimalWasmModule ||
+        coreSpec.moduleKind == ModuleKind.WasmComponent
+      ) {
+        instantiateClass(IllegalArgumentExceptionClass, StringArgConstructorName)
+      },
 
       // Wasm Component Model
       // instantiateClass(WasmComponentResultClass, NoArgConstructorName),

--- a/linker/shared/src/main/scala/org/scalajs/linker/backend/wasmemitter/canonicalabi/ScalaJSToCABI.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/backend/wasmemitter/canonicalabi/ScalaJSToCABI.scala
@@ -384,8 +384,16 @@ object ScalaJSToCABI {
 
             // value
             fb += wa.LocalGet(arr)
+            fb += wa.StructGet(arrayStructTypeID, genFieldID.objStruct.arrayUnderlying)
             fb += wa.LocalGet(iLocal)
-            fb += wa.Call(genFunctionID.arrayGetFor(ArrayTypeRef.of(wit.toTypeRef(elemType))))
+            wit.toTypeRef(elemType) match {
+              case BooleanRef | CharRef =>
+                fb += wa.ArrayGetU(genTypeID.underlyingOf(arrayTypeRef))
+              case ByteRef | ShortRef =>
+                fb += wa.ArrayGetS(genTypeID.underlyingOf(arrayTypeRef))
+              case _ =>
+                fb += wa.ArrayGet(genTypeID.underlyingOf(arrayTypeRef))
+            }
             genStoreMemory(fb, elemType)
 
             // i := i + 1


### PR DESCRIPTION
Previously, coreWasmLib emits ArrayIndexOutOfBoundsException for missing reflective proxy, but it's going to be disabled by semantics settings when fullLinkJS.

Use `IllegalArgumentException` instead and make it required when linking against pure Wasm.