### PR TITLE
Deprecate wasmEnv for jsEnv

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -194,6 +194,12 @@ jobs:
           node-version: '26'
       - name: npm install
         run: npm install
+      - name: Install wasmtime, wasm-tools, and wac-cli
+        uses: taiki-e/install-action@v2
+        with:
+          tool: wasmtime@44.0.2,wasm-tools,wac-cli
+      - name: Install wit-bindgen from scala-wasm/wit-bindgen scala-wasm-wasm.4 tag
+        run: cargo install --git https://github.com/scala-wasm/wit-bindgen --tag scala-wasm-wasm.4 wit-bindgen-cli
       - name: sbtPlugin2_12/scripted
         run: sbt sbtPlugin2_12/scripted
       - name: sbtPlugin3/scripted

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -592,10 +592,12 @@ def allESVersions = [
   "ES2018",
   // "ES2019", // We do not use anything specifically from ES2019
   "ES2020",
-  "ES2021" // We do not use anything specifically from ES2021, but always test the latest to avoid #4675
+  // "ES2021", // We do not use anything specifically from ES2021
+  "ES2022", // the 'd' flag for RegExp
+  "ES2026" // We do not use anything specifically from ES2023-ES2026, but always test the latest to avoid #4675
 ]
 def defaultESVersion = "ES2015"
-def latestESVersion = "ES2021"
+def latestESVersion = "ES2026"
 
 // The 'quick' matrix
 def quickMatrix = []

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -593,10 +593,11 @@ def allESVersions = [
   // "ES2019", // We do not use anything specifically from ES2019
   "ES2020",
   // "ES2021", // We do not use anything specifically from ES2021
-  "ES2022", // the 'd' flag for RegExp
+  "ES2022", // the 'd' flag for RegExp, and minimum version for Wasm
   "ES2026" // We do not use anything specifically from ES2023-ES2026, but always test the latest to avoid #4675
 ]
 def defaultESVersion = "ES2015"
+def minWasmESVersion = "ES2022"
 def latestESVersion = "ES2026"
 
 // The 'quick' matrix

--- a/javalib/src/main/scala/java/util/regex/PatternCompiler.scala
+++ b/javalib/src/main/scala/java/util/regex/PatternCompiler.scala
@@ -74,7 +74,7 @@ private[regex] object PatternCompiler {
 
   /** Cache for `Support.supportsIndices`. */
   private val _supportsIndices =
-    featureTest("d")
+    (LinkingInfo.esVersion >= ESVersion.ES2022) || featureTest("d")
 
   /** Feature-test methods.
    *
@@ -102,7 +102,7 @@ private[regex] object PatternCompiler {
     /** Tests whether the underlying JS RegExp supports the 'd' flag. */
     @inline
     def supportsIndices: Boolean =
-      _supportsIndices
+      (LinkingInfo.esVersion >= ESVersion.ES2022) || _supportsIndices
 
     /** Tests whether features requiring support for the 'u' flag are enabled.
      *

--- a/library/src/main/scala/scala/scalajs/LinkingInfo.scala
+++ b/library/src/main/scala/scala/scalajs/LinkingInfo.scala
@@ -371,6 +371,57 @@ object LinkingInfo {
      *  - Separators for numeric literals (e.g., `1_000`)
      */
     final val ES2021 = 12
+
+    /** ECMAScript 2022 (13th edition).
+     *
+     *  Contains the following notable features:
+     *
+     *  - Top-level `await`
+     *  - New class elements: public/private instance/static fields/methods/accessors
+     *  - `RegExp` match indices with the `/d` flag
+     *  - `Error.cause`
+     *  - `Object.hasOwn`
+     */
+    final val ES2022 = 13
+
+    /** ECMAScript 2023 (14th edition).
+     *
+     *  Contains the following notable features:
+     *
+     *  - New methods on Arrays and TypedArrays
+     *  - `#!` comments at the top of the file
+     *  - Most Symbols in weak collections
+     */
+    final val ES2023 = 14
+
+    /** ECMAScript 2024 (15th edition).
+     *
+     *  Contains the following notable features:
+     *
+     *  - `RegExp` advanced features for sets of strings with the `/v` flag
+     *  - `Atomics.waitAsync`
+     */
+    final val ES2024 = 15
+
+    /** ECMAScript 2025 (16th edition).
+     *
+     *  Contains the following notable features:
+     *
+     *  - 16-bit floating point: `Math.f16round`, `Float16Array`, `DataView.{get,set}Float16`
+     *  - `Iterator` global
+     *  - `RegExp.escape`
+     *  - `Promise.try`
+     */
+    final val ES2025 = 16
+
+    /** ECMAScript 2026 (17th edition).
+     *
+     *  Contains the following notable features:
+     *
+     *  - `Uint8Array` methods for converting to/from hex and base64 strings
+     *  - `Math.sumPrecise`
+     */
+    final val ES2026 = 17
   }
 
   /** Constants for the value of `moduleKind`. */

