### PR TITLE
New WIT exports representation

### DIFF
--- a/compiler/src/main/scala/org/scalajs/nscplugin/GenJSCode.scala
+++ b/compiler/src/main/scala/org/scalajs/nscplugin/GenJSCode.scala
@@ -691,8 +691,7 @@ abstract class GenJSCode[G <: Global with Singleton](val global: G)
           witNativeMembersBuilder ++= genWitResourceConstructor(dd)
         } else if (dd.symbol.hasAnnotation(JSNativeAnnotation)) {
           jsNativeMembersBuilder += genJSNativeMemberDef(dd)
-        } else if (cd.symbol.hasAnnotation(WitImplementationAnnotation) &&
-            jsInterop.witExportOf(dd.symbol).isDefined) {
+        } else if (jsInterop.witExportOf(dd.symbol).isDefined) {
           val info = jsInterop.witExportOf(dd.symbol).get
           for (method <- genMethod(dd)) {
             methodsBuilder += method

--- a/compiler/src/main/scala/org/scalajs/nscplugin/PrepJSExports.scala
+++ b/compiler/src/main/scala/org/scalajs/nscplugin/PrepJSExports.scala
@@ -62,20 +62,6 @@ trait PrepJSExports[G <: Global with Singleton] { this: PrepJSInterop[G] =>
    *  * Returns (non-static) exporters for this symbol.
    */
   def genExport(sym: Symbol): List[Tree] = {
-    if (sym.isModuleClass && sym.hasAnnotation(WitImplementationAnnotation)) {
-      validateWitImplementation(sym)
-    }
-
-    // Check if this symbol extends a @WitExportInterface trait
-    if (sym.isClass || sym.isTrait || sym.isModuleClass) {
-      validateWitExportInterfaceExtension(sym)
-    }
-
-    if (sym.isTrait && sym.hasAnnotation(WitExportInterfaceAnnotation)) {
-      validateWitExportInterface(sym)
-      return Nil
-    }
-
     // Scala classes are never exported: Their constructors are.
     val isScalaClass = sym.isClass && !sym.isTrait && !sym.isModuleClass && !isJSAny(sym)
 
@@ -143,19 +129,10 @@ trait PrepJSExports[G <: Global with Singleton] { this: PrepJSInterop[G] =>
         jsInterop.WitExportInfo(moduleName, name)(info.pos)
     }
 
-    if (sym.isMethod && wasmComponent.nonEmpty) {
-      val ownerSym = sym.owner
-      // Only register actual exports (not trait method specs)
-      if (!(ownerSym.isTrait && sym.isDeferred)) {
-        jsInterop.registerWitExport(sym, wasmComponent.head)
-      } else {
-        // Validate that trait methods are in @WitExportInterface traits
-        if (!ownerSym.hasAnnotation(WitExportInterfaceAnnotation)) {
-          reporter.error(sym.pos,
-              s"Trait ${ownerSym.name} contains @WitExport methods but is not annotated with @WitExportInterface. " +
-              s"Add @WitExportInterface to the trait definition.")
-        }
-      }
+    // TODO: Remove this trait no-op once wit-bindgen stops generating export
+    // interfaces annotated with @WitExport.
+    if (sym.isMethod && wasmComponent.nonEmpty && !sym.owner.isTrait) {
+      jsInterop.registerWitExport(sym, wasmComponent.head)
     }
   }
 
@@ -176,11 +153,6 @@ trait PrepJSExports[G <: Global with Singleton] { this: PrepJSInterop[G] =>
     val symOwner =
       if (sym.isConstructor) sym.owner.owner
       else sym.owner
-
-    if (sym.isMethod && symOwner.isModuleClass &&
-        symOwner.hasAnnotation(WitImplementationAnnotation)) {
-      return exportsFromImplementationMethod(sym)
-    }
 
     // Annotations that are directly on the member
     val directAnnots = trgSym.annotations.filter(annot => isDirectMemberAnnot(annot.symbol))
@@ -360,18 +332,15 @@ trait PrepJSExports[G <: Global with Singleton] { this: PrepJSInterop[G] =>
                 "You may not export a lazy val to the Wasm Component")
           }
 
-          // @WitExport can ONLY be used in @WitExportInterface traits
-          val isInExportInterface =
-            symOwner.isTrait && symOwner.hasAnnotation(WitExportInterfaceAnnotation)
-          if (!isInExportInterface) {
-            if (symOwner.isTrait) {
-              reporter.error(annot.pos,
-                  s"@WitExport can only be used in traits annotated with @WitExportInterface. " +
-                  s"Trait ${symOwner.name} is missing the annotation.")
-            } else {
-              reporter.error(annot.pos,
-                  s"@WitExport can only be used in @WitExportInterface traits.")
-            }
+          // @WitExport is a direct export annotation for static object methods.
+          val isInStaticObject =
+            sym.isMethod && symOwner.isStatic && symOwner.isModuleClass
+          // TODO: Remove this trait no-op once wit-bindgen stops generating
+          // export interface traits annotated with @WitExport.
+          val isIgnoredTraitMethod = sym.isMethod && symOwner.isTrait
+          if (!isInStaticObject && !isIgnoredTraitMethod) {
+            reporter.error(annot.pos,
+                s"@WitExport can only be used in static objects.")
           }
 
         case ExportDestination.Static =>
@@ -452,50 +421,6 @@ trait PrepJSExports[G <: Global with Singleton] { this: PrepJSInterop[G] =>
     }
 
     allExportInfos.distinct
-  }
-
-  /** Collects exports for a method in a @WitImplementation object
-   *  by finding the corresponding trait method's @WitExport annotations.
-   */
-  private def exportsFromImplementationMethod(implMethod: Symbol): List[ExportInfo] = {
-    val implOwner = implMethod.owner
-    implicit val pos = implMethod.pos
-
-    // Find the trait with @WitExportInterface
-    val exportTrait = implOwner.ancestors.find { ancestor =>
-      ancestor.isTrait && ancestor.hasAnnotation(WitExportInterfaceAnnotation)
-    }
-
-    exportTrait match {
-      case None =>
-        reporter.error(pos,
-            s"@WitImplementation object ${implOwner.name} must extend a trait " +
-            s"annotated with @WitExportInterface")
-        Nil
-
-      case Some(traitSym) =>
-        // Find the corresponding trait method
-        val traitMethod = traitSym.info.member(implMethod.name).suchThat(
-            m =>
-              m.isMethod && m.isDeferred
-        )
-
-        if (traitMethod == NoSymbol) {
-          reporter.error(pos,
-              s"Method ${implMethod.name} does not override any method in trait ${traitSym.name}")
-          Nil
-        } else {
-          // Get exports from the trait method
-          // Call exportsOf recursively on the trait method to get its @WitExport
-          val traitExports = exportsOf(traitMethod)
-
-          // Filter to only WasmComponent exports
-          traitExports.filter {
-            case ExportInfo(_, _: ExportDestination.WasmComponent) => true
-            case _                                                 => false
-          }
-        }
-    }
   }
 
   /** Checks whether the given target is suitable for export and exporting
@@ -687,131 +612,5 @@ trait PrepJSExports[G <: Global with Singleton] { this: PrepJSInterop[G] =>
     JSExportStaticAnnotation,
     WitExportAnnotation
   )
-
-  /** Validates that a @WitExportInterface trait follows the rules.
-   *
-   *  1. All methods must be abstract (no concrete implementations)
-   *  2. All methods must have @WitExport annotation
-   *  3. No non-method members allowed (vals, vars, etc.)
-   */
-  private def validateWitExportInterface(traitSym: Symbol): Unit = {
-    implicit val pos = traitSym.pos
-
-    // Check all members of the trait
-    val methods = traitSym.info.decls.filter(
-        m =>
-          m.isMethod && !m.isConstructor && !m.isSynthetic
-    )
-
-    for (method <- methods) {
-      // All methods must be abstract
-      if (!method.isDeferred) {
-        reporter.error(method.pos,
-            s"@WitExportInterface trait cannot contain concrete method implementations. " +
-            s"Method '${method.name}' must be abstract.")
-      }
-
-      // All methods must have @WitExport
-      if (!method.hasAnnotation(WitExportAnnotation)) {
-        reporter.error(method.pos,
-            s"All methods in @WitExportInterface trait must be annotated with @WitExport. " +
-            s"Method '${method.name}' is missing the annotation.")
-      }
-    }
-
-    // Check for non-method members (vals, vars, etc.)
-    val nonMethodMembers = traitSym.info.decls.filter { m =>
-      !m.isMethod && !m.isType && !m.isConstructor && !m.isSynthetic
-    }
-    for (member <- nonMethodMembers) {
-      reporter.error(member.pos,
-          s"@WitExportInterface trait cannot contain non-method members. " +
-          s"Member '${member.name}' is not allowed.")
-    }
-  }
-
-  /** Validates that a symbol properly extends @WitExportInterface traits.
-   *
-   *  A @WitExportInterface trait can ONLY be extended by:
-   *  - An object annotated with @WitImplementation
-   *
-   *  It CANNOT be extended by:
-   *  - A class (even with @WitImplementation)
-   *  - A trait (even with @WitImplementation)
-   *  - An object without @WitImplementation
-   */
-  private def validateWitExportInterfaceExtension(sym: Symbol): Unit = {
-    val exportInterfaceTraits = sym.ancestors.filter { ancestor =>
-      ancestor.isTrait &&
-      ancestor != sym && // Don't check itself if it's a WitExportInterface
-      ancestor.hasAnnotation(WitExportInterfaceAnnotation)
-    }
-
-    if (exportInterfaceTraits.nonEmpty) {
-      val exportTrait = exportInterfaceTraits.head
-
-      // Case 1: Regular class (not module class) extending WitExportInterface
-      if (sym.isClass && !sym.isTrait && !sym.isModuleClass) {
-        reporter.error(sym.pos,
-            s"@WitExportInterface trait ${exportTrait.name} cannot be extended by a class. " +
-            s"Use an object annotated with @WitImplementation instead.")
-      }
-      // Case 2: Trait extending WitExportInterface
-      else if (sym.isTrait && !sym.hasAnnotation(WitExportInterfaceAnnotation)) {
-        reporter.error(sym.pos,
-            s"@WitExportInterface trait ${exportTrait.name} cannot be extended by another trait. " +
-            s"Use an object annotated with @WitImplementation instead.")
-      }
-      // Case 3: Object (module class) without @WitImplementation
-      else if (sym.isModuleClass && !sym.hasAnnotation(WitImplementationAnnotation)) {
-        reporter.error(sym.pos,
-            s"Object ${sym.name} extends @WitExportInterface trait ${exportTrait.name} " +
-            s"but is not annotated with @WitImplementation. " +
-            s"Add @WitImplementation annotation to the object.")
-      }
-    }
-  }
-
-  /** Validates a @WitImplementation object. */
-  private def validateWitImplementation(implSym: Symbol): Unit = {
-    implicit val pos = implSym.pos
-
-    if (!implSym.isStatic || !implSym.isModuleClass) {
-      reporter.error(
-          pos, "Only static objects may be annotated with @WitImplementation. Use object instead.")
-      return
-    }
-
-    // Find the trait with @WitExportInterface
-    val exportTrait = implSym.ancestors.find { ancestor =>
-      ancestor.isTrait && ancestor.hasAnnotation(WitExportInterfaceAnnotation)
-    }
-    if (exportTrait.isEmpty) {
-      reporter.error(pos,
-          s"@WitImplementation object must extend a trait annotated with @WitExportInterface")
-      return
-    }
-    for (traitSym <- exportTrait) {
-      val exportMethods = traitSym.info.decls.filter { m =>
-        m.isMethod && m.isDeferred && m.hasAnnotation(WitExportAnnotation)
-      }
-      for (abstractMethod <- exportMethods) {
-        val implMethod = implSym.info.member(abstractMethod.name)
-        if (implMethod == NoSymbol || implMethod.isDeferred) {
-          reporter.error(pos,
-              s"Must implement method ${abstractMethod.name} from trait ${traitSym.name}")
-        } else {
-          // Check signature compatibility
-          val implType = implMethod.tpe.asSeenFrom(implSym.tpe, implMethod.owner)
-          val abstractType = abstractMethod.tpe.asSeenFrom(traitSym.tpe, abstractMethod.owner)
-          if (!implType.matches(abstractType)) {
-            reporter.error(pos,
-                s"Method ${implMethod.name} has incompatible signature. " +
-                s"Expected: ${abstractType}, Found: ${implType}")
-          }
-        }
-      }
-    }
-  }
 
 }

--- a/compiler/src/test/scala/org/scalajs/nscplugin/test/WitInteropTest.scala
+++ b/compiler/src/test/scala/org/scalajs/nscplugin/test/WitInteropTest.scala
@@ -851,270 +851,74 @@ class WitInteropTest extends DirectTest with TestHelpers {
     """.hasNoWarns()
   }
 
-  // --- Component Export Interface Tests ---
+  // --- Component Export Tests ---
 
-  @Test def exportInterfaceMustBeOnTrait: Unit = {
+  @Test def witExportMustBeInStaticObject: Unit = {
     """
-    @WitExportInterface
-    class NotATrait {
-      @WitExport("test:module", "func")
-      def func(): Unit
-    }
-    """ hasErrors
-    """
-      |newSource1.scala:8: error: @WitExport can only be used in @WitExportInterface traits.
-      |      @WitExport("test:module", "func")
-      |       ^
-    """
-
-    """
-    @WitExportInterface
-    object NotATrait {
-      @WitExport("test:module", "func")
-      def func(): Unit = ???
-    }
-    """ hasErrors
-    """
-      |newSource1.scala:8: error: @WitExport can only be used in @WitExportInterface traits.
-      |      @WitExport("test:module", "func")
-      |       ^
-    """
-  }
-
-  @Test def exportInterfaceCannotHaveConcreteMethod: Unit = {
-    """
-    @WitExportInterface
-    trait MyExport {
-      @WitExport("test:module", "concrete")
-      def concreteMethod(): Unit = {
-        println("concrete")
-      }
-    }
-    """ hasErrors
-    """
-      |newSource1.scala:9: error: @WitExportInterface trait cannot contain concrete method implementations. Method 'concreteMethod' must be abstract.
-      |      def concreteMethod(): Unit = {
-      |          ^
-    """
-  }
-
-  @Test def exportInterfaceMethodsMustHaveAnnotation: Unit = {
-    """
-    @WitExportInterface
-    trait MyExport {
-      @WitExport("test:module", "annotated")
-      def annotated(): Unit
-
-      def unannotated(): Unit
-    }
-    """ hasErrors
-    """
-      |newSource1.scala:11: error: All methods in @WitExportInterface trait must be annotated with @WitExport. Method 'unannotated' is missing the annotation.
-      |      def unannotated(): Unit
-      |          ^
-    """
-  }
-
-  @Test def exportInterfaceCannotHaveNonMethodMembers: Unit = {
-    """
-    @WitExportInterface
-    trait MyExport {
+    class NotStatic {
       @WitExport("test:module", "method")
-      def method(): Unit
-
-      val value: Int = 42
-    }
-    """ hasErrors
-    """
-      |newSource1.scala:11: error: @WitExportInterface trait cannot contain concrete method implementations. Method 'value' must be abstract.
-      |      val value: Int = 42
-      |          ^
-    """
-
-    """
-    @WitExportInterface
-    trait MyExport {
-      var mutableValue: String = "foo"
-    }
-    """ hasErrors
-    """
-      |newSource1.scala:8: error: @WitExportInterface trait cannot contain concrete method implementations. Method 'mutableValue' must be abstract.
-      |      var mutableValue: String = "foo"
-      |          ^
-    """
-  }
-
-  @Test def exportInterfaceExtendedByClassOrTrait: Unit = {
-
-    """
-    @WitExportInterface
-    trait MyExport {
-      @WitExport("test:module", "method")
-      def method(): Unit
-    }
-
-    @WitImplementation
-    class MyClass extends MyExport {
-      override def method(): Unit = ???
-    }
-    """ hasErrors
-    """
-      |newSource1.scala:13: error: @WitExportInterface trait MyExport cannot be extended by a class. Use an object annotated with @WitImplementation instead.
-      |    class MyClass extends MyExport {
-      |          ^
-    """
-
-    """
-    @WitExportInterface
-    trait MyExport {
-      @WitExport("test:module", "method")
-      def method(): Unit
-    }
-
-    @WitImplementation
-    trait AnotherTrait extends MyExport {
-      override def method(): Unit = ???
-    }
-    """ hasErrors
-    """
-      |newSource1.scala:13: error: @WitExportInterface trait MyExport cannot be extended by another trait. Use an object annotated with @WitImplementation instead.
-      |    trait AnotherTrait extends MyExport {
-      |          ^
-    """
-
-    """
-    @WitExportInterface
-    trait MyExport {
-      @WitExport("test:module", "method")
-      def method(): Unit
-    }
-
-    object MyObjectWithoutAnnotation extends MyExport {
-      override def method(): Unit = ???
-    }
-    """ hasErrors
-    """
-      |newSource1.scala:12: error: Object MyObjectWithoutAnnotation extends @WitExportInterface trait MyExport but is not annotated with @WitImplementation. Add @WitImplementation annotation to the object.
-      |    object MyObjectWithoutAnnotation extends MyExport {
-      |           ^
-    """
-  }
-
-  // --- Component Implementation Tests ---
-
-  @Test def witImplementationMustExtendExportInterface: Unit = {
-    """
-    trait PlainTrait {
-      def method(): Unit
-    }
-
-    @WitImplementation
-    object MyImpl extends PlainTrait {
-      override def method(): Unit = ???
-    }
-    """ hasErrors
-    """
-      |newSource1.scala:11: error: @WitImplementation object must extend a trait annotated with @WitExportInterface
-      |    object MyImpl extends PlainTrait {
-      |           ^
-      |newSource1.scala:12: error: @WitImplementation object MyImpl must extend a trait annotated with @WitExportInterface
-      |      override def method(): Unit = ???
-      |                   ^
-    """
-
-    """
-    @WitImplementation
-    object StandaloneImpl {
       def method(): Unit = ???
     }
     """ hasErrors
     """
-      |newSource1.scala:7: error: @WitImplementation object must extend a trait annotated with @WitExportInterface
-      |    object StandaloneImpl {
-      |           ^
-      |newSource1.scala:8: error: @WitImplementation object StandaloneImpl must extend a trait annotated with @WitExportInterface
-      |      def method(): Unit = ???
-      |          ^
+      |newSource1.scala:7: error: @WitExport can only be used in static objects.
+      |      @WitExport("test:module", "method")
+      |       ^
     """
-  }
 
-  @Test def witImplementationMustImplementAllMethods: Unit = {
     """
-    @WitExportInterface
-    trait MyExport {
-      @WitExport("test:module", "method1")
-      def method1(): Unit
-
-      @WitExport("test:module", "method2")
-      def method2(x: Int): String
-    }
-
-    @WitImplementation
-    object IncompleteImpl extends MyExport {
-      override def method1(): Unit = ???
-      // missing method2
+    class Owner {
+      object Nested {
+        @WitExport("test:module", "method")
+        def method(): Unit = ()
+      }
     }
     """ hasErrors
     """
-      |newSource1.scala:16: error: Must implement method method2 from trait MyExport
-      |    object IncompleteImpl extends MyExport {
-      |           ^
+      |newSource1.scala:8: error: @WitExport can only be used in static objects.
+      |        @WitExport("test:module", "method")
+      |         ^
     """
   }
 
-  @Test def witImplementationMethodSignatureMustMatch: Unit = {
+  @Test def witExportTraitMethodsAreTemporarilyIgnored: Unit = {
     """
-    @WitExportInterface
-    trait MyExport {
+    trait GeneratedExports {
       @WitExport("test:module", "method")
-      def method(x: Int): String
+      def method(): Unit
     }
-
-    @WitImplementation
-    object WrongSignature extends MyExport {
-      override def method(x: Int): Int = 42  // Wrong return type
-    }
-    """ hasErrors
-    """
-      |newSource1.scala:14: error: overriding method method in trait MyExport of type (x: Int)String;
-      | method method has incompatible type
-      |      override def method(x: Int): Int = 42  // Wrong return type
-      |                   ^
-    """
+    """.hasNoWarns()
   }
 
   @Test def validWitExportExamples: Unit = {
     """
-    @WitExportInterface
-    trait Run {
+    object DirectRunImpl {
+      val foo = "bar"
+
       @WitExport("wasi:cli/run@0.2.0", "run")
-      def run(): wm.Result[Unit, Unit]
+      def run(): wm.Result[Unit, Unit] = {
+        println(foo)
+        new wm.Ok(())
+      }
+
+      def helper(): String = foo
     }
 
-    @WitImplementation
-    object RunImpl extends Run {
-      override def run(): wm.Result[Unit, Unit] = {
-        println("Hello!")
-        new wm.Ok(())
+    object MyAPIImpl {
+      @WitExport("test:api", "get-data")
+      def getData(id: Int): wm.Result[String, String] =
+        new wm.Ok(s"data-$id")
+
+      @WitExport("test:api", "process")
+      def process(data: Array[UByte]): Unit = {
+        // Process data
       }
     }
 
-    @WitExportInterface
-    trait MyAPI {
-      @WitExport("test:api", "get-data")
-      def getData(id: Int): wm.Result[String, String]
-
-      @WitExport("test:api", "process")
-      def process(data: Array[UByte]): Unit
-    }
-
-    @WitImplementation
-    object MyAPIImpl extends MyAPI {
-      override def getData(id: Int): wm.Result[String, String] =
-        new wm.Ok(s"data-$id")
-
-      override def process(data: Array[UByte]): Unit = {
-        // Process data
+    object Outer {
+      object Nested {
+        @WitExport("test:nested", "method")
+        def method(): Unit = ()
       }
     }
     """.hasNoWarns()

--- a/examples/echo-server/src/main/scala/echo/Server.scala
+++ b/examples/echo-server/src/main/scala/echo/Server.scala
@@ -11,13 +11,25 @@ import scala.scalajs.wit
 import scala.scalajs.WitUtils._
 import scala.collection.mutable
 
-import echo.exports.wasi.http.IncomingHandler
 import scala.scalajs.wasi.http.types._
 
-@WitImplementation
-object Server extends IncomingHandler {
-  override def handle(request: IncomingRequest, outParam: ResponseOutparam): Unit = {
-    val inputBody = (for {
+object Server {
+  @WitExport("wasi:http/incoming-handler@0.2.0", "handle")
+  def handle(request: IncomingRequest, outParam: ResponseOutparam): Unit = {
+    val inputBody = readRequestBody(request)
+
+    val headers: Headers = Fields()
+    val resp = OutgoingResponse(headers)
+    val body: OutgoingBody =
+      toEither(resp.body()).getOrElse(throw new Error("failed to obtain outgoing response"))
+
+    ResponseOutparam.set(outParam, new wit.Ok(resp))
+
+    writeResponseBody(body, inputBody)
+  }
+
+  private def readRequestBody(request: IncomingRequest): Array[Byte] = {
+    (for {
       body <- toEither(request.consume())
       inputStream <- toEither(body.stream())
     } yield {
@@ -37,16 +49,11 @@ object Server extends IncomingHandler {
       }
       in.toArray
     }).getOrElse(throw new Error("failed to obtain request body"))
+  }
 
-    val headers: Headers = Fields()
-    val resp = OutgoingResponse(headers)
-    val body: OutgoingBody =
-      toEither(resp.body()).getOrElse(throw new Error("failed to obtain outgoing response"))
-
-    ResponseOutparam.set(outParam, new wit.Ok(resp))
-
+  private def writeResponseBody(body: OutgoingBody, bytes: Array[Byte]): Unit = {
     val out = toEither(body.write()).getOrElse(throw new Error("failed to get outgoing stream"))
-    out.blockingWriteAndFlush(inputBody)
+    out.blockingWriteAndFlush(bytes)
 
     out.close()
 

--- a/examples/helloworld-component-model/src/main/scala/helloworld/RunImpl.scala
+++ b/examples/helloworld-component-model/src/main/scala/helloworld/RunImpl.scala
@@ -3,10 +3,8 @@ package helloworld
 import helloworld.scala_wasm.helloworld.greeter.greet
 
 object RunImpl {
-
   def main(args: Array[String]): Unit = {
     val greeting = greet("Scala")
     println(greeting)
   }
-
 }

--- a/examples/test-component-model/src/main/scala/componentmodel/RootImpl.scala
+++ b/examples/test-component-model/src/main/scala/componentmodel/RootImpl.scala
@@ -3,13 +3,12 @@ package componentmodel
 import scala.scalajs.wit
 import scala.scalajs.wit.annotation._
 
-import componentmodel.exports.Root
+object RootImpl {
 
-@WitImplementation
-object RootImpl extends Root {
+  @WitExport("", "bare-multiply")
+  def bareMultiply(a: Int, b: Int): Int = a * b
 
-  override def bareMultiply(a: Int, b: Int): Int = a * b
-
-  override def bareUppercase(text: String): String = text.toUpperCase()
+  @WitExport("", "bare-uppercase")
+  def bareUppercase(text: String): String = text.toUpperCase()
 
 }

--- a/examples/test-component-model/src/main/scala/componentmodel/TestImportsImpl.scala
+++ b/examples/test-component-model/src/main/scala/componentmodel/TestImportsImpl.scala
@@ -8,15 +8,14 @@ import componentmodel.component.testing.basics._
 import componentmodel.component.testing.tests._
 import componentmodel.component.testing.countable._
 import componentmodel.root._
-import componentmodel.exports.component.testing.TestImports
 
 import scala.scalajs.WitUtils.toEither
 
 import java.util.Optional
 
-@WitImplementation
-object TestImportsImpl extends TestImports {
-  override def run(): Unit = {
+object TestImportsImpl {
+  @WitExport("component:testing/test-imports", "run")
+  def run(): Unit = {
     def newCounterArray(size: Int): Array[Counter] =
       new Array[Counter](size)
 

--- a/examples/test-component-model/src/main/scala/componentmodel/TestsImpl.scala
+++ b/examples/test-component-model/src/main/scala/componentmodel/TestsImpl.scala
@@ -4,60 +4,91 @@ import scala.scalajs.wit
 import scala.scalajs.wit.annotation._
 import scala.scalajs.wit.unsigned._
 
-import componentmodel.exports.component.testing.Tests
-import componentmodel.exports.component.testing.tests._
+import componentmodel.component.testing.tests._
 
 import scala.scalajs.WitUtils.toEither
 
 import java.util.Optional
 
-@WitImplementation
-object TestsImpl extends Tests {
+object TestsImpl {
 
-  override def roundtripPoint(a: Point): Point = a
+  private def roundtrip[A](a: A): A = a
 
-  override def roundtripBasics1(a: wit.Tuple9[UByte, Byte, UShort, Short, UInt, Int, Float, Double,
-          Char]): wit.Tuple9[UByte, Byte, UShort, Short, UInt, Int, Float, Double, Char] = a
+  private def ignore[A](a: A): Unit = ()
 
-  override def roundtripListU16(a: Array[UShort]): Array[UShort] = a
+  @WitExport("component:testing/tests", "roundtrip-point")
+  def roundtripPoint(a: Point): Point = roundtrip(a)
 
-  override def roundtripListPoint(a: Array[Point]): Array[Point] = a
+  @WitExport("component:testing/tests", "roundtrip-basics1")
+  def roundtripBasics1(a: wit.Tuple9[UByte, Byte, UShort, Short, UInt, Int, Float, Double,
+          Char]): wit.Tuple9[UByte, Byte, UShort, Short, UInt, Int, Float, Double, Char] = {
+    roundtrip(a)
+  }
 
-  override def roundtripListVariant(a: Array[C1]): Array[C1] = a
+  @WitExport("component:testing/tests", "roundtrip-list-u16")
+  def roundtripListU16(a: Array[UShort]): Array[UShort] = roundtrip(a)
 
-  override def roundtripString(a: String): String = a
+  @WitExport("component:testing/tests", "roundtrip-list-point")
+  def roundtripListPoint(a: Array[Point]): Array[Point] = roundtrip(a)
 
-  override def roundtripC1(a: C1): C1 = a
+  @WitExport("component:testing/tests", "roundtrip-list-variant")
+  def roundtripListVariant(a: Array[C1]): Array[C1] = roundtrip(a)
 
-  override def roundtripZ1(a: Z1): Z1 = a
+  @WitExport("component:testing/tests", "roundtrip-string")
+  def roundtripString(a: String): String = roundtrip(a)
 
-  override def testC1(a: C1): Unit = {}
+  @WitExport("component:testing/tests", "roundtrip-c1")
+  def roundtripC1(a: C1): C1 = roundtrip(a)
 
-  override def roundtripEnum(a: E1): E1 = a
+  @WitExport("component:testing/tests", "roundtrip-z1")
+  def roundtripZ1(a: Z1): Z1 = roundtrip(a)
 
-  override def roundtripTuple(a: wit.Tuple2[C1, Z1]): wit.Tuple2[C1, Z1] = a
+  @WitExport("component:testing/tests", "test-c1")
+  def testC1(a: C1): Unit = ignore(a)
 
-  override def roundtripOption(a: Optional[String]): Optional[String] = a
+  @WitExport("component:testing/tests", "roundtrip-enum")
+  def roundtripEnum(a: E1): E1 = roundtrip(a)
 
-  override def roundtripDoubleOption(a: Optional[Optional[String]]): Optional[Optional[String]] = a
+  @WitExport("component:testing/tests", "roundtrip-tuple")
+  def roundtripTuple(a: wit.Tuple2[C1, Z1]): wit.Tuple2[C1, Z1] = roundtrip(a)
 
-  override def roundtripResult(a: wit.Result[Unit, Unit]): wit.Result[Unit, Unit] = a
+  @WitExport("component:testing/tests", "roundtrip-option")
+  def roundtripOption(a: Optional[String]): Optional[String] = roundtrip(a)
 
-  override def roundtripStringError(a: wit.Result[Float, String]): wit.Result[Float, String] = a
+  @WitExport("component:testing/tests", "roundtrip-double-option")
+  def roundtripDoubleOption(a: Optional[Optional[String]]): Optional[Optional[String]] =
+    roundtrip(a)
 
-  override def roundtripEnumError(a: wit.Result[C1, E1]): wit.Result[C1, E1] = a
+  @WitExport("component:testing/tests", "roundtrip-result")
+  def roundtripResult(a: wit.Result[Unit, Unit]): wit.Result[Unit, Unit] = roundtrip(a)
 
-  override def roundtripF1(a: F1): F1 = a
+  @WitExport("component:testing/tests", "roundtrip-string-error")
+  def roundtripStringError(a: wit.Result[Float, String]): wit.Result[Float, String] =
+    roundtrip(a)
 
-  override def roundtripF2(a: F2): F2 = a
+  @WitExport("component:testing/tests", "roundtrip-enum-error")
+  def roundtripEnumError(a: wit.Result[C1, E1]): wit.Result[C1, E1] = roundtrip(a)
 
-  override def roundtripF3(a: F3): F3 = a
+  @WitExport("component:testing/tests", "roundtrip-f1")
+  def roundtripF1(a: F1): F1 = roundtrip(a)
 
-  override def roundtripFlags(a: wit.Tuple2[F1, F1]): wit.Tuple2[F1, F1] = a
+  @WitExport("component:testing/tests", "roundtrip-f2")
+  def roundtripF2(a: F2): F2 = roundtrip(a)
 
-  override def roundtripTuple2(a: wit.Tuple2[Int, String]): wit.Tuple2[Int, String] = a
+  @WitExport("component:testing/tests", "roundtrip-f3")
+  def roundtripF3(a: F3): F3 = roundtrip(a)
 
-  override def roundtripTuple3(
-      a: wit.Tuple3[Int, String, Boolean]): wit.Tuple3[Int, String, Boolean] = a
+  @WitExport("component:testing/tests", "roundtrip-flags")
+  def roundtripFlags(a: wit.Tuple2[F1, F1]): wit.Tuple2[F1, F1] = roundtrip(a)
+
+  @WitExport("component:testing/tests", "roundtrip-tuple2")
+  def roundtripTuple2(a: wit.Tuple2[Int, String]): wit.Tuple2[Int, String] =
+    roundtrip(a)
+
+  @WitExport("component:testing/tests", "roundtrip-tuple3")
+  def roundtripTuple3(
+      a: wit.Tuple3[Int, String, Boolean]): wit.Tuple3[Int, String, Boolean] = {
+    roundtrip(a)
+  }
 
 }

--- a/library/src/main/scala/scala/scalajs/wit/annotation/WitExport.scala
+++ b/library/src/main/scala/scala/scalajs/wit/annotation/WitExport.scala
@@ -14,6 +14,10 @@ package scala.scalajs.wit.annotation
 
 import scala.annotation.meta._
 
+/** Marks a function as a Wasm Component Model export.
+ *
+ *  This annotation is only valid on methods in static objects.
+ */
 @field @getter @setter
 class WitExport private () extends scala.annotation.StaticAnnotation {
   def this(moduleName: String, name: String) = this()

--- a/library/src/main/scala/scala/scalajs/wit/annotation/WitExportInterface.scala
+++ b/library/src/main/scala/scala/scalajs/wit/annotation/WitExportInterface.scala
@@ -38,5 +38,6 @@ import scala.annotation.meta._
  *  }
  *  }}}
  */
+@deprecated("Use @WitExport directly on static object methods instead.", "1.22.1-wasm.4")
 @getter
 class WitExportInterface extends scala.annotation.StaticAnnotation

--- a/library/src/main/scala/scala/scalajs/wit/annotation/WitImplementation.scala
+++ b/library/src/main/scala/scala/scalajs/wit/annotation/WitImplementation.scala
@@ -36,5 +36,6 @@ import scala.annotation.meta._
  *  }
  *  }}}
  */
+@deprecated("Use @WitExport directly on static object methods instead.", "1.22.1-wasm.4")
 @getter
 class WitImplementation extends scala.annotation.StaticAnnotation

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -2166,6 +2166,9 @@ object Build {
       exampleSettings,
       name := "Echo Server - Scala.js WASI example",
       moduleName := "echo",
+      // TODO: Re-enable fatal warnings once wit-bindgen stops generating
+      // deprecated export interface sources.
+      Compile / scalacOptions ~= (_.filterNot(Set("-Xfatal-warnings", "-Werror"))),
       scalaJSWitDirectory := baseDirectory.value.getParentFile / "wit",
       scalaJSWitWorld := Some("sample"),
       scalaJSWitPackage := Some("echo"),
@@ -2174,7 +2177,7 @@ object Build {
         val witWorld = scalaJSWitWorld.value
         scalaJSLinkerConfig.value
          .withPrettyPrint(true)
-         .withESFeatures(_.withUseWebAssembly(true).withESVersion(ESVersion.ES2022))
+         .withESFeatures(_.withESVersion(ESVersion.ES2022).withUseWebAssembly(true))
          .withModuleKind(ModuleKind.WasmComponent)
          .withWasmFeatures { prevFeatures =>
            prevFeatures
@@ -2217,21 +2220,24 @@ object Build {
       name := "HelloWorld WASI",
       moduleName := "helloworld-wasi",
       scalaJSUseMainModuleInitializer := true,
+      // TODO: Re-enable fatal warnings once wit-bindgen stops generating
+      // deprecated export interface sources.
+      Compile / scalacOptions ~= (_.filterNot(Set("-Xfatal-warnings", "-Werror"))),
       scalaJSWitDirectory := baseDirectory.value.getParentFile / "wit",
       scalaJSWitPackage := Some("helloworld"),
       scalaJSLinkerConfig := {
         val witDir = scalaJSWitDirectory.value
         val witWorld = scalaJSWitWorld.value
         scalaJSLinkerConfig.value
-          .withPrettyPrint(true)
-          .withESFeatures(_.withUseWebAssembly(true).withESVersion(ESVersion.ES2022))
-          .withModuleKind(ModuleKind.WasmComponent)
-        .withWasmFeatures { prevFeatures =>
-          prevFeatures
-            .withWitDirectory(Some(witDir.getAbsolutePath))
-            .withWitWorld(witWorld)
-            .withModuleInitializerExport(Some(WasiCliRunModuleInitializerExport))
-        }
+         .withPrettyPrint(true)
+         .withESFeatures(_.withESVersion(ESVersion.ES2022).withUseWebAssembly(true))
+         .withModuleKind(ModuleKind.WasmComponent)
+         .withWasmFeatures { prevFeatures =>
+           prevFeatures
+             .withWitDirectory(Some(witDir.getAbsolutePath))
+             .withWitWorld(witWorld)
+             .withModuleInitializerExport(Some(WasiCliRunModuleInitializerExport))
+          }
       },
   ).withScalaJSCompiler.dependsOnLibrary
 
@@ -2244,6 +2250,9 @@ object Build {
       name := "HelloWorld Component Model",
       moduleName := "helloworld-component-model",
       scalaJSUseMainModuleInitializer := true,
+      // TODO: Re-enable fatal warnings once wit-bindgen stops generating
+      // deprecated export interface sources.
+      Compile / scalacOptions ~= (_.filterNot(Set("-Xfatal-warnings", "-Werror"))),
       scalaJSWitDirectory := baseDirectory.value.getParentFile / "wit",
       scalaJSWitWorld := Some("scala"),
       scalaJSWitPackage := Some("helloworld"),
@@ -2251,15 +2260,15 @@ object Build {
         val witDir = scalaJSWitDirectory.value
         val witWorld = scalaJSWitWorld.value
         scalaJSLinkerConfig.value
-            .withPrettyPrint(true)
-            .withESFeatures(_.withUseWebAssembly(true).withESVersion(ESVersion.ES2022))
-            .withModuleKind(ModuleKind.WasmComponent)
-        .withWasmFeatures { prevFeatures =>
-          prevFeatures
-            .withWitDirectory(Some(witDir.getAbsolutePath))
-            .withWitWorld(witWorld)
-            .withModuleInitializerExport(Some(WasiCliRunModuleInitializerExport))
-        }
+         .withPrettyPrint(true)
+         .withESFeatures(_.withESVersion(ESVersion.ES2022).withUseWebAssembly(true))
+         .withModuleKind(ModuleKind.WasmComponent)
+         .withWasmFeatures { prevFeatures =>
+           prevFeatures
+             .withWitDirectory(Some(witDir.getAbsolutePath))
+             .withWitWorld(witWorld)
+             .withModuleInitializerExport(Some(WasiCliRunModuleInitializerExport))
+          }
       },
   ).withScalaJSCompiler.dependsOnLibrary
 
@@ -2270,6 +2279,9 @@ object Build {
   ).settings(
       exampleSettings,
       name := "Testing module for component model",
+      // TODO: Re-enable fatal warnings once wit-bindgen stops generating
+      // deprecated export interface sources.
+      Compile / scalacOptions ~= (_.filterNot(Set("-Xfatal-warnings", "-Werror"))),
       // MultiScalaProject creates subprojects with base directories at .2.12 and .2.13
       scalaJSWitDirectory := baseDirectory.value.getParentFile / "wit",
       scalaJSWitWorld := Some("scala"),
@@ -2280,7 +2292,7 @@ object Build {
         scalaJSLinkerConfig.value
          .withPrettyPrint(true)
          .withModuleKind(ModuleKind.WasmComponent)
-         .withESFeatures(_.withUseWebAssembly(true).withESVersion(ESVersion.ES2022))
+         .withESFeatures(_.withESVersion(ESVersion.ES2022).withUseWebAssembly(true))
          .withWasmFeatures { prevFeatures =>
            prevFeatures
              .withWitDirectory(Some(witDir.getAbsolutePath))

--- a/sbt-plugin/src/main/scala/org/scalajs/sbtplugin/ScalaJSPluginInternal.scala
+++ b/sbt-plugin/src/main/scala/org/scalajs/sbtplugin/ScalaJSPluginInternal.scala
@@ -96,6 +96,13 @@ private[sbtplugin] object ScalaJSPluginInternal {
 
     private final val World = "test-bridge"
 
+    private final val TestBridgeModuleInitializerExport = {
+      WasmComponentModuleInitializerExport(
+          "wasi:cli/run@0.2.0",
+          "run",
+          WasmComponentModuleInitializerExport.ResultType.ResultUnitUnit)
+    }
+
     private lazy val syntheticWitDirectory: File = {
       val base = new File(
           System.getProperty("java.io.tmpdir"),
@@ -129,6 +136,8 @@ private[sbtplugin] object ScalaJSPluginInternal {
           prev
             .withWitDirectory(Some(syntheticWitDirectory.getAbsolutePath))
             .withWitWorld(prev.witWorld.orElse(Some(World)))
+            .withModuleInitializerExport(
+                prev.moduleInitializerExport.orElse(Some(TestBridgeModuleInitializerExport)))
         }
       } else {
         config

--- a/sbt-plugin/src/sbt-test/settings/wasm-component-jsenv/run-component/src/main/scala/wasmcomponent/Main.scala
+++ b/sbt-plugin/src/sbt-test/settings/wasm-component-jsenv/run-component/src/main/scala/wasmcomponent/Main.scala
@@ -3,11 +3,9 @@ package wasmcomponent
 import scala.scalajs.wit
 import scala.scalajs.wit.annotation._
 
-import componentmodel.exports.wasi.cli.Run
-
-@WitImplementation
-object Main extends Run {
-  override def run(): wit.Result[Unit, Unit] = {
+object Main {
+  @WitExport("wasi:cli/run@0.2.0", "run")
+  def run(): wit.Result[Unit, Unit] = {
     println("WasmComponent run")
     new wit.Ok(())
   }


### PR DESCRIPTION
fix https://github.com/scala-wasm/scala-wasm/issues/231

**Background**
Previously, WIT exports through generated (by `wit-bindgen`) Scala traits:

```wit
package component:testing;
world scala {
  export tests;
}
interface tests {
  roundtrip-string: func(a: string) -> string;
}
```

generates

```scala
@WitExportInterface
trait Tests {
  @scala.scalajs.wit.annotation.WitExport(
      "component:testing/tests",
      "roundtrip-string")
  def roundtripString(a: String): String
}
```

and, users implement those export interface by overriding.

```scala
@WitImplementation
object TestsImpl extends Tests {
  override def roundtripString(a: String): String = a
}
```

It's convenient because users would be enforced to use corresponding types for the export WIT functions.
However, these two WIT's and Scala's "interface"s have different semantics. A WIT interface represents an application-wide interface, a Scala trait represents an object-level contract inside the Scala program. Because of this mismatch, overriding WIT interface has more restrictions than overriding `trait`s (such as it must be inherited by a single object instead of class, and etc), which is validated at `PrepWasmInterop`.

**Change**
This commit makes `@WitExport` on static object methods:

```scala
object TestsImpl {
  private def roundtrip[A](a: A): A = a

  @WitExport("component:testing/tests", "roundtrip-string")
  def roundtripString(a: String): String =
    roundtrip(a)
}
```

without `@WitImplementation` or `@WitExportInterface`.

`wit-bindgen` would NOT generate any Scala `interface`, it just prints a boilerplate like below, but implementing corresponding methods are users' responsitibility.

```scala
@WitExport("component:testing/tests", "roundtrip-string")
def roundtripString(a: String): String = ???
```

`@WitImplementation` and `@WitExportInterface` are deprecated but kept available.
Generated `wit-bindgen` export traits are temporarily accepted as no-op
`@WitExport` sites so existing generated sources can still compile while
`wit-bindgen` transitions from generating export interfaces.