### PR TITLE
Allow @WitResourceImport classes to extend java.lang.AutoCloseable

### DIFF
--- a/compiler/src/main/scala/org/scalajs/nscplugin/PrepJSInterop.scala
+++ b/compiler/src/main/scala/org/scalajs/nscplugin/PrepJSInterop.scala
@@ -963,12 +963,20 @@ abstract class PrepJSInterop[G <: Global with Singleton](val global: G)
                   s"Return type '${returnType}' in method '${member.name}' is not compatible with Component Model")
             }
 
-            // Check for overriding inherited members
+            // Check for overriding inherited members. A @WitResourceDrop
+            // `close(): Unit` is allowed to implement java.lang.AutoCloseable.close():
+            // the resource drop already provides exactly that method, which is what
+            // lets an imported resource mix in AutoCloseable. Any other override or
+            // implementation of an inherited member is still rejected.
             for (overridden <- member.allOverriddenSymbols.headOption) {
-              val verb = if (overridden.isDeferred) "implement" else "override"
-              reporter.error(member.pos,
-                  s"A @WitResourceMethod or @WitResourceDrop member cannot $verb the inherited member " +
-                  overridden.fullName)
+              val implementsAutoCloseable =
+                hasResourceDrop && overridden.owner == AutoCloseableClass
+              if (!implementsAutoCloseable) {
+                val verb = if (overridden.isDeferred) "implement" else "override"
+                reporter.error(member.pos,
+                    s"A @WitResourceMethod or @WitResourceDrop member cannot $verb the inherited member " +
+                    overridden.fullName)
+              }
             }
           }
 

--- a/compiler/src/main/scala/org/scalajs/nscplugin/PrepJSInterop.scala
+++ b/compiler/src/main/scala/org/scalajs/nscplugin/PrepJSInterop.scala
@@ -894,10 +894,13 @@ abstract class PrepJSInterop[G <: Global with Singleton](val global: G)
         return
       }
 
-      val nonObjectParents = sym.info.parents.map(_.typeSymbol).filter(_ != definitions.ObjectClass)
+      val nonObjectParents = sym.info.parents.map(_.typeSymbol).filterNot { parent =>
+        parent == definitions.ObjectClass || parent == AutoCloseableClass
+      }
       if (nonObjectParents.nonEmpty) {
         reporter.error(pos,
-            "@WitResourceImport class may only extend java.lang.Object")
+            "@WitResourceImport class may only extend java.lang.Object " +
+            "and/or java.lang.AutoCloseable")
         return
       }
 
@@ -2036,6 +2039,8 @@ abstract class PrepJSInterop[G <: Global with Singleton](val global: G)
     Set(JSGlobalAnnotation, JSImportAnnotation, JSGlobalScopeAnnotation)
 
   private lazy val ScalaEnumClass = getRequiredClass("scala.Enumeration")
+
+  private lazy val AutoCloseableClass = getRequiredClass("java.lang.AutoCloseable")
 
   private def wasPublicBeforeTyper(sym: Symbol): Boolean =
     sym.hasAnnotation(WasPublicBeforeTyperClass)

