### PR TITLE
Decouple module initializer exports from WASI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -140,6 +140,8 @@ jobs:
           tool: wasmtime@44.0.2,wasm-tools,wac-cli,cargo-component
       - name: Install wit-bindgen from scala-wasm/wit-bindgen scala-wasm-wasm.4 tag
         run: cargo install --git https://github.com/scala-wasm/wit-bindgen --tag scala-wasm-wasm.4 wit-bindgen-cli
+      - name: helloworldWASI${{ matrix.suffix }}/run
+        run: sbt "$SBT_SET_COMMAND" helloworldWASI${{ matrix.suffix }}/run
       - name: Build rust-exports
         run: cargo component build --target wasm32-wasip2 -r
         working-directory: examples/test-component-model/rust-exports

--- a/examples/helloworld-component-model/.gitignore
+++ b/examples/helloworld-component-model/.gitignore
@@ -1,4 +1,3 @@
 *.wasm
-wit/deps
 
 bindings.rs

--- a/examples/helloworld-component-model/src/main/scala/helloworld/RunImpl.scala
+++ b/examples/helloworld-component-model/src/main/scala/helloworld/RunImpl.scala
@@ -1,19 +1,12 @@
 package helloworld
 
-import scala.scalajs.wit.annotation._
-import scala.scalajs.wit
-
-import helloworld.exports.wasi.cli.Run
 import helloworld.scala_wasm.helloworld.greeter.greet
 