--- a/linker-interface/shared/src/main/scala/org/scalajs/linker/interface/ESVersion.scala
+++ b/linker-interface/shared/src/main/scala/org/scalajs/linker/interface/ESVersion.scala
@@ -99,6 +99,57 @@ object ESVersion {
    */
   val ES2021: ESVersion = new ESVersion(12, "ECMAScript 2021")
 
+  /** ECMAScript 2022 (13th edition).
+   *
+   *  Contains the following notable features:
+   *
+   *  - Top-level `await`
+   *  - New class elements: public/private instance/static fields/methods/accessors
+   *  - `RegExp` match indices with the `/d` flag
+   *  - `Error.cause`
+   *  - `Object.hasOwn`
+   */
+  val ES2022: ESVersion = new ESVersion(13, "ECMAScript 2022")
+
+  /** ECMAScript 2023 (14th edition).
+   *
+   *  Contains the following notable features:
+   *
+   *  - New methods on Arrays and TypedArrays
+   *  - `#!` comments at the top of the file
+   *  - Most Symbols in weak collections
+   */
+  val ES2023: ESVersion = new ESVersion(14, "ECMAScript 2023")
+
+  /** ECMAScript 2024 (15th edition).
+   *
+   *  Contains the following notable features:
+   *
+   *  - `RegExp` advanced features for sets of strings with the `/v` flag
+   *  - `Atomics.waitAsync`
+   */
+  val ES2024: ESVersion = new ESVersion(15, "ECMAScript 2024")
+
+  /** ECMAScript 2025 (16th edition).
+   *
+   *  Contains the following notable features:
+   *
+   *  - 16-bit floating point: `Math.f16round`, `Float16Array`, `DataView.{get,set}Float16`
+   *  - `Iterator` global
+   *  - `RegExp.escape`
+   *  - `Promise.try`
+   */
+  val ES2025: ESVersion = new ESVersion(16, "ECMAScript 2025")
+
+  /** ECMAScript 2026 (17th edition).
+   *
+   *  Contains the following notable features:
+   *
+   *  - `Uint8Array` methods for converting to/from hex and base64 strings
+   *  - `Math.sumPrecise`
+   */
+  val ES2026: ESVersion = new ESVersion(17, "ECMAScript 2026")
+
   private[interface] implicit object ESVersionFingerprint extends Fingerprint[ESVersion] {
 
     override def fingerprint(esVersion: ESVersion): String = {

--- a/linker/jvm/src/main/scala/org/scalajs/linker/backend/closure/ClosureLinkerBackend.scala
+++ b/linker/jvm/src/main/scala/org/scalajs/linker/backend/closure/ClosureLinkerBackend.scala
@@ -85,6 +85,9 @@ final class ClosureLinkerBackend(config: LinkerBackendImpl.Config) extends Linke
       case ESVersion.ES2020 => ECMASCRIPT_2020
       case ESVersion.ES2021 => ECMASCRIPT_2021
 
+      // GCC does not have constants for later versions of ECMAScript
+      case esVersion if esVersion > ESVersion.ES2021 => ECMASCRIPT_2021
+
       // Test for ESVersion.ES5_1 without triggering the deprecation warning
       case esVersion if esVersion.edition == 5 =>
         ECMASCRIPT5_STRICT

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -31,6 +31,7 @@ import org.scalajs.sbtplugin._
 import org.scalajs.jsenv.{JSEnv, RunConfig, Input}
 import org.scalajs.jsenv.JSUtils.escapeJS
 import org.scalajs.jsenv.nodejs.NodeJSEnv
+import org.scalajs.jsenv.wasmtime.WasmtimeEnv
 
 import ScalaJSPlugin.autoImport.{ModuleKind => _, _}
 import org.scalastyle.sbt.ScalastylePlugin.autoImport.scalastyle
@@ -244,8 +245,20 @@ object MyScalaJSPlugin extends AutoPlugin {
       wantSourceMaps := true,
 
       jsEnv := {
-        val config = NodeJSEnv.Config().withSourceMap(wantSourceMaps.value)
-        new NodeJSEnv(config)
+        scalaJSLinkerConfig.value.moduleKind match {
+          case ModuleKind.WasmComponent =>
+            val config = WasmtimeEnv.Config()
+              .withArgs(List(
+                  "run",
+                  "-W", "gc,function-references,exceptions",
+                  "-S", "cli,http,inherit-env,inherit-network,tcp"
+              ))
+            new WasmtimeEnv(config)
+
+          case _ =>
+            val config = NodeJSEnv.Config().withSourceMap(wantSourceMaps.value)
+            new NodeJSEnv(config)
+        }
       },
 
       Compile / jsEnvInput :=

--- a/project/NodeJSEnvForcePolyfills.scala
+++ b/project/NodeJSEnvForcePolyfills.scala
@@ -101,8 +101,10 @@ final class NodeJSEnvForcePolyfills(esVersion: ESVersion, config: NodeJSEnv.Conf
         |      if (flags.indexOf('s') >= 0)
         |        throw new SyntaxError("unsupported flag 's'");
         |""".stripMargin)}
+        |${cond(ES2022, """
         |      if (flags.indexOf('d') >= 0)
         |        throw new SyntaxError("unsupported flag 'd'");
+        |""".stripMargin)}
         |    }
         |
         |${cond(ES2018, """

--- a/sbt-plugin/src/main/scala/org/scalajs/sbtplugin/ScalaJSPlugin.scala
+++ b/sbt-plugin/src/main/scala/org/scalajs/sbtplugin/ScalaJSPlugin.scala
@@ -33,7 +33,6 @@ import org.scalajs.linker.interface._
 
 import org.scalajs.jsenv.{Input, JSEnv}
 import org.scalajs.jsenv.nodejs.NodeJSEnv
-import org.scalajs.jsenv.wasmtime.WasmtimeEnv
 
 import PluginCompat.DefOps
 
@@ -282,8 +281,7 @@ object ScalaJSPlugin extends AutoPlugin {
         AMinusTask)
 
     val wasmEnv = TaskKey[JSEnv]("wasmEnv",
-        "The WebAssembly environment in which to run no-JS Wasm Scala.js applications.",
-        AMinusTask)
+        "Deprecated: Use jsEnv instead.", AMinusTask)
 
     /** All Scala.js class names on the fullClasspath, used by scalajsp. */
     val scalaJSClassNamesOnClasspath = TaskKey[Seq[String]]("scalaJSClassNamesOnClasspath",
@@ -420,18 +418,6 @@ object ScalaJSPlugin extends AutoPlugin {
 
         jsEnv := Def.uncached {
           new NodeJSEnv()
-        },
-
-        wasmEnv := Def.uncached {
-          val configuredEnvVars = envVars.value
-          val config = WasmtimeEnv.Config()
-            .withArgs(List(
-                "run",
-                "-W", "gc,function-references,exceptions",
-                "-S", "cli,inherit-env,inherit-network,tcp"
-            ))
-            .withEnv(configuredEnvVars)
-          new WasmtimeEnv(config)
         },
 
         scalaJSLoggerFactory := ((logger: Logger) => Loggers.sbtLogger2ToolsLogger(logger)),

--- a/sbt-plugin/src/main/scala/org/scalajs/sbtplugin/ScalaJSPluginInternal.scala
+++ b/sbt-plugin/src/main/scala/org/scalajs/sbtplugin/ScalaJSPluginInternal.scala
@@ -712,11 +712,7 @@ private[sbtplugin] object ScalaJSPluginInternal {
             "scalaJSUseMainModuleInitializer := true")
         }
         val log = streams.value.log
-        val env = if (isWasmComponent) {
-          wasmEnv.value
-        } else {
-          jsEnv.value
-        }
+        val env = jsEnv.value
 
         val className =
           if (isWasmComponent) "wasi:cli/run"
@@ -909,11 +905,7 @@ private[sbtplugin] object ScalaJSPluginInternal {
         val config = TestAdapter.Config()
           .withLogger(scalaJSLoggerFactory.value(log))
           .withEnv(envVars.value)
-        val jsEnvironment = jsEnv.value
-        val wasmEnvironment = wasmEnv.value
-        val env =
-          if (scalaJSLinkerConfig.value.moduleKind == ModuleKind.WasmComponent) wasmEnvironment
-          else jsEnvironment
+        val env = jsEnv.value
 
         val adapter = newTestAdapter(env, input, config)
         val frameworkAdapters = enhanceNotInstalledException(resolvedScoped.value, log) {

--- a/sbt-plugin/src/sbt-test/settings/wasm-component-jsenv/build.sbt
+++ b/sbt-plugin/src/sbt-test/settings/wasm-component-jsenv/build.sbt
@@ -1,0 +1,58 @@
+import sbtcompat.PluginCompat._
+import org.scalajs.linker.interface.ESVersion
+import org.scalajs.jsenv.wasmtime.WasmtimeEnv
+
+// TODO: currently we can't run tests using the wasmtime env,
+// if the Compile scope has it's own WIT files
+
+inThisBuild(Def.settings(
+  version := scalaJSVersion,
+  scalaVersion := "2.12.21",
+))
+
+val wasmtimeEnvSettings = Def.settings(
+  jsEnv := Def.uncached {
+    val config = WasmtimeEnv.Config()
+      .withArgs(List(
+          "run",
+          "-W", "gc,function-references,exceptions",
+          "-S", "cli,http,inherit-env,inherit-network,tcp"
+      ))
+      .withEnv(envVars.value)
+    new WasmtimeEnv(config)
+  }
+)
+
+lazy val runComponent = project
+  .in(file("run-component"))
+  .enablePlugins(ScalaJSPlugin)
+  .settings(wasmtimeEnvSettings)
+  .settings(
+      scalaJSWitDirectory := baseDirectory.value / "wit",
+      scalaJSWitWorld := Some("command"),
+      Compile / scalaJSLinkerConfig := {
+        val witDir = scalaJSWitDirectory.value
+        val witWorld = scalaJSWitWorld.value
+        (Compile / scalaJSLinkerConfig).value
+          .withExperimentalUseWebAssembly(true)
+          .withESFeatures(_.withESVersion(ESVersion.ES2022))
+          .withModuleKind(ModuleKind.WasmComponent)
+          .withWasmFeatures { features =>
+            features
+              .withWitDirectory(Some(witDir.getAbsolutePath))
+              .withWitWorld(witWorld)
+          }
+      }
+  )
+
+lazy val testComponent = project
+  .in(file("test-component"))
+  .enablePlugins(ScalaJSPlugin, ScalaJSJUnitPlugin)
+  .settings(wasmtimeEnvSettings)
+  .settings(
+      Test / scalaJSLinkerConfig ~= {
+        _.withExperimentalUseWebAssembly(true)
+          .withESFeatures(_.withESVersion(ESVersion.ES2022))
+          .withModuleKind(ModuleKind.WasmComponent)
+      }
+  )

--- a/sbt-plugin/src/sbt-test/settings/wasm-component-jsenv/project/build.sbt
+++ b/sbt-plugin/src/sbt-test/settings/wasm-component-jsenv/project/build.sbt
@@ -1,0 +1,2 @@
+addSbtPlugin("io.github.scala-wasm" % "sbt-scalajs" % sys.props("plugin.version"))
+addSbtPlugin("com.github.sbt" % "sbt2-compat" % "0.1.0")

--- a/sbt-plugin/src/sbt-test/settings/wasm-component-jsenv/run-component/src/main/scala/wasmcomponent/Main.scala
+++ b/sbt-plugin/src/sbt-test/settings/wasm-component-jsenv/run-component/src/main/scala/wasmcomponent/Main.scala
@@ -1,0 +1,14 @@
+package wasmcomponent
+
+import scala.scalajs.wit
+import scala.scalajs.wit.annotation._
+
+import componentmodel.exports.wasi.cli.Run
+
+@WitImplementation
+object Main extends Run {
+  override def run(): wit.Result[Unit, Unit] = {
+    println("WasmComponent run")
+    new wit.Ok(())
+  }
+}

--- a/sbt-plugin/src/sbt-test/settings/wasm-component-jsenv/run-component/wit/deps/wasi-cli-0.2.0/package.wit
+++ b/sbt-plugin/src/sbt-test/settings/wasm-component-jsenv/run-component/wit/deps/wasi-cli-0.2.0/package.wit
@@ -1,0 +1,5 @@
+package wasi:cli@0.2.0;
+
+interface run {
+  run: func() -> result;
+}

--- a/sbt-plugin/src/sbt-test/settings/wasm-component-jsenv/run-component/wit/world.wit
+++ b/sbt-plugin/src/sbt-test/settings/wasm-component-jsenv/run-component/wit/world.wit
@@ -1,0 +1,5 @@
+package scala-wasm:scripted;
+
+world command {
+  export wasi:cli/run@0.2.0;
+}

--- a/sbt-plugin/src/sbt-test/settings/wasm-component-jsenv/test
+++ b/sbt-plugin/src/sbt-test/settings/wasm-component-jsenv/test
@@ -1,0 +1,2 @@
+> runComponent/run
+> testComponent/test

--- a/sbt-plugin/src/sbt-test/settings/wasm-component-jsenv/test-component/src/test/scala/wasmcomponent/ComponentTest.scala
+++ b/sbt-plugin/src/sbt-test/settings/wasm-component-jsenv/test-component/src/test/scala/wasmcomponent/ComponentTest.scala
@@ -1,0 +1,10 @@
+package wasmcomponent
+
+import org.junit.Assert._
+import org.junit.Test
+
+class ComponentTest {
+  @Test
+  def testRunsInWasmComponent(): Unit =
+    assertEquals(42, 40 + 2)
+}

--- a/test-suite/js/src/test/scala/org/scalajs/testsuite/library/LinkingInfoTest.scala
+++ b/test-suite/js/src/test/scala/org/scalajs/testsuite/library/LinkingInfoTest.scala
@@ -59,6 +59,11 @@ class LinkingInfoTest {
     assertEquals(10, ESVersion.ES2019)
     assertEquals(11, ESVersion.ES2020)
     assertEquals(12, ESVersion.ES2021)
+    assertEquals(13, ESVersion.ES2022)
+    assertEquals(14, ESVersion.ES2023)
+    assertEquals(15, ESVersion.ES2024)
+    assertEquals(16, ESVersion.ES2025)
+    assertEquals(17, ESVersion.ES2026)
   }
 
   @Test def moduleKindConstants(): Unit = {


### PR DESCRIPTION
Previously, we declared a `wasmEnv` task aside from `jsEnv`, and plugin automatically selected `wasmEnv` when `moduleKind` was `WasmComponent`.

At the time, I thought (for some reason) that having a separate env task from `jsEnv` would be nice, but it just ended up confusing (in fact, I got comments about `WasmtimeEnv` set on `jsEnv` is ignored).

This commit deprecates `wasmEnv` and unifies it into `jsEnv`. Also, previously the plugin would automatically set `WasmtimeEnv` when `moduleKind = WasmComponent`, but `WasmtimeEnv` is a third-party library and, users are expected to explicitly set `WasmtimeEnv` by themselves.