### PR TITLE
Queue ExecutionContext tasks in pure Wasm

### DIFF
--- a/library/src/main/scala/scala/scalajs/concurrent/QueueExecutionContext.scala
+++ b/library/src/main/scala/scala/scalajs/concurrent/QueueExecutionContext.scala
@@ -12,6 +12,7 @@
 
 package scala.scalajs.concurrent
 
+import scala.collection.mutable
 import scala.concurrent.ExecutionContextExecutor
 import scala.concurrent.ExecutionContext
 import java.util.concurrent.Executor
@@ -42,9 +43,29 @@ object QueueExecutionContext {
   }
 
   private final class SingleThreadedExecutionContext extends ExecutionContextExecutor {
+    private val tasks = mutable.ListBuffer.empty[Runnable]
 
-    def execute(runnable: Runnable): Unit =
-      runnable.run()
+    private var running: Boolean = false
+
+    def execute(runnable: Runnable): Unit = {
+      tasks += runnable
+
+      if (!running) {
+        running = true
+        try {
+          while (tasks.nonEmpty) {
+            val task = tasks.remove(0)
+            try {
+              task.run()
+            } catch {
+              case t: Throwable => reportFailure(t)
+            }
+          }
+        } finally {
+          running = false
+        }
+      }
+    }
 
     def reportFailure(t: Throwable): Unit =
       t.printStackTrace()

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -2426,12 +2426,14 @@ object Build {
 
               ) ||
               contains(f, "/js/src/test/scala/org/scalajs/testsuite/") && (
-                // compiler
                 // endsWith(f, "/ModuleInitializersTest.scala") ||
-                endsWith(f, "/EqJSTest.scala") ||
-                // library
-                endsWith(f, "/LinkTimeIfTest.scala") ||
-                endsWith(f, "/ReflectTest.scala")
+                endsWith(f, "/compiler/EqJSTest.scala") ||
+                endsWith(f, "/jsinterop/AsyncTest.scala") ||
+                endsWith(f, "/jsinterop/PromiseMock.scala") ||
+                endsWith(f, "/jsinterop/TimeoutMock.scala") ||
+                endsWith(f, "/library/LinkTimeIfTest.scala") ||
+                endsWith(f, "/library/ReflectTest.scala") ||
+                endsWith(f, "/utils/JSUtils.scala")
               )
             )
         }

--- a/test-suite/js/src/test/scala/org/scalajs/testsuite/jsinterop/AsyncTest.scala
+++ b/test-suite/js/src/test/scala/org/scalajs/testsuite/jsinterop/AsyncTest.scala
@@ -15,6 +15,8 @@ package org.scalajs.testsuite.jsinterop
 import scala.scalajs.js
 import scala.scalajs.js.JSConverters._
 import scala.scalajs.js.|
+import scala.scalajs.LinkingInfo.{linkTimeIf, moduleKind}
+import scala.scalajs.LinkingInfo.ModuleKind.{MinimalWasmModule, WasmComponent}
 
 import scala.concurrent.{Future, ExecutionContext}
 import scala.scalajs.concurrent._