-/** Implementation using the new @WitImplementation pattern */
-@WitImplementation
-object RunImpl extends Run {
+object RunImpl {
 
-  override def run(): wit.Result[Unit, Unit] = {
+  def main(args: Array[String]): Unit = {
     val greeting = greet("Scala")
     println(greeting)
-    new wit.Ok(())
   }
 
 }

--- a/examples/helloworld-component-model/wit/deps/wasi-cli-0.2.0/package.wit
+++ b/examples/helloworld-component-model/wit/deps/wasi-cli-0.2.0/package.wit
@@ -1,0 +1,6 @@
+package wasi:cli@0.2.0;
+
+interface run {
+  /// Run the program.
+  run: func() -> result;
+}

--- a/examples/helloworld-wasi/.gitignore
+++ b/examples/helloworld-wasi/.gitignore
@@ -1,2 +1,1 @@
 main.wasm
-wit/deps

--- a/examples/helloworld-wasi/README.md
+++ b/examples/helloworld-wasi/README.md
@@ -1,17 +1,5 @@
 ```sh
-$ sbt helloworldWASI2_12/fastLinkJS
-[info] Fast optimizing .../scala-wasm/examples/helloworld-wasi/.2.12/target/scala-2.12/helloworld-wasi-fastopt
-
-# Download WIT dependencies
-$ make fetch
-# Build Wasm Component Model binary
-$ make component
-
-$ ls -lh main.wasm
-... 124K ... main.wasm
-
-$ time make run
-wasmtime run -W function-references,gc -C collector=null main.wasm
+$ sbt helloworldWASI2_12/run
+[info] Running wasi:cli/run.
 Hello world!
-make run  0.02s user 0.01s system 94% cpu 0.027 total
 ```

--- a/examples/helloworld-wasi/src/main/scala/helloworld/HelloWorld.scala
+++ b/examples/helloworld-wasi/src/main/scala/helloworld/HelloWorld.scala
@@ -1,13 +1,6 @@
 package helloworld
 
-import scala.scalajs.wit.annotation._
-import scala.scalajs.wit
-import helloworld.exports.wasi.cli.Run
-
-@WitImplementation
-object HelloWorld extends Run {
-  override def run(): wit.Result[Unit, Unit] = {
+object HelloWorld {
+  def main(args: Array[String]): Unit =
     println("Hello world!")
-    new wit.Ok(())
-  }
 }

--- a/examples/helloworld-wasi/wit/deps/wasi-cli-0.2.0/package.wit
+++ b/examples/helloworld-wasi/wit/deps/wasi-cli-0.2.0/package.wit
@@ -1,0 +1,6 @@
+package wasi:cli@0.2.0;
+
+interface run {
+  /// Run the program.
+  run: func() -> result;
+}

--- a/linker-interface/shared/src/main/scala/org/scalajs/linker/interface/WasmComponentModuleInitializerExport.scala
+++ b/linker-interface/shared/src/main/scala/org/scalajs/linker/interface/WasmComponentModuleInitializerExport.scala
@@ -1,0 +1,94 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
+package org.scalajs.linker.interface
+
+import Fingerprint.FingerprintBuilder
+
+/** The Wasm Component export name used to invoke the module initializers.
+ *
+ *  This only describes which export name to use. It does not generate WIT
+ *  declarations, the selected WIT world must declare an export.
+ *
+ *  For Wasm modules, we generate initializers in `_start` function, that runs
+ *  when the module is instantiated. In the Component Model, calling WIT functions
+ *  from `_start` isn't safe, it can access component imports before those components
+ *  are initialized. Therefore, for `ModuleKind.WasmComponent`, module initializers are
+ *  invoked from the configured component export instead of `_start`.
+ */
+final class WasmComponentModuleInitializerExport private (
+    val moduleName: String,
+    val functionName: String,
+    val resultType: WasmComponentModuleInitializerExport.ResultType
+) {
+  require(functionName.nonEmpty, "functionName must not be empty")
+
+  def exportName: String =
+    if (moduleName.isEmpty) functionName
+    else s"$moduleName#$functionName"
+
+  override def equals(that: Any): Boolean = that match {
+    case that: WasmComponentModuleInitializerExport =>
+      this.moduleName == that.moduleName &&
+      this.functionName == that.functionName &&
+      this.resultType == that.resultType
+    case _ =>
+      false
+  }
+
+  override def hashCode(): Int =
+    (moduleName, functionName, resultType).##
+
+  override def toString(): String =
+    s"WasmComponentModuleInitializerExport($moduleName, $functionName, $resultType)"
+}
+
+object WasmComponentModuleInitializerExport {
+
+  def apply(moduleName: String, functionName: String,
+      resultType: ResultType): WasmComponentModuleInitializerExport = {
+    new WasmComponentModuleInitializerExport(moduleName, functionName, resultType)
+  }
+
+  /** WIT result types for a module-initializer export. */
+  sealed abstract class ResultType private ()
+
+  object ResultType {
+
+    /** WIT `unit` */
+    case object Unit extends ResultType
+
+    /** WIT `result<unit, unit>`. */
+    case object ResultUnitUnit extends ResultType
+  }
+
+  private[interface] implicit object ResultTypeFingerprint extends Fingerprint[ResultType] {
+    override def fingerprint(resultType: ResultType): String = resultType match {
+      case ResultType.Unit           => "Unit"
+      case ResultType.ResultUnitUnit => "ResultUnitUnit"
+    }
+  }
+
+  private[interface] implicit object WasmComponentModuleInitializerExportFingerprint
+      extends Fingerprint[WasmComponentModuleInitializerExport] {
+    override def fingerprint(componentExport: WasmComponentModuleInitializerExport): String = {
+      new FingerprintBuilder("WasmComponentModuleInitializerExport")
+        .addField("moduleName", componentExport.moduleName)
+        .addField("functionName", componentExport.functionName)
+        .addField("resultType", componentExport.resultType)
+        .build()
+    }
+  }
+
+  def fingerprint(componentExport: WasmComponentModuleInitializerExport): String =
+    Fingerprint.fingerprint(componentExport)
+}

--- a/linker-interface/shared/src/main/scala/org/scalajs/linker/interface/WasmFeatures.scala
+++ b/linker-interface/shared/src/main/scala/org/scalajs/linker/interface/WasmFeatures.scala
@@ -18,6 +18,9 @@ import Fingerprint.FingerprintBuilder
  *
  *  The options in `WasmFeatures` specify what features of modern versions of
  *  WebAssembly are used by the Scala.js linker.
+ *
+ *  TODO: Move WIT and Wasm Component packaging options to a dedicated Wasm
+ *  Component configuration once such a configuration exists.
  */
 final class WasmFeatures private (
     /* We define `val`s separately below so that we can attach Scaladoc to them
@@ -26,6 +29,7 @@ final class WasmFeatures private (
     _exceptionHandling: Boolean,
     _witDirectory: Option[String],
     _witWorld: Option[String],
+    _moduleInitializerExport: Option[WasmComponentModuleInitializerExport],
     _autoIncludeWasiImports: Boolean,
     _useJSPI: Boolean
 ) {
@@ -36,6 +40,7 @@ final class WasmFeatures private (
       _exceptionHandling = true,
       _witDirectory = None,
       _witWorld = None,
+      _moduleInitializerExport = None,
       _autoIncludeWasiImports = true,
       _useJSPI = false
     )
@@ -59,6 +64,15 @@ final class WasmFeatures private (
    */
   val witWorld = _witWorld
 
+  /** Wasm Component export that invokes the module initializers.
+   *
+   *  This does not generate WIT declarations. The selected WIT world must
+   *  already declare the corresponding export.
+   *
+   *  Default: `None`
+   */
+  val moduleInitializerExport = _moduleInitializerExport
+
   /** Automatically include WASI imports when generating a WebAssembly component.
    *
    *  Default: `true`
@@ -73,6 +87,11 @@ final class WasmFeatures private (
 
   def withWitWorld(witWorld: Option[String]): WasmFeatures =
     copy(witWorld = witWorld)
+
+  def withModuleInitializerExport(
+      moduleInitializerExport: Option[WasmComponentModuleInitializerExport]): WasmFeatures = {
+    copy(moduleInitializerExport = moduleInitializerExport)
+  }
 
   def withAutoIncludeWasiImports(autoIncludeWasiImports: Boolean): WasmFeatures =
     copy(autoIncludeWasiImports = autoIncludeWasiImports)
@@ -95,6 +114,7 @@ final class WasmFeatures private (
       this.exceptionHandling == that.exceptionHandling &&
       this.witDirectory == that.witDirectory &&
       this.witWorld == that.witWorld &&
+      this.moduleInitializerExport == that.moduleInitializerExport &&
       this.autoIncludeWasiImports == that.autoIncludeWasiImports &&
       this.useJSPI == that.useJSPI
     case _ =>
@@ -107,9 +127,10 @@ final class WasmFeatures private (
     acc = mix(acc, exceptionHandling.##)
     acc = mix(acc, witDirectory.##)
     acc = mix(acc, witWorld.##)
+    acc = mix(acc, moduleInitializerExport.##)
     acc = mix(acc, autoIncludeWasiImports.##)
     acc = mixLast(acc, useJSPI.##)
-    finalizeHash(acc, 5)
+    finalizeHash(acc, 6)
   }
 
   override def toString(): String = {
@@ -117,6 +138,7 @@ final class WasmFeatures private (
        |  exceptionHandling = $exceptionHandling,
        |  witDirectory = $witDirectory,
        |  witWorld = $witWorld,
+       |  moduleInitializerExport = $moduleInitializerExport,
        |  autoIncludeWasiImports = $autoIncludeWasiImports,
        |  useJSPI = $useJSPI
        |)""".stripMargin
@@ -126,6 +148,8 @@ final class WasmFeatures private (
       exceptionHandling: Boolean = this.exceptionHandling,
       witDirectory: Option[String] = this.witDirectory,
       witWorld: Option[String] = this.witWorld,
+      moduleInitializerExport: Option[WasmComponentModuleInitializerExport] =
+        this.moduleInitializerExport,
       autoIncludeWasiImports: Boolean = this.autoIncludeWasiImports,
       useJSPI: Boolean = this.useJSPI
   ): WasmFeatures = {
@@ -133,6 +157,7 @@ final class WasmFeatures private (
       _exceptionHandling = exceptionHandling,
       _witDirectory = witDirectory,
       _witWorld = witWorld,
+      _moduleInitializerExport = moduleInitializerExport,
       _autoIncludeWasiImports = autoIncludeWasiImports,
       _useJSPI = useJSPI
     )
@@ -148,6 +173,7 @@ object WasmFeatures {
    *  - `exceptionHandling`: true
    *  - `witDirectory`: `None`
    *  - `witWorld`: `None`
+   *  - `moduleInitializerExport`: `None`
    *  - `autoIncludeWasiImports`: true
    *  - `useJSPI`: false
    */
@@ -160,6 +186,7 @@ object WasmFeatures {
         .addField("exceptionHandling", wasmFeatures.exceptionHandling)
         .addField("witDirectory", wasmFeatures.witDirectory)
         .addField("witWorld", wasmFeatures.witWorld)
+        .addField("moduleInitializerExport", wasmFeatures.moduleInitializerExport)
         .addField("autoIncludeWasiImports", wasmFeatures.autoIncludeWasiImports)
         .addField("useJSPI", wasmFeatures.useJSPI)
         .build()

--- a/linker/shared/src/main/scala/org/scalajs/linker/backend/wasmemitter/Emitter.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/backend/wasmemitter/Emitter.scala
@@ -45,14 +45,12 @@ import org.scalajs.logging.Logger
 import SpecialNames._
 import VarGen._
 import org.scalajs.linker.backend.javascript.ByteArrayWriter
-import _root_.org.scalajs.ir.Trees.WitExportDef
+import _root_.org.scalajs.ir.Trees.{WitExportDef, WitFunctionName}
 
 final class Emitter(config: Emitter.Config) {
   import Emitter._
 
   private val coreSpec = config.coreSpec
-
-  private val WasiCliRunExportName = "wasi:cli/run@0.2.0#run"
 
   private val loaderContent = LoaderContent.makeBytesContent(coreSpec)
 
@@ -103,21 +101,27 @@ final class Emitter(config: Emitter.Config) {
     classEmitter.genArrayClasses()
     coreLib.genPostClasses()
 
-    /* For Wasm components, `wasm-tools component new` first instantiates the
-     * core module with shim imports, then uses the instantiated core module's
-     * exports such as `memory` and `cabi_realloc` to lower the final component
-     * imports, and finally patches the shim through a fixup step. The core
-     * module's `start` function runs during core module instantiation, before
-     * that fixup is complete. Any module initializer that calls into component
-     * imports (e.g., `Bridge.start()` for tests, or user `main` methods that
-     * use imported WIT interfaces) would trap with `uninitialized element`
-     * because the fixup has not happened yet. Move all module initializers to
-     * the synthetic `wasi:cli/run` export, which executes after component
-     * instantiation is completed for WasmComponent.
+    /* In the Component Model, `_start` runs before other components are
+     * initialized. Move module initializers to a configured component export so
+     * they can safely call WIT functions.
      */
     val isWasmComponent = coreSpec.moduleKind == ModuleKind.WasmComponent
-    if (isWasmComponent && moduleInitializers.nonEmpty)
-      genSyntheticWasiCliRunExport(moduleInitializers)
+    coreSpec.wasmFeatures.moduleInitializerExport match {
+      case Some(componentExport) if isWasmComponent =>
+        validateWasmComponentModuleInitializerExport(topLevelExports, componentExport)
+        genSyntheticModuleInitializerExport(componentExport, moduleInitializers)
+
+      case Some(_) =>
+        ()
+
+      case None =>
+        if (isWasmComponent && moduleInitializers.nonEmpty) {
+          throw new LinkingException(
+              "Wasm Component module initializers require a configured " +
+              "Wasm Component module initializer export.")
+        }
+    }
+
     val startModuleInitializers =
       if (isWasmComponent) Nil else moduleInitializers
     genStartFunction(sortedClasses, startModuleInitializers, topLevelExports)
@@ -274,28 +278,64 @@ final class Emitter(config: Emitter.Config) {
     ctx.moduleBuilder.setStart(genFunctionID.start)
   }
 
-  private def genSyntheticWasiCliRunExport(
+  private def validateWasmComponentModuleInitializerExport(
+      topLevelExports: List[LinkedTopLevelExport],
+      componentExport: WasmComponentModuleInitializerExport): Unit = {
+    val conflicts = topLevelExports.exists {
+      case topLevelExport =>
+        topLevelExport.tree match {
+          case WitExportDef(moduleName, WitFunctionName.Function(functionName), _, _) =>
+            moduleName == componentExport.moduleName &&
+            functionName == componentExport.functionName
+          case _ =>
+            false
+        }
+    }
+
+    if (conflicts) {
+      throw new LinkingException(
+          "Wasm Component module initializer export conflicts with " +
+          s"a WIT export: ${componentExport.moduleName}#${componentExport.functionName}")
+    }
+  }
+
+  private def genSyntheticModuleInitializerExport(
+      componentExport: WasmComponentModuleInitializerExport,
       moduleInitializers: List[ModuleInitializer.Initializer])(
       implicit ctx: WasmContext): Unit = {
     implicit val pos = Position.NoPosition
 
-    val functionID = genFunctionID.forExport(WasiCliRunExportName)
+    val exportName =
+      if (componentExport.moduleName.isEmpty) componentExport.functionName
+      else s"${componentExport.moduleName}#${componentExport.functionName}"
+    val functionID = genFunctionID.forExport(exportName)
     val fb = new FunctionBuilder(
       ctx.moduleBuilder,
       functionID,
-      OriginalName(WasiCliRunExportName),
+      OriginalName(exportName),
       pos
     )
-    fb.setResultType(watpe.Int32)
+
+    componentExport.resultType match {
+      case WasmComponentModuleInitializerExport.ResultType.Unit =>
+        ()
+      case WasmComponentModuleInitializerExport.ResultType.ResultUnitUnit =>
+        fb.setResultType(watpe.Int32)
+    }
 
     genModuleInitializers(fb, moduleInitializers)(())
 
-    fb += wa.I32Const(0)
+    componentExport.resultType match {
+      case WasmComponentModuleInitializerExport.ResultType.Unit =>
+        ()
+      case WasmComponentModuleInitializerExport.ResultType.ResultUnitUnit =>
+        fb += wa.I32Const(0)
+    }
 
     fb.buildAndAddToModule()
     ctx.moduleBuilder.addExport(
       wamod.Export(
-        WasiCliRunExportName,
+        exportName,
         wamod.ExportDesc.Func(functionID)
       )
     )

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -2149,7 +2149,7 @@ object Build {
         val witWorld = scalaJSWitWorld.value
         scalaJSLinkerConfig.value
          .withPrettyPrint(true)
-         .withExperimentalUseWebAssembly(true)
+         .withESFeatures(_.withUseWebAssembly(true).withESVersion(ESVersion.ES2022))
          .withModuleKind(ModuleKind.WasmComponent)
          .withWasmFeatures { prevFeatures =>
            prevFeatures
@@ -2170,7 +2170,7 @@ object Build {
       scalaJSUseMainModuleInitializer := true,
       scalaJSLinkerConfig ~= {
         _.withPrettyPrint(true)
-         .withExperimentalUseWebAssembly(true)
+         .withESFeatures(_.withUseWebAssembly(true).withESVersion(ESVersion.ES2022))
          .withModuleKind(ModuleKind.MinimalWasmModule)
       },
       jsEnv := {
@@ -2191,20 +2191,26 @@ object Build {
       exampleSettings,
       name := "HelloWorld WASI",
       moduleName := "helloworld-wasi",
-      // scalaJSUseMainModuleInitializer := true,
+      scalaJSUseMainModuleInitializer := true,
       scalaJSWitDirectory := baseDirectory.value.getParentFile / "wit",
       scalaJSWitPackage := Some("helloworld"),
       scalaJSLinkerConfig := {
         val witDir = scalaJSWitDirectory.value
         val witWorld = scalaJSWitWorld.value
+        val moduleInitializerExport =
+          WasmComponentModuleInitializerExport(
+              "wasi:cli/run@0.2.0",
+              "run",
+              WasmComponentModuleInitializerExport.ResultType.ResultUnitUnit)
         scalaJSLinkerConfig.value
          .withPrettyPrint(true)
-         .withExperimentalUseWebAssembly(true)
+         .withESFeatures(_.withUseWebAssembly(true).withESVersion(ESVersion.ES2022))
          .withModuleKind(ModuleKind.WasmComponent)
          .withWasmFeatures { prevFeatures =>
            prevFeatures
              .withWitDirectory(Some(witDir.getAbsolutePath))
              .withWitWorld(witWorld)
+             .withModuleInitializerExport(Some(moduleInitializerExport))
           }
       },
   ).withScalaJSCompiler.dependsOnLibrary
@@ -2217,20 +2223,27 @@ object Build {
       exampleSettings,
       name := "HelloWorld Component Model",
       moduleName := "helloworld-component-model",
+      scalaJSUseMainModuleInitializer := true,
       scalaJSWitDirectory := baseDirectory.value.getParentFile / "wit",
       scalaJSWitWorld := Some("scala"),
       scalaJSWitPackage := Some("helloworld"),
       scalaJSLinkerConfig := {
         val witDir = scalaJSWitDirectory.value
         val witWorld = scalaJSWitWorld.value
+        val moduleInitializerExport =
+          WasmComponentModuleInitializerExport(
+              "wasi:cli/run@0.2.0",
+              "run",
+              WasmComponentModuleInitializerExport.ResultType.ResultUnitUnit)
         scalaJSLinkerConfig.value
          .withPrettyPrint(true)
-         .withExperimentalUseWebAssembly(true)
+         .withESFeatures(_.withUseWebAssembly(true).withESVersion(ESVersion.ES2022))
          .withModuleKind(ModuleKind.WasmComponent)
          .withWasmFeatures { prevFeatures =>
            prevFeatures
              .withWitDirectory(Some(witDir.getAbsolutePath))
              .withWitWorld(witWorld)
+             .withModuleInitializerExport(Some(moduleInitializerExport))
           }
       },
   ).withScalaJSCompiler.dependsOnLibrary
@@ -2252,7 +2265,7 @@ object Build {
         scalaJSLinkerConfig.value
          .withPrettyPrint(true)
          .withModuleKind(ModuleKind.WasmComponent)
-         .withExperimentalUseWebAssembly(true)
+         .withESFeatures(_.withUseWebAssembly(true).withESVersion(ESVersion.ES2022))
          .withWasmFeatures { prevFeatures =>
            prevFeatures
              .withWitDirectory(Some(witDir.getAbsolutePath))

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -393,6 +393,18 @@ object Build {
       "1.22.0")
   val previousVersion = previousVersions.last
 
+  private val WasiCliRunModuleInitializerExport =
+    WasmComponentModuleInitializerExport(
+        "wasi:cli/run@0.2.0",
+        "run",
+        WasmComponentModuleInitializerExport.ResultType.ResultUnitUnit)
+
+  private def withWasiCliRunModuleInitializerExport(
+      config: StandardConfig): StandardConfig = {
+    config.withWasmFeatures(
+        _.withModuleInitializerExport(Some(WasiCliRunModuleInitializerExport)))
+  }
+
   val previousBinaryCrossVersion = CrossVersion.binaryWith("sjs1_", "")
 
   val newScalaBinaryVersionsInThisRelease: Set[String] =
@@ -2197,21 +2209,16 @@ object Build {
       scalaJSLinkerConfig := {
         val witDir = scalaJSWitDirectory.value
         val witWorld = scalaJSWitWorld.value
-        val moduleInitializerExport =
-          WasmComponentModuleInitializerExport(
-              "wasi:cli/run@0.2.0",
-              "run",
-              WasmComponentModuleInitializerExport.ResultType.ResultUnitUnit)
         scalaJSLinkerConfig.value
-         .withPrettyPrint(true)
-         .withESFeatures(_.withUseWebAssembly(true).withESVersion(ESVersion.ES2022))
-         .withModuleKind(ModuleKind.WasmComponent)
-         .withWasmFeatures { prevFeatures =>
-           prevFeatures
-             .withWitDirectory(Some(witDir.getAbsolutePath))
-             .withWitWorld(witWorld)
-             .withModuleInitializerExport(Some(moduleInitializerExport))
-          }
+          .withPrettyPrint(true)
+          .withESFeatures(_.withUseWebAssembly(true).withESVersion(ESVersion.ES2022))
+          .withModuleKind(ModuleKind.WasmComponent)
+        .withWasmFeatures { prevFeatures =>
+          prevFeatures
+            .withWitDirectory(Some(witDir.getAbsolutePath))
+            .withWitWorld(witWorld)
+            .withModuleInitializerExport(Some(WasiCliRunModuleInitializerExport))
+        }
       },
   ).withScalaJSCompiler.dependsOnLibrary
 
@@ -2230,21 +2237,16 @@ object Build {
       scalaJSLinkerConfig := {
         val witDir = scalaJSWitDirectory.value
         val witWorld = scalaJSWitWorld.value
-        val moduleInitializerExport =
-          WasmComponentModuleInitializerExport(
-              "wasi:cli/run@0.2.0",
-              "run",
-              WasmComponentModuleInitializerExport.ResultType.ResultUnitUnit)
         scalaJSLinkerConfig.value
-         .withPrettyPrint(true)
-         .withESFeatures(_.withUseWebAssembly(true).withESVersion(ESVersion.ES2022))
-         .withModuleKind(ModuleKind.WasmComponent)
-         .withWasmFeatures { prevFeatures =>
-           prevFeatures
-             .withWitDirectory(Some(witDir.getAbsolutePath))
-             .withWitWorld(witWorld)
-             .withModuleInitializerExport(Some(moduleInitializerExport))
-          }
+            .withPrettyPrint(true)
+            .withESFeatures(_.withUseWebAssembly(true).withESVersion(ESVersion.ES2022))
+            .withModuleKind(ModuleKind.WasmComponent)
+        .withWasmFeatures { prevFeatures =>
+          prevFeatures
+            .withWitDirectory(Some(witDir.getAbsolutePath))
+            .withWitWorld(witWorld)
+            .withModuleInitializerExport(Some(WasiCliRunModuleInitializerExport))
+        }
       },
   ).withScalaJSCompiler.dependsOnLibrary
 
@@ -2639,6 +2641,8 @@ object Build {
         )
         .withPrettyPrint(true)
       },
+      Test / fastLinkJS / scalaJSLinkerConfig ~= withWasiCliRunModuleInitializerExport,
+      Test / fullLinkJS / scalaJSLinkerConfig ~= withWasiCliRunModuleInitializerExport,
 
       buildInfoOrStubs(Compile, Def.setting(baseDirectory.value / "src/main")),
 

--- a/sbt-plugin/src/main/scala/org/scalajs/sbtplugin/ScalaJSPluginInternal.scala
+++ b/sbt-plugin/src/main/scala/org/scalajs/sbtplugin/ScalaJSPluginInternal.scala
@@ -704,9 +704,9 @@ private[sbtplugin] object ScalaJSPluginInternal {
       run := Def.uncached {
         val linkerConfig = scalaJSLinkerConfig.value
         val isWasmComponent = linkerConfig.moduleKind == ModuleKind.WasmComponent
-        // Currently, `run` is supported for Wasm Component when it implements `wasi:cli/run`.
-        // We might want to automatiacally implement `wasi:cli/run` that invokes
-        // `scalaJSMainModuleInitializer.value` in future?
+        // Wasmtime's `run` command uses `wasi:cli/run` as the component entry point.
+        // A Wasm Component project can bind its module initializers to that export
+        // with `WasmFeatures.moduleInitializerExport`.
         if (!scalaJSUseMainModuleInitializer.value && !isWasmComponent) {
           throw new MessageOnlyException("`run` is only supported with " +
             "scalaJSUseMainModuleInitializer := true")


### PR DESCRIPTION
part of https://github.com/scala-wasm/scala-wasm/issues/221 (3)

**background**
scala-wasm core should not hard-code WASI-specific entry points like `wasi:cli/run`. Instead, module initializers should be able to bound to a Component export chosen by the user.

**Approach**
This commit adds `WasmFeatures.moduleInitializerExport` (I'd like to move those config from `WasmFeatures` to `WITConfiguration` or something in future), that configure which Wasm Component export invokes the module initializers. While the option generates WIT export in binary, it doesn't generate WIT file, users must include the configured export by themselves.

```scala
scalaJSUseMainModuleInitializer := true
scalaJSLinkerConfig ~= {
  _.withWasmFeatures(
    _.withModuleInitializerExport(Some(
      WasmComponentModuleInitializerExport(
        "wasi:cli/run@0.2.0",
        "run",
        WasmComponentModuleInitializerExport.ResultType.ResultUnitUnit))))
}
```