--- a/compiler/src/test/scala/org/scalajs/nscplugin/test/WitInteropTest.scala
+++ b/compiler/src/test/scala/org/scalajs/nscplugin/test/WitInteropTest.scala
@@ -346,6 +346,34 @@ class WitInteropTest extends DirectTest with TestHelpers {
     """.hasNoWarns()
   }
 
+  @Test def resourceMayExtendAutoCloseable: Unit = {
+    """
+    @WitResourceImport("test:io/streams", "input-stream")
+    final class InputStream private () extends Object with AutoCloseable {
+      @WitResourceMethod("read")
+      def read(len: ULong): wm.Result[Array[UByte], String] = wm.native
+
+      @WitResourceDrop
+      def close(): Unit = wm.native
+    }
+    """.hasNoWarns()
+  }
+
+  @Test def resourceOnlyDropMayImplementAutoCloseableClose: Unit = {
+    """
+    @WitResourceImport("test:io/streams", "input-stream")
+    final class InputStream private () extends Object with AutoCloseable {
+      @WitResourceMethod("close")
+      def close(): Unit = wm.native
+    }
+    """ hasErrors
+    """
+      |newSource1.scala:9: error: A @WitResourceMethod or @WitResourceDrop member cannot implement the inherited member java.lang.AutoCloseable.close
+      |      def close(): Unit = wm.native
+      |          ^
+    """
+  }
+
   // --- Component Variant Tests ---
 
   @Test def variantMustBeSealed: Unit = {

--- a/examples/test-component-model/src/main/scala/componentmodel/TestImportsImpl.scala
+++ b/examples/test-component-model/src/main/scala/componentmodel/TestImportsImpl.scala
@@ -167,6 +167,9 @@ object TestImportsImpl {
     // Test Object methods on imported resources
     TestFunctions.testResourceObjectMethods()
 
+    // Test AutoCloseable on imported resources
+    TestFunctions.testResourceAutoCloseable()
+
     val end = System.currentTimeMillis()
     println(s"elapsed: ${(end - start).toInt} ms")
   }
@@ -221,5 +224,26 @@ object TestFunctions {
     assert(cls1 == cls2)
     assert(cls1 == cls3)
     assert(cls2 == cls3)
+  }
+
+  def testResourceAutoCloseable(): Unit = {
+    // An imported resource whose @WitResourceDrop is `def close(): Unit` can mix
+    // in java.lang.AutoCloseable, so callers may manage its lifetime through the
+    // AutoCloseable interface (try-with-resources style). Kept cross-version
+    // safe: scala.util.Using is 2.13-only, so we use a plain try/finally here.
+
+    // The resource can be used polymorphically as an AutoCloseable.
+    val closeable: AutoCloseable = Counter(7)
+    closeable.close()
+
+    // try/finally releases the handle via close() (the resource drop) on both
+    // the normal and the exceptional path.
+    val counter = Counter(41)
+    try {
+      counter.up()
+      assert(42 == counter.valueOf())
+    } finally {
+      counter.close()
+    }
   }
 }

--- a/examples/test-component-model/src/main/scala/componentmodel/component/testing/countable.scala
+++ b/examples/test-component-model/src/main/scala/componentmodel/component/testing/countable.scala
@@ -7,7 +7,7 @@ package object countable {
 
   // Resources
   @WitResourceImport("component:testing/countable", "counter")
-  final class Counter private () extends Object {
+  final class Counter private () extends Object with AutoCloseable {
     @WitResourceMethod("up")
     def up(): Unit = wit.native
 

--- a/linker/shared/src/main/scala/org/scalajs/linker/backend/wasmemitter/FunctionEmitter.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/backend/wasmemitter/FunctionEmitter.scala
@@ -288,6 +288,7 @@ object FunctionEmitter {
   private val toStringMethodName = MethodName("toString", Nil, BoxedStringRef)
   private val equalsMethodName = MethodName("equals", List(ObjectRef), BooleanRef)
   private val compareToMethodName = MethodName("compareTo", List(ObjectRef), IntRef)
+  private val closeMethodName = MethodName("close", Nil, VoidRef)
 
   private val CharSequenceClass = ClassName("java.lang.CharSequence")
   private val ComparableClass = ClassName("java.lang.Comparable")
@@ -997,28 +998,45 @@ private class FunctionEmitter private (
         }
         val receiverClassInfo = ctx.getClassInfo(receiverClassName)
 
-        /* Hijacked classes do not receive tables at all, and `Apply`s on array
-         * types and WIT resource types are considered to be statically resolved
-         * by the `Analyzer`. Therefore, if the receiver's static type is a prim
-         * type, hijacked class, array type, or WIT resource type, we must use
-         * static dispatch instead.
-         * We can also use static dispatch for exact class types.
-         *
-         * This never happens when we use the optimizer, since it already turns
-         * any such `Apply` into an `ApplyStatically` (when it does not inline
-         * it altogether).
+        /* A `close(): Unit` call reaching this point on a WIT resource class is
+         * the resource drop being invoked through `java.lang.AutoCloseable.close()`.
+         * A direct call on the resource type is turned into a `WitFunctionApply` by
+         * the compiler (the callee carries `@WitResourceDrop`), but a polymorphic
+         * call through `AutoCloseable` resolves to the abstract `AutoCloseable.close`
+         * and stays a regular `Apply`. The resource has no vtable/itable slot for it,
+         * so we route it to the resource drop intrinsic instead. Implementing
+         * `AutoCloseable.close` is the only inherited member a resource drop is
+         * allowed to provide (enforced by `PrepJSInterop`), so there is no ambiguity
+         * with the resource's own `@WitResourceMethod`s.
          */
-        val useStaticDispatch = receiver.tpe match {
-          case _ if receiverClassInfo.kind == ClassKind.HijackedClass => true
-          case _: ArrayType                                           => true
-          case ClassType(_, _, exact)                                 => exact
-          case _                                                      => false
-        }
-        if (useStaticDispatch) {
-          genApplyStatically(ApplyStatically(
-              flags, receiver, receiverClassName, method, args)(tree.tpe)(tree.pos))
+        if (receiverClassInfo.kind == ClassKind.WasmComponentResourceClass &&
+            method.name == closeMethodName) {
+          genWitFunctionApply(WitFunctionApply(
+              Some(receiver), receiverClassName, method, args)(tree.tpe)(tree.pos))
         } else {
-          genApplyWithDispatch(tree, receiverClassInfo)
+          /* Hijacked classes do not receive tables at all, and `Apply`s on array
+           * types and WIT resource types are considered to be statically resolved
+           * by the `Analyzer`. Therefore, if the receiver's static type is a prim
+           * type, hijacked class, array type, or WIT resource type, we must use
+           * static dispatch instead.
+           * We can also use static dispatch for exact class types.
+           *
+           * This never happens when we use the optimizer, since it already turns
+           * any such `Apply` into an `ApplyStatically` (when it does not inline
+           * it altogether).
+           */
+          val useStaticDispatch = receiver.tpe match {
+            case _ if receiverClassInfo.kind == ClassKind.HijackedClass => true
+            case _: ArrayType                                           => true
+            case ClassType(_, _, exact)                                 => exact
+            case _                                                      => false
+          }
+          if (useStaticDispatch) {
+            genApplyStatically(ApplyStatically(
+                flags, receiver, receiverClassName, method, args)(tree.tpe)(tree.pos))
+          } else {
+            genApplyWithDispatch(tree, receiverClassInfo)
+          }
         }
     }
   }


### PR DESCRIPTION
## What

Let a `@WitResourceImport` class extend `java.lang.AutoCloseable` **and actually work end to end** — including calling the resource drop through `AutoCloseable.close()`.

```scala
@WitResourceImport("component:testing/countable", "counter")
final class Counter private () extends Object with AutoCloseable {
  @WitResourceMethod("up")
  def up(): Unit = scala.scalajs.wit.native
  @WitResourceDrop
  def close(): Unit = scala.scalajs.wit.native
}
```

## Why

An imported WIT resource is an opaque, host-owned handle whose lifetime the guest must release (the resource drop). The generated drop is already `def close(): Unit` — exactly `AutoCloseable.close()` — so mixing in `AutoCloseable` lets callers manage handles with try-with-resources patterns (`scala.util.Using`, etc.) at no runtime cost. Suggested by @tanishiking in #205.

## Changes

1. **Frontend (`PrepJSInterop`), parent check** — permit `java.lang.AutoCloseable` (in addition to `java.lang.Object`) as a parent of a `@WitResourceImport` class.

2. **Frontend (`PrepJSInterop`), inherited-member check** — a second check rejected any `@WitResourceMethod`/`@WitResourceDrop` member implementing an inherited member (`... cannot implement the inherited member java.lang.AutoCloseable.close`). Relaxed so a `@WitResourceDrop` may implement `AutoCloseable.close()` — and only the drop, only that member.

3. **Backend (`FunctionEmitter`)** — a direct `resource.close()` is lowered to a `WitFunctionApply` (the callee carries `@WitResourceDrop`), but a polymorphic call through `AutoCloseable` resolves to the abstract `AutoCloseable.close` and stays a plain `Apply`. Resource classes reuse `Object`'s vtable type and have no table slot for `close`, so this previously crashed the emitter (`key not found: forVTable(<Resource>)` / `MethodName<close;V>`). Such calls are now routed to the resource drop intrinsic.

## Tests

- `WitInteropTest`: added a positive case (resource extends `AutoCloseable`) and a negative case (only the drop may satisfy `close`).
- `test-component-model`: `Counter` now extends `AutoCloseable`, exercised both polymorphically and via try/finally (cross-version-safe; `scala.util.Using` is 2.13-only).

## Verification

- `WitInteropTest` 2.12 + 2.13: 46/46 pass
- `testComponentModel` fastLinkJS + fullLinkJS, 2.12 + 2.13: link clean
- Full end-to-end `make run` under wasmtime, 2.12 + 2.13: passes, no assertion failures
- `scalafmt --test`: clean

## Scope note

Full itable generation for resource classes is intentionally **not** included. The interception handles the case where the optimizer devirtualizes `AutoCloseable.close()` to the concrete resource (which is what happens under both fast and full link). A genuinely non-devirtualized interface dispatch to a resource drop would still need itable support; can be a follow-up if the more general solution is preferred.

Enables the generator-side counterpart scala-wasm/wit-bindgen-scala#3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
