### PR TITLE
Prepare release on `io.github.scala-wasm` 1.21.1-wasm.4

### DIFF
--- a/ir/shared/src/main/scala/org/scalajs/ir/ScalaJSVersions.scala
+++ b/ir/shared/src/main/scala/org/scalajs/ir/ScalaJSVersions.scala
@@ -17,9 +17,11 @@ import java.util.concurrent.ConcurrentHashMap
 import scala.util.matching.Regex
 
 object ScalaJSVersions extends VersionChecks(
-      current = "1.21.1-SNAPSHOT",
+      current = "1.21.1-wasm.4",
       binaryEmitted = "1.21"
-    )
+    ) {
+  final val organization = "io.github.scala-wasm"
+}
 
 /** Helper class to allow for testing of logic. */
 class VersionChecks private[ir] (

--- a/library/src/main/scala/scala/scalajs/WitUtils.scala
+++ b/library/src/main/scala/scala/scalajs/WitUtils.scala
@@ -21,7 +21,7 @@ object WitUtils {
   }
 
   def toOption[A, B](opt: java.util.Optional[A]): Option[A] = {
-    if (opt.isEmpty()) None
-    else Some(opt.get())
+    if (opt.isPresent()) Some(opt.get())
+    else None
   }
 }

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -508,16 +508,16 @@ object Build {
   }
 
   val publishConfigSettings = Seq(
-      organization := "org.scala-js",
+      organization := ir.ScalaJSVersions.organization,
       version := scalaJSVersion,
 
       homepage := Some(url("https://www.scala-js.org/")),
       startYear := Some(2013),
       licenses += (("Apache-2.0", url("https://www.apache.org/licenses/LICENSE-2.0"))),
       scmInfo := Some(ScmInfo(
-          url("https://github.com/scala-js/scala-js"),
-          "scm:git:git@github.com:scala-js/scala-js.git",
-          Some("scm:git:git@github.com:scala-js/scala-js.git"))),
+          url("https://github.com/scala-wasm/scala-wasm"),
+          "scm:git:git@github.com:scala-wasm/scala-wasm.git",
+          Some("scm:git:git@github.com:scala-wasm/scala-wasm.git"))),
 
       publishTo := {
         val centralSnapshots = "https://central.sonatype.com/repository/maven-snapshots/"
@@ -992,15 +992,6 @@ object Build {
 
   val thisBuildSettings = Def.settings(
       cross212ScalaVersions := Seq(
-        "2.12.6",
-        "2.12.7",
-        "2.12.8",
-        "2.12.9",
-        "2.12.10",
-        "2.12.11",
-        "2.12.12",
-        "2.12.13",
-        "2.12.14",
         "2.12.15",
         "2.12.16",
         "2.12.17",
@@ -1010,9 +1001,6 @@ object Build {
         "2.12.21",
       ),
       cross213ScalaVersions := Seq(
-        "2.13.3",
-        "2.13.4",
-        "2.13.5",
         "2.13.6",
         "2.13.7",
         "2.13.8",
@@ -1306,9 +1294,13 @@ object Build {
       fatalWarningsSettings,
       name := "Scala.js linker",
 
-      // Temporarily disable scaladoc generation for linker on publish
+      // Temporarily publish an empty scaladoc jar for linker artifacts.
       // https://github.com/scala-js/scala-js/issues/5272
-      Compile / packageDoc / publishArtifact := false,
+      Compile / doc := {
+        val dir = (Compile / doc / target).value
+        IO.createDirectory(dir)
+        dir
+      },
 
       Compile / unmanagedSourceDirectories +=
         baseDirectory.value.getParentFile.getParentFile / "shared/src/main/scala",

--- a/sbt-plugin/src/main/scala/org/scalajs/sbtplugin/ScalaJSJUnitPlugin.scala
+++ b/sbt-plugin/src/main/scala/org/scalajs/sbtplugin/ScalaJSJUnitPlugin.scala
@@ -38,14 +38,14 @@ object ScalaJSJUnitPlugin extends AutoPlugin {
       val scalaV = scalaVersion.value
       if (scalaV.startsWith("3.")) {
         Seq(
-          "org.scala-js" % "scalajs-junit-test-runtime_2.13" % scalaJSVersion % "test"
+          scalaJSOrganization % "scalajs-junit-test-runtime_2.13" % scalaJSVersion % "test"
         )
       } else {
         val scalaBinV = scalaBinaryVersion.value
         Seq(
-          PluginCompat.scalaJSFullCrossVersionLib("org.scala-js", "scalajs-junit-test-plugin",
+          PluginCompat.scalaJSFullCrossVersionLib(scalaJSOrganization, "scalajs-junit-test-plugin",
               scalaJSVersion, scalaV) % "scala-js-test-plugin",
-          PluginCompat.scalaJSCoreLib("org.scala-js", "scalajs-junit-test-runtime",
+          PluginCompat.scalaJSCoreLib(scalaJSOrganization, "scalajs-junit-test-runtime",
               scalaJSVersion, scalaBinV) % "test"
         )
       }

--- a/sbt-plugin/src/main/scala/org/scalajs/sbtplugin/ScalaJSPlugin.scala
+++ b/sbt-plugin/src/main/scala/org/scalajs/sbtplugin/ScalaJSPlugin.scala
@@ -46,6 +46,8 @@ object ScalaJSPlugin extends AutoPlugin {
     /** The current version of the Scala.js sbt plugin and tool chain. */
     val scalaJSVersion = ScalaJSVersions.current
 
+    val scalaJSOrganization = ScalaJSVersions.organization
+
     /** Declares `Tag`s which may be used to limit the concurrency of build
      *  tasks.
      *
@@ -392,7 +394,7 @@ object ScalaJSPlugin extends AutoPlugin {
           val retrieveDir = s.cacheDirectory / "scalajs-linker" / scalaJSVersion
           val lm = (scalaJSLinkerImpl / dependencyResolution).value
           lm.retrieve(
-              "org.scala-js" % ("scalajs-linker" + PluginCompat.linkerScalaSuffix) % scalaJSVersion,
+              scalaJSOrganization % ("scalajs-linker" + PluginCompat.linkerScalaSuffix) % scalaJSVersion,
               scalaModuleInfo = None, retrieveDir, log)
             .fold(w => throw w.resolveException, files => PluginCompat.toAttributedFiles(files.toSeq))
         },

--- a/sbt-plugin/src/main/scala/org/scalajs/sbtplugin/ScalaJSPluginInternal.scala
+++ b/sbt-plugin/src/main/scala/org/scalajs/sbtplugin/ScalaJSPluginInternal.scala
@@ -1020,25 +1020,25 @@ private[sbtplugin] object ScalaJSPluginInternal {
                * (It will also depend on some version of scalajs-scalalib_2.13,
                * but we do not have to worry about that here.)
                */
-              "org.scala-js" % "scalajs-library_2.13" % scalaJSVersion,
-              "org.scala-js" % "scalajs-test-bridge_2.13" % scalaJSVersion % "test"
+              scalaJSOrganization % "scalajs-library_2.13" % scalaJSVersion,
+              scalaJSOrganization % "scalajs-test-bridge_2.13" % scalaJSVersion % "test"
           )
         } else {
           val scalaBinV = scalaBinaryVersion.value
           prev ++ Seq(
               compilerPlugin(
-                  PluginCompat.scalaJSFullCrossVersionLib("org.scala-js", "scalajs-compiler",
+                  PluginCompat.scalaJSFullCrossVersionLib(scalaJSOrganization, "scalajs-compiler",
                       scalaJSVersion, scalaV)),
-              PluginCompat.scalaJSCoreLib("org.scala-js", "scalajs-library", scalaJSVersion,
+              PluginCompat.scalaJSCoreLib(scalaJSOrganization, "scalajs-library", scalaJSVersion,
                   scalaBinV),
               /* scalajs-library depends on some version of scalajs-scalalib,
                * but we want to make sure to bump it to be at least the one
                * of our own `scalaVersion` (which would have back-published in
                * the meantime).
                */
-              PluginCompat.scalaJSCoreLib("org.scala-js", "scalajs-scalalib",
+              PluginCompat.scalaJSCoreLib(scalaJSOrganization, "scalajs-scalalib",
                   s"$scalaV+$scalaJSVersion", scalaBinV),
-              PluginCompat.scalaJSCoreLib("org.scala-js", "scalajs-test-bridge", scalaJSVersion,
+              PluginCompat.scalaJSCoreLib(scalaJSOrganization, "scalajs-test-bridge", scalaJSVersion,
                   scalaBinV) % "test"
           )
         }

--- a/sbt-plugin/src/sbt-test/cross-version/2.13/project/build.sbt
+++ b/sbt-plugin/src/sbt-test/cross-version/2.13/project/build.sbt
@@ -1,1 +1,1 @@
-addSbtPlugin("org.scala-js" % "sbt-scalajs" % sys.props("plugin.version"))
+addSbtPlugin("io.github.scala-wasm" % "sbt-scalajs" % sys.props("plugin.version"))

--- a/sbt-plugin/src/sbt-test/incremental/change-config-and-source/project/build.sbt
+++ b/sbt-plugin/src/sbt-test/incremental/change-config-and-source/project/build.sbt
@@ -1,1 +1,1 @@
-addSbtPlugin("org.scala-js" % "sbt-scalajs" % sys.props("plugin.version"))
+addSbtPlugin("io.github.scala-wasm" % "sbt-scalajs" % sys.props("plugin.version"))

--- a/sbt-plugin/src/sbt-test/incremental/change-config/project/build.sbt
+++ b/sbt-plugin/src/sbt-test/incremental/change-config/project/build.sbt
@@ -1,1 +1,1 @@
-addSbtPlugin("org.scala-js" % "sbt-scalajs" % sys.props("plugin.version"))
+addSbtPlugin("io.github.scala-wasm" % "sbt-scalajs" % sys.props("plugin.version"))

--- a/sbt-plugin/src/sbt-test/incremental/fix-compile-error/project/build.sbt
+++ b/sbt-plugin/src/sbt-test/incremental/fix-compile-error/project/build.sbt
@@ -1,1 +1,1 @@
-addSbtPlugin("org.scala-js" % "sbt-scalajs" % sys.props("plugin.version"))
+addSbtPlugin("io.github.scala-wasm" % "sbt-scalajs" % sys.props("plugin.version"))

--- a/sbt-plugin/src/sbt-test/linker/anonfunction-compat/build.sbt
+++ b/sbt-plugin/src/sbt-test/linker/anonfunction-compat/build.sbt
@@ -51,7 +51,8 @@ lazy val scala2OldCompilerNewLib = project.in(file("scala2-old-compiler-new-lib"
     replaceDependency("scalajs-compiler",
         scalaJSCompilerPlugin(ScalaJSVersionBeforeTypedClosures, scala2Version)),
     replaceDependency("scalajs-scalalib",
-        scalaJSCoreLib("scalajs-scalalib", s"$mainBuildScala2Version+$scalaJSVersion", scala2BinaryVersion)),
+        scalaJSOrganization % s"scalajs-scalalib_$scala2BinaryVersion" %
+          s"$mainBuildScala2Version+$scalaJSVersion"),
     scalaJSUseMainModuleInitializer := true
   )
 

--- a/sbt-plugin/src/sbt-test/linker/anonfunction-compat/project/build.sbt
+++ b/sbt-plugin/src/sbt-test/linker/anonfunction-compat/project/build.sbt
@@ -1,6 +1,7 @@
 val scalaJSVersion = sys.props("plugin.version")
+val scalaJSOrganization = "io.github.scala-wasm"
 
-addSbtPlugin("org.scala-js" % "sbt-scalajs" % scalaJSVersion)
+addSbtPlugin("io.github.scala-wasm" % "sbt-scalajs" % scalaJSVersion)
 
 /* Workaround: we use scalajs-linker_2.13 in sbt2 because linker is not yet
  * published for Scala 3.
@@ -18,9 +19,9 @@ addSbtPlugin("org.scala-js" % "sbt-scalajs" % scalaJSVersion)
  * It shouldn't be a problem for regular Scala.js project,
  * as long as they don't use linker directly.
  */
-libraryDependencies += ("org.scala-js" %% "scalajs-linker" % scalaJSVersion)
+libraryDependencies += (scalaJSOrganization %% "scalajs-linker" % scalaJSVersion)
   .cross(CrossVersion.for3Use2_13)
-  .exclude("org.scala-js", "scalajs-linker-interface_2.13")
-  .exclude("org.scala-js", "scalajs-ir_2.13")
-  .exclude("org.scala-js", "scalajs-logging_2.13")
+  .exclude(scalaJSOrganization, "scalajs-linker-interface_2.13")
+  .exclude(scalaJSOrganization, "scalajs-ir_2.13")
+  .exclude(scalaJSOrganization, "scalajs-logging_2.13")
 

--- a/sbt-plugin/src/sbt-test/linker/concurrent-linker-use/project/build.sbt
+++ b/sbt-plugin/src/sbt-test/linker/concurrent-linker-use/project/build.sbt
@@ -1,11 +1,12 @@
 val scalaJSVersion = sys.props("plugin.version")
+val scalaJSOrganization = "io.github.scala-wasm"
 
-addSbtPlugin("org.scala-js" % "sbt-scalajs" % scalaJSVersion)
+addSbtPlugin("io.github.scala-wasm" % "sbt-scalajs" % scalaJSVersion)
 addSbtPlugin("com.github.sbt" % "sbt2-compat" % "0.1.0")
 
 // see: anonfunction-compat/project/build.sbt
-libraryDependencies += ("org.scala-js" %% "scalajs-linker" % scalaJSVersion)
+libraryDependencies += (scalaJSOrganization %% "scalajs-linker" % scalaJSVersion)
   .cross(CrossVersion.for3Use2_13)
-  .exclude("org.scala-js", "scalajs-linker-interface_2.13")
-  .exclude("org.scala-js", "scalajs-ir_2.13")
-  .exclude("org.scala-js", "scalajs-logging_2.13")
+  .exclude(scalaJSOrganization, "scalajs-linker-interface_2.13")
+  .exclude(scalaJSOrganization, "scalajs-ir_2.13")
+  .exclude(scalaJSOrganization, "scalajs-logging_2.13")

--- a/sbt-plugin/src/sbt-test/linker/custom-linker/build.sbt
+++ b/sbt-plugin/src/sbt-test/linker/custom-linker/build.sbt
@@ -26,7 +26,7 @@ lazy val customLinker = project.in(file("custom-linker"))
       else "3.8.3"
     },
     libraryDependencies +=
-      ("org.scala-js" %% "scalajs-linker" % scalaJSVersion).cross(CrossVersion.for3Use2_13),
+      (scalaJSOrganization %% "scalajs-linker" % scalaJSVersion).cross(CrossVersion.for3Use2_13),
   )
 
 name := "Scala.js sbt test"

--- a/sbt-plugin/src/sbt-test/linker/custom-linker/project/build.sbt
+++ b/sbt-plugin/src/sbt-test/linker/custom-linker/project/build.sbt
@@ -1,4 +1,4 @@
 val scalaJSVersion = sys.props("plugin.version")
 
-addSbtPlugin("org.scala-js" % "sbt-scalajs" % scalaJSVersion)
+addSbtPlugin("io.github.scala-wasm" % "sbt-scalajs" % scalaJSVersion)
 addSbtPlugin("com.github.sbt" % "sbt2-compat" % "0.1.0")

--- a/sbt-plugin/src/sbt-test/linker/no-root-dependency-resolution/project/build.sbt
+++ b/sbt-plugin/src/sbt-test/linker/no-root-dependency-resolution/project/build.sbt
@@ -1,3 +1,3 @@
 val scalaJSVersion = sys.props("plugin.version")
 
-addSbtPlugin("org.scala-js" % "sbt-scalajs" % scalaJSVersion)
+addSbtPlugin("io.github.scala-wasm" % "sbt-scalajs" % scalaJSVersion)

--- a/sbt-plugin/src/sbt-test/linker/non-existent-classpath/project/build.sbt
+++ b/sbt-plugin/src/sbt-test/linker/non-existent-classpath/project/build.sbt
@@ -1,1 +1,1 @@
-addSbtPlugin("org.scala-js" % "sbt-scalajs" % sys.props("plugin.version"))
+addSbtPlugin("io.github.scala-wasm" % "sbt-scalajs" % sys.props("plugin.version"))

--- a/sbt-plugin/src/sbt-test/sbt2/helloworld-scalajs-dom/project/plugins.sbt
+++ b/sbt-plugin/src/sbt-test/sbt2/helloworld-scalajs-dom/project/plugins.sbt
@@ -1,3 +1,3 @@
 val scalaJSVersion = sys.props("plugin.version")
 
-addSbtPlugin("org.scala-js" % "sbt-scalajs" % scalaJSVersion)
+addSbtPlugin("io.github.scala-wasm" % "sbt-scalajs" % scalaJSVersion)

--- a/sbt-plugin/src/sbt-test/sbt2/scala3-basic/build.sbt
+++ b/sbt-plugin/src/sbt-test/sbt2/scala3-basic/build.sbt
@@ -5,6 +5,6 @@ scalaVersion := "3.3.4"
 // Test CrossVersion.for3Use2_13 for %% dependencies
 // In sbt2, there's no %%%, %% does the same job for %%% in sbt1.
 libraryDependencies +=
-  ("org.scala-js" %% "scalajs-ir" % scalaJSVersion).cross(CrossVersion.for3Use2_13)
+  (scalaJSOrganization %% "scalajs-ir" % scalaJSVersion).cross(CrossVersion.for3Use2_13)
 
 scalaJSUseMainModuleInitializer := true

--- a/sbt-plugin/src/sbt-test/sbt2/scala3-basic/project/plugins.sbt
+++ b/sbt-plugin/src/sbt-test/sbt2/scala3-basic/project/plugins.sbt
@@ -1,3 +1,3 @@
 val scalaJSVersion = sys.props("plugin.version")
 
-addSbtPlugin("org.scala-js" % "sbt-scalajs" % scalaJSVersion)
+addSbtPlugin("io.github.scala-wasm" % "sbt-scalajs" % scalaJSVersion)

--- a/sbt-plugin/src/sbt-test/scala3/basic/build.sbt
+++ b/sbt-plugin/src/sbt-test/scala3/basic/build.sbt
@@ -4,6 +4,6 @@ scalaVersion := "3.3.4"
 
 // Test CrossVersion.for3Use2_13 for %%% dependencies
 libraryDependencies +=
-  ("org.scala-js" %%% "scalajs-ir" % scalaJSVersion).cross(CrossVersion.for3Use2_13)
+  (scalaJSOrganization %%% "scalajs-ir" % scalaJSVersion).cross(CrossVersion.for3Use2_13)
 
 scalaJSUseMainModuleInitializer := true

--- a/sbt-plugin/src/sbt-test/scala3/basic/project/plugins.sbt
+++ b/sbt-plugin/src/sbt-test/scala3/basic/project/plugins.sbt
@@ -1,3 +1,3 @@
 val scalaJSVersion = sys.props("plugin.version")
 
-addSbtPlugin("org.scala-js" % "sbt-scalajs" % scalaJSVersion)
+addSbtPlugin("io.github.scala-wasm" % "sbt-scalajs" % scalaJSVersion)

--- a/sbt-plugin/src/sbt-test/scala3/junit/project/plugins.sbt
+++ b/sbt-plugin/src/sbt-test/scala3/junit/project/plugins.sbt
@@ -1,3 +1,3 @@
 val scalaJSVersion = sys.props("plugin.version")
 
-addSbtPlugin("org.scala-js" % "sbt-scalajs" % scalaJSVersion)
+addSbtPlugin("io.github.scala-wasm" % "sbt-scalajs" % scalaJSVersion)

--- a/sbt-plugin/src/sbt-test/scala3/tasty-reader/project/plugins.sbt
+++ b/sbt-plugin/src/sbt-test/scala3/tasty-reader/project/plugins.sbt
@@ -1,3 +1,3 @@
 val scalaJSVersion = sys.props("plugin.version")
 
-addSbtPlugin("org.scala-js" % "sbt-scalajs" % scalaJSVersion)
+addSbtPlugin("io.github.scala-wasm" % "sbt-scalajs" % scalaJSVersion)

--- a/sbt-plugin/src/sbt-test/settings/cross-version/project/build.sbt
+++ b/sbt-plugin/src/sbt-test/settings/cross-version/project/build.sbt
@@ -1,1 +1,1 @@
-addSbtPlugin("org.scala-js" % "sbt-scalajs" % sys.props("plugin.version"))
+addSbtPlugin("io.github.scala-wasm" % "sbt-scalajs" % sys.props("plugin.version"))

--- a/sbt-plugin/src/sbt-test/settings/env-vars/project/build.sbt
+++ b/sbt-plugin/src/sbt-test/settings/env-vars/project/build.sbt
@@ -1,1 +1,1 @@
-addSbtPlugin("org.scala-js" % "sbt-scalajs" % sys.props("plugin.version"))
+addSbtPlugin("io.github.scala-wasm" % "sbt-scalajs" % sys.props("plugin.version"))

--- a/sbt-plugin/src/sbt-test/settings/legacy-link-empty/project/build.sbt
+++ b/sbt-plugin/src/sbt-test/settings/legacy-link-empty/project/build.sbt
@@ -1,1 +1,1 @@
-addSbtPlugin("org.scala-js" % "sbt-scalajs" % sys.props("plugin.version"))
+addSbtPlugin("io.github.scala-wasm" % "sbt-scalajs" % sys.props("plugin.version"))

--- a/sbt-plugin/src/sbt-test/settings/legacy-link-tasks/project/build.sbt
+++ b/sbt-plugin/src/sbt-test/settings/legacy-link-tasks/project/build.sbt
@@ -1,2 +1,2 @@
-addSbtPlugin("org.scala-js" % "sbt-scalajs" % sys.props("plugin.version"))
+addSbtPlugin("io.github.scala-wasm" % "sbt-scalajs" % sys.props("plugin.version"))
 addSbtPlugin("com.github.sbt" % "sbt2-compat" % "0.1.0")

--- a/sbt-plugin/src/sbt-test/settings/module-init/project/build.sbt
+++ b/sbt-plugin/src/sbt-test/settings/module-init/project/build.sbt
@@ -1,1 +1,1 @@
-addSbtPlugin("org.scala-js" % "sbt-scalajs" % sys.props("plugin.version"))
+addSbtPlugin("io.github.scala-wasm" % "sbt-scalajs" % sys.props("plugin.version"))

--- a/sbt-plugin/src/sbt-test/settings/source-map/project/build.sbt
+++ b/sbt-plugin/src/sbt-test/settings/source-map/project/build.sbt
@@ -1,2 +1,2 @@
-addSbtPlugin("org.scala-js" % "sbt-scalajs" % sys.props("plugin.version"))
+addSbtPlugin("io.github.scala-wasm" % "sbt-scalajs" % sys.props("plugin.version"))
 addSbtPlugin("com.github.sbt" % "sbt2-compat" % "0.1.0")

--- a/sbt-plugin/src/sbt-test/testing/multi-framework/build.sbt
+++ b/sbt-plugin/src/sbt-test/testing/multi-framework/build.sbt
@@ -17,7 +17,7 @@ lazy val testFrameworkJS = project.in(file("testFramework/js")).
       // Use % with explicit suffix because scalajs-test-interface is published
       // without _sjs1, but sbt 2.x's %% adds _sjs1
       libraryDependencies +=
-        "org.scala-js" % ("scalajs-test-interface_" + scalaBinaryVersion.value) % scalaJSVersion
+        scalaJSOrganization % ("scalajs-test-interface_" + scalaBinaryVersion.value) % scalaJSVersion
   )
 
 lazy val testFrameworkJVM = project.in(file("testFramework/jvm")).

--- a/sbt-plugin/src/sbt-test/testing/multi-framework/project/build.sbt
+++ b/sbt-plugin/src/sbt-test/testing/multi-framework/project/build.sbt
@@ -1,1 +1,1 @@
-addSbtPlugin("org.scala-js" % "sbt-scalajs" % sys.props("plugin.version"))
+addSbtPlugin("io.github.scala-wasm" % "sbt-scalajs" % sys.props("plugin.version"))


### PR DESCRIPTION
- Release on `io.github.scala-wasm`
- Drop older versions of Scala compilers for faster iteration + for Java 17
- Publish empty scaladoc for linker for now
- Version: `1.21.1-wasm.4`
  - `<upstream next scalajs vesrion>-wasm.x` where `x` is our version