@@ -69,6 +71,10 @@ class AsyncTest {
 
     processQueue()
 
+    assertQueueExecOrderCompleted(res)
+  }
+
+  private def assertQueueExecOrderCompleted(res: ArrayBuffer[String]): Unit = {
     assertArrayEquals(
         Array[AnyRef](
             "prep-future",
@@ -81,7 +87,10 @@ class AsyncTest {
         res.toArray[AnyRef])
   }
 
-  @Test def scalaScalajsConcurrentJSExecutionContextQueue(): Unit = {
+  // format: off
+  // scalastyle:off line.size.limit
+
+  @Test def scalaScalajsConcurrentJSExecutionContextQueue(): Unit = { linkTimeIf(moduleKind != MinimalWasmModule && moduleKind != WasmComponent) {
     assumeTrue("Assumed js.Dynamic.global.Promise is undefined",
         js.typeOf(js.Dynamic.global.Promise) == "undefined")
     TimeoutMock.withMockedTimeout { tick =>
@@ -89,9 +98,9 @@ class AsyncTest {
         tick(1)
       }(JSExecutionContext.queue)
     }
-  }
+  }{()}}
 
-  @Test def scalaScalaConcurrentExecutionContextGlobal(): Unit = {
+  @Test def scalaScalaConcurrentExecutionContextGlobal(): Unit = { linkTimeIf(moduleKind != MinimalWasmModule && moduleKind != WasmComponent) {
     assumeTrue("Assumed js.Dynamic.global.Promise is undefined",
         js.typeOf(js.Dynamic.global.Promise) == "undefined")
     TimeoutMock.withMockedTimeout { tick =>
@@ -101,9 +110,9 @@ class AsyncTest {
 
       assertSame(JSExecutionContext.queue, ExecutionContext.global)
     }
-  }
+  }{()}}
 
-  @Test def scalaScalajsConcurrentQueueExecutionContext(): Unit = {
+  @Test def scalaScalajsConcurrentQueueExecutionContext(): Unit = { linkTimeIf(moduleKind != MinimalWasmModule && moduleKind != WasmComponent) {
     TimeoutMock.withMockedTimeout { tick =>
       PromiseMock.withMockedPromiseIfExists { optProcessQueue =>
         implicit val executor = QueueExecutionContext()
@@ -113,25 +122,32 @@ class AsyncTest {
         }
       }
     }
+  }{()}}
+
+  @Test def scalaScalajsConcurrentQueueExecutionContextSingleThreaded(): Unit = {
+    implicit val ec: ExecutionContext = QueueExecutionContext.single()
+    Future {
+      asyncTest
+    }.foreach(assertQueueExecOrderCompleted)
   }
 
-  @Test def scalaScalajsConcurrentQueueExecutionContextTimeouts(): Unit = {
+  @Test def scalaScalajsConcurrentQueueExecutionContextTimeouts(): Unit = { linkTimeIf(moduleKind != MinimalWasmModule && moduleKind != WasmComponent) {
     TimeoutMock.withMockedTimeout { tick =>
       implicit val executor = QueueExecutionContext.timeouts()
       queueExecOrderTests { () =>
         tick(1)
       }
     }
-  }
+  }{()}}
 
-  @Test def scalaScalajsConcurrentQueueExecutionContextPromises(): Unit = {
+  @Test def scalaScalajsConcurrentQueueExecutionContextPromises(): Unit = { linkTimeIf(moduleKind != MinimalWasmModule && moduleKind != WasmComponent) {
     PromiseMock.withMockedPromise { processQueue =>
       implicit val executor = QueueExecutionContext.promises()
       queueExecOrderTests { () =>
         processQueue()
       }
     }
-  }
+  }{()}}
 
   @Test def scalaConcurrentFutureSupportsMap(): AsyncResult = await {
     import ExecutionContext.Implicits.global
@@ -151,7 +167,7 @@ class AsyncTest {
     f.map(v => assertEquals(Seq(3, 5), v))
   }
 
-  @Test def jsPromiseToFutureBasicCase(): Unit = {
+  @Test def jsPromiseToFutureBasicCase(): Unit = { linkTimeIf(moduleKind != MinimalWasmModule && moduleKind != WasmComponent) {
     PromiseMock.withMockedPromise { processQueue =>
       implicit val ec = QueueExecutionContext.promises()
 
@@ -174,9 +190,9 @@ class AsyncTest {
 
       assertTrue(callbackDone)
     }
-  }
+  }{()}}
 
-  @Test def scalaConcurrentFutureToJSPromiseBasicCase(): Unit = {
+  @Test def scalaConcurrentFutureToJSPromiseBasicCase(): Unit = { linkTimeIf(moduleKind != MinimalWasmModule && moduleKind != WasmComponent) {
     PromiseMock.withMockedPromise { processQueue =>
       implicit val ec = QueueExecutionContext.promises()
 
@@ -196,9 +212,9 @@ class AsyncTest {
 
       assertTrue(callbackDone)
     }
-  }
+  }{()}}
 
-  @Test def scalaConcurrentFutureToJSPromiseThenableCase(): Unit = {
+  @Test def scalaConcurrentFutureToJSPromiseThenableCase(): Unit = { linkTimeIf(moduleKind != MinimalWasmModule && moduleKind != WasmComponent) {
     PromiseMock.withMockedPromise { processQueue =>
       implicit val ec = QueueExecutionContext.promises()
 
@@ -223,5 +239,8 @@ class AsyncTest {
 
       assertTrue(callbackDone)
     }
-  }
+  }{()}}
+
+  // scalastyle:on line.size.limit
+  // format: on
 }


### PR DESCRIPTION
close https://github.com/scala-wasm/scala-wasm/issues/60

Queue tasks, and do not reentrant/execute tasks with ExecutionContext for pure Wasm. If the tasks are running, `execute` just enqueue the task, and run that task later in FIFO.

```scala
val tasks = new ArrayBuffer[String]
Future {
  tasks += "outer-start"
  Future {
    tasks += "inner"
  }
  tasks += "outer-end"
}
// Previously: Array("outer-start", "inner", "outer-end")
// Now: Array("outer-start", "outer-end", "inner"),
```

Unlike scala-native, we don't have runtime hooks to drain the queue later, and `execute` starts processing tasks immediately.