### PR TITLE
Enrich WIT annotations and IR so component metadata can be reconstruct

### DIFF
--- a/compiler/src/main/scala/org/scalajs/nscplugin/GenJSCode.scala
+++ b/compiler/src/main/scala/org/scalajs/nscplugin/GenJSCode.scala
@@ -678,25 +678,29 @@ abstract class GenJSCode[G <: Global with Singleton](val global: G)
         if (isWitResourceClass && (dd.symbol.hasAnnotation(WitResourceMethodAnnotation) ||
               dd.symbol.hasAnnotation(WitResourceDropAnnotation))) {
           val annot = sym.getAnnotation(WitResourceImportAnnotation).get
-          val moduleName = annot.stringArg(0).get
+          val scope = jsInterop.witScopeArg(annot, 0).getOrElse {
+            abort(s"@WitResourceImport on $sym requires a literal WitScope argument")
+          }
           val resourceName = annot.stringArg(1).get
           val flags = js.MemberFlags.empty.withNamespace(js.MemberNamespace.Public)
           if (dd.symbol.hasAnnotation(WitResourceMethodAnnotation)) {
             val methodAnnot = dd.symbol.getAnnotation(WitResourceMethodAnnotation).get
             val functionName = methodAnnot.stringArg(0).get
-            witNativeMembersBuilder += genWitNativeMemberDef(flags, dd, moduleName,
+            witNativeMembersBuilder += genWitNativeMemberDef(flags, dd, scope,
                 js.WitFunctionName.ResourceMethod(functionName, resourceName))
           } else {
-            witNativeMembersBuilder += genWitNativeMemberDef(flags, dd, moduleName,
+            witNativeMembersBuilder += genWitNativeMemberDef(flags, dd, scope,
                 js.WitFunctionName.ResourceDrop(resourceName))
           }
         } else if (dd.symbol.hasAnnotation(WitImportAnnotation)) {
           val annot = dd.symbol.getAnnotation(WitImportAnnotation).get
-          val moduleName = annot.stringArg(0).get
+          val scope = jsInterop.witScopeArg(annot, 0).getOrElse {
+            abort(s"@WitImport on ${dd.symbol} requires a literal WitScope argument")
+          }
           val functionName = annot.stringArg(1).get
           val flags = js.MemberFlags.empty.withNamespace(js.MemberNamespace.PublicStatic)
           witNativeMembersBuilder +=
-            genWitNativeMemberDef(flags, dd, moduleName,
+            genWitNativeMemberDef(flags, dd, scope,
                 js.WitFunctionName.Function(functionName))
         } else if (isWasmWitResourceStaticMethod(dd.symbol)) {
           witNativeMembersBuilder ++= genWitResourceStaticMethodDef(dd)
@@ -790,6 +794,7 @@ abstract class GenJSCode[G <: Global with Singleton](val global: G)
                 jsConstructor = None,
                 jsMethodProps = Nil,
                 jsNativeMembers = Nil,
+                witTypeDef = None,
                 witNativeMembers = Nil,
                 topLevelExportDefs = Nil
               )(js.OptimizerHints.empty)
@@ -841,6 +846,7 @@ abstract class GenJSCode[G <: Global with Singleton](val global: G)
           jsConstructor = None,
           memberExports,
           jsNativeMembers,
+          witTypeDef = genWitTypeDef(sym),
           witNativeMembers = witNativeMembersBuilder.result(),
           topLevelExportDefs ++ witExportDefsBuilder.result())(
           optimizerHints)
@@ -975,6 +981,7 @@ abstract class GenJSCode[G <: Global with Singleton](val global: G)
           Some(generatedCtor),
           jsMethodProps,
           jsNativeMembers = Nil,
+          witTypeDef = None,
           witNativeMembers = Nil,
           topLevelExports)(
           OptimizerHints.empty)
@@ -1026,7 +1033,8 @@ abstract class GenJSCode[G <: Global with Singleton](val global: G)
             ClassKind.AbstractJSType, None, Some(parent), interfaces = Nil,
             jsSuperClass = None, jsNativeLoadSpec = None, fields = Nil,
             methods = origJsClass.methods, jsConstructor = None, jsMethodProps = Nil,
-            jsNativeMembers = Nil, Nil, topLevelExportDefs = Nil)(
+            jsNativeMembers = Nil, witTypeDef = None, witNativeMembers = Nil,
+            topLevelExportDefs = Nil)(
             origJsClass.optimizerHints)
       }
 
@@ -1203,7 +1211,7 @@ abstract class GenJSCode[G <: Global with Singleton](val global: G)
 
       js.ClassDef(classIdent, originalNameOfClass(sym), kind, None, superClass,
           genClassInterfaces(sym, forJSClass = true), None, jsNativeLoadSpec,
-          Nil, Nil, None, Nil, Nil, Nil, Nil)(
+          Nil, Nil, None, Nil, Nil, None, Nil, Nil)(
           OptimizerHints.empty)
     }
 
@@ -1225,7 +1233,7 @@ abstract class GenJSCode[G <: Global with Singleton](val global: G)
 
       js.ClassDef(classIdent, originalNameOfClass(sym), ClassKind.Interface,
           None, None, interfaces, None, None, fields = Nil, methods = allMemberDefs,
-          None, Nil, Nil, Nil, Nil)(
+          None, Nil, Nil, genWitTypeDef(sym), Nil, Nil)(
           OptimizerHints.empty)
     }
 
@@ -6901,6 +6909,7 @@ abstract class GenJSCode[G <: Global with Singleton](val global: G)
           jsConstructor = None,
           Nil,
           Nil,
+          None,
           Nil,
           Nil)(
           js.OptimizerHints.empty.withInline(true))

--- a/compiler/src/main/scala/org/scalajs/nscplugin/GenWitInterop.scala
+++ b/compiler/src/main/scala/org/scalajs/nscplugin/GenWitInterop.scala
@@ -21,6 +21,9 @@ import org.scalajs.ir.{
   Trees => js,
   Types => jstpe,
   WasmInterfaceTypes => wit,
+  WitScope,
+  ResourceOwnership,
+  WitTypeDef,
   ClassKind,
   Position
 }
@@ -80,26 +83,32 @@ trait GenWitInterop[G <: Global with Singleton] extends SubComponent {
     }
   }
 
-  def genWitNativeMemberDef(flags: js.MemberFlags, tree: DefDef, moduleName: String,
-      name: js.WitFunctionName): js.WitNativeMemberDef = {
+  def genWitNativeMemberDef(flags: js.MemberFlags, tree: DefDef,
+      scope: WitScope, name: js.WitFunctionName): js.WitNativeMemberDef = {
     implicit val pos = tree.pos
     val sym = tree.symbol
     withNewLocalNameScope {
-      val (paramTypes, resultType) = witMethodSignatureOf(sym)
-      val baseParams = paramTypes.map(toWIT(_))
+      val (paramInfos, resultType) = witMethodSignatureOf(sym)
+      val baseParams = witParamsOf(paramInfos)
       val params = name match {
         case _:js.WitFunctionName.Function |
             _:js.WitFunctionName.ResourceConstructor |
             _:js.WitFunctionName.ResourceStaticMethod => baseParams
         case _:js.WitFunctionName.ResourceMethod |
             _:js.WitFunctionName.ResourceDrop =>
-          wit.ResourceType(encodeClassName(sym.owner)) +: baseParams
+          // WIT resource methods have an implicit self handle, make it explicit in the IR.
+          // methods borrow self, while drop consumes an owned self.
+          val ownership = name match {
+            case _: js.WitFunctionName.ResourceDrop => ResourceOwnership.Own
+            case _                                  => ResourceOwnership.Borrow
+          }
+          wit.ParamType("self", resourceTypeOf(sym.owner, ownership)) +: baseParams
       }
       val witFuncType = wit.FuncType(
         params,
         toResultWIT(resultType)
       )
-      js.WitNativeMemberDef(flags, moduleName, name,
+      js.WitNativeMemberDef(flags, scope, name,
           encodeMethodSym(sym), witFuncType)
     }
   }
@@ -109,20 +118,19 @@ trait GenWitInterop[G <: Global with Singleton] extends SubComponent {
     val sym = tree.symbol
 
     val flags = js.MemberFlags.empty.withNamespace(js.MemberNamespace.PublicStatic)
-    val (paramTypes, resultType) = witMethodSignatureOf(sym)
+    val (paramInfos, resultType) = witMethodSignatureOf(sym)
     for {
       methodAnnot <- sym.getAnnotation(WitResourceStaticMethodAnnotation)
       resourceAnnot <- sym.owner.companionClass.getAnnotation(WitResourceImportAnnotation)
       methodName <- methodAnnot.stringArg(0)
-      moduleName <- resourceAnnot.stringArg(0)
+      scope <- jsInterop.witScopeArg(resourceAnnot, 0)
       resourceName <- resourceAnnot.stringArg(1)
     } yield {
       val name = js.WitFunctionName.ResourceStaticMethod(
           func = methodName, resource = resourceName)
       withNewLocalNameScope {
-        val params = paramTypes.map(toWIT(_))
-        val ft = wit.FuncType(params, toResultWIT(resultType))
-        js.WitNativeMemberDef(flags, moduleName, name, encodeMethodSym(sym), ft)
+        val ft = wit.FuncType(witParamsOf(paramInfos), toResultWIT(resultType))
+        js.WitNativeMemberDef(flags, scope, name, encodeMethodSym(sym), ft)
       }
     }
   }
@@ -132,19 +140,18 @@ trait GenWitInterop[G <: Global with Singleton] extends SubComponent {
     val sym = tree.symbol
 
     val flags = js.MemberFlags.empty.withNamespace(js.MemberNamespace.PublicStatic)
-    val (paramTypes, resultType) = witMethodSignatureOf(sym)
+    val (paramInfos, resultType) = witMethodSignatureOf(sym)
 
     for {
       methodAnnot <- sym.getAnnotation(WitResourceConstructorAnnotation)
       resourceAnnot <- sym.owner.companionClass.getAnnotation(WitResourceImportAnnotation)
-      moduleName <- resourceAnnot.stringArg(0)
+      scope <- jsInterop.witScopeArg(resourceAnnot, 0)
       resourceName <- resourceAnnot.stringArg(1)
     } yield {
       val name = js.WitFunctionName.ResourceConstructor(resourceName)
       withNewLocalNameScope {
-        val params = paramTypes.map(toWIT(_))
-        val ft = wit.FuncType(params, toResultWIT(resultType))
-        js.WitNativeMemberDef(flags, moduleName, name, encodeMethodSym(sym), ft)
+        val ft = wit.FuncType(witParamsOf(paramInfos), toResultWIT(resultType))
+        js.WitNativeMemberDef(flags, scope, name, encodeMethodSym(sym), ft)
       }
     }
   }
@@ -152,13 +159,13 @@ trait GenWitInterop[G <: Global with Singleton] extends SubComponent {
   def genWitExportDef(info: jsInterop.WitExportInfo, sym: Symbol,
       methodDef: js.MethodDef): js.WitExportDef = {
     withNewLocalNameScope {
-      val (paramTypes, resultType) = witMethodSignatureOf(sym)
+      val (paramInfos, resultType) = witMethodSignatureOf(sym)
       val signature = wit.FuncType(
-        paramTypes.map(toWIT(_)),
+        witParamsOf(paramInfos),
         toResultWIT(resultType)
       )
       js.WitExportDef(
-        info.moduleName,
+        info.scope,
         js.WitFunctionName.Function(info.name),
         methodDef,
         signature
@@ -166,13 +173,65 @@ trait GenWitInterop[G <: Global with Singleton] extends SubComponent {
     }
   }
 
-  private def witMethodSignatureOf(sym: Symbol): (List[Type], Type) = {
+  private final class WitParamInfo(val witName: String, val tpe: Type)
+
+  private def witMethodSignatureOf(sym: Symbol): (List[WitParamInfo], Type) = {
     exitingPhase(currentRun.typerPhase) {
       val methodType = sym.tpe
-      val params =
+      val params = {
         if (methodType.paramss.isEmpty) Nil
-        else methodType.paramss.head.map(_.tpe)
+        else {
+          methodType.paramss.head.map { p =>
+            new WitParamInfo(witNameOf(p), p.tpe)
+          }
+        }
+      }
       (params, methodType.resultType)
+    }
+  }
+
+  private def witParamsOf(params: List[WitParamInfo]): List[wit.ParamType] = {
+    params.map { param =>
+      wit.ParamType(param.witName, toWIT(param.tpe))
+    }
+  }
+
+  def genWitTypeDef(sym: Symbol): Option[WitTypeDef] = {
+    val tsym = exitingPhase(currentRun.typerPhase)(sym)
+    if (tsym.hasAnnotation(WitFlagsAnnotation)) {
+      val annot = tsym.getAnnotation(WitFlagsAnnotation).get
+      val className = encodeClassName(tsym)
+      val ((scope, name), names) = witFlagsInfo(tsym, annot)
+      Some(WitTypeDef.Flags(className, scope, name, names))
+    } else if (isWasmWitRecordClass(tsym)) {
+      val className = encodeClassName(tsym)
+      val fields = exitingPhase(currentRun.typerPhase) {
+        tsym.primaryConstructor.paramss.flatten.map { param =>
+          val scalaName = param.name.dropLocal.toString()
+          val witName = witNameOf(param)
+          (scalaName, witName, param.tpe)
+        }
+      }
+      val irFields = fields.map { case (scalaName, witName, fieldType) =>
+        val label = Names.FieldName(className, Names.SimpleFieldName(scalaName))
+        wit.FieldType(label, witName, toWIT(fieldType))
+      }
+      val (scope, name) = witIdOf(tsym, WitRecordAnnotation)
+      Some(WitTypeDef.Record(className, scope, name, irFields))
+    } else if (isWasmWitResourceType(tsym)) {
+      Some(WitTypeDef.Resource(resourceRefOf(tsym)))
+    } else if (tsym.hasAnnotation(WitEnumAnnotation) && tsym.isSealed) {
+      val cases = witEnumCasesOf(tsym)
+      val (scope, name) = witIdOf(tsym, WitEnumAnnotation)
+      val className = encodeClassName(tsym)
+      Some(WitTypeDef.Enum(className, scope, name, cases))
+    } else if (tsym.hasAnnotation(WitVariantAnnotation) && tsym.isSealed) {
+      val cases = witVariantCasesOf(tsym)
+      val (scope, name) = witIdOf(tsym, WitVariantAnnotation)
+      val className = encodeClassName(tsym)
+      Some(WitTypeDef.Variant(className, scope, name, cases))
+    } else {
+      None
     }
   }
 
@@ -195,74 +254,64 @@ trait GenWitInterop[G <: Global with Singleton] extends SubComponent {
     }
   }
 
-  private def toWIT(tpe: Type): wit.ValType = {
-    val widenedTpe = exitingPhase(currentRun.typerPhase)(tpe.dealiasWiden)
+  // Read `Borrow[T]` as `borrow<resource>`
+  private def borrowToWIT(tpe: Type): Option[wit.ValType] = {
+    if (tpe.typeSymbolDirect != WitBorrowAlias) {
+      None
+    } else {
+      val arg = tpe.typeArgs.headOption.getOrElse {
+        throw new AssertionError(s"Borrow without a type argument in $tpe")
+      }
+      toWIT(arg) match {
+        case res: wit.ResourceType =>
+          Some(res.copy(ownership = ResourceOwnership.Borrow))
+        case other =>
+          throw new AssertionError(
+              s"Borrow[_] is not applicable to $other (in $tpe)")
+      }
+    }
+  }
 
-    unsigned2WIT.get(widenedTpe.typeSymbolDirect).orElse {
-      toWITMaybeArray(widenedTpe)
+  private def toWIT(tpe: Type): wit.ValType = {
+    val directTpe = exitingPhase(currentRun.typerPhase)(tpe)
+    val dealiasedTpe = exitingPhase(currentRun.typerPhase)(directTpe.dealias)
+
+    unsigned2WIT.get(directTpe.typeSymbolDirect).orElse {
+      borrowToWIT(directTpe)
     }.orElse {
-      primitiveIRWIT.get(toIRType(widenedTpe))
+      toWITMaybeArray(dealiasedTpe)
+    }.orElse {
+      primitiveIRWIT.get(toIRType(dealiasedTpe))
     }.getOrElse {
-      widenedTpe.typeSymbol match {
+      dealiasedTpe.typeSymbol match {
         case tsym if isWasmComponentTupleClass(tsym) =>
-          wit.TupleType(widenedTpe.baseType(tsym).typeArgs.map(toWIT(_)))
+          wit.TupleType(dealiasedTpe.baseType(tsym).typeArgs.map(toWIT(_)))
 
         case tsym if tsym.hasAnnotation(WitFlagsAnnotation) =>
-          // Read numFlags from annotation parameter
-          val numFlags = tsym.getAnnotation(WitFlagsAnnotation)
-            .flatMap(_.intArg(0))
-            .getOrElse {
-              throw new AssertionError(s"@WitFlags on $tsym missing numFlags parameter")
-            }
           val className = encodeClassName(tsym)
-          wit.FlagsType(className, numFlags)
+          wit.FlagsTypeRef(className)
 
         case tsym if isWasmWitRecordClass(tsym) =>
-          val className = encodeClassName(tsym)
-          val fields = exitingPhase(currentRun.typerPhase) {
-            tsym.primaryConstructor.paramss.flatten.map { param =>
-              (param.name.dropLocal.toString(), param.tpe)
-            }
-          }.map { case (fieldName, fieldType) =>
-            val label = Names.FieldName(className, Names.SimpleFieldName(fieldName))
-            wit.FieldType(label, toWIT(fieldType))
-          }
-          wit.RecordType(className, fields)
+          wit.RecordTypeRef(encodeClassName(tsym))
 
         case tsym if isWasmWitResourceType(tsym) =>
-          wit.ResourceType(encodeClassName(tsym))
+          // A bare WIT resource type is shorthand for `own<resource>`.
+          resourceTypeOf(tsym, ResourceOwnership.Own)
 
         case tsym if tsym.isSubClass(ComponentResultClass) && tsym.isSealed =>
-          val List(ok, err) = widenedTpe.baseType(ComponentResultClass).typeArgs
+          val List(ok, err) = dealiasedTpe.baseType(ComponentResultClass).typeArgs
           wit.ResultType(toResultWIT(ok), toResultWIT(err))
 
         case tsym if tsym.fullName == "java.util.Optional" =>
-          val List(t) = widenedTpe.baseType(tsym).typeArgs
+          val List(t) = dealiasedTpe.baseType(tsym).typeArgs
           wit.OptionType(toWIT(t))
 
+        case tsym if tsym.hasAnnotation(WitEnumAnnotation) && tsym.isSealed =>
+          val _ = witEnumCasesOf(tsym) // validates that there are no payload cases
+          wit.EnumTypeRef(encodeClassName(tsym))
+
         case tsym if tsym.hasAnnotation(WitVariantAnnotation) && tsym.isSealed =>
-          // Sort by declaration order, we need to know which index
-          // corresponds to which type.
-          // Make sure code generator declare children by index order.
-          // assert(tsym.isClass)
-          val cases = tsym.sealedChildren.toList.sortBy(_.pos.line) map { child =>
-            // assert(child.isFinal)
-            // assert(child.isClass)
-            val valueType = witVariantValueTypeOf(child)
-            val caseTyp = if (toIRType(valueType) == jstpe.VoidType) {
-              None
-            } else {
-              Some(toWIT(valueType))
-            }
-            wit.CaseType(
-              encodeClassName(child),
-              caseTyp
-            )
-          }
-          wit.VariantType(
-            encodeClassName(tsym),
-            cases
-          )
+          wit.VariantTypeRef(encodeClassName(tsym))
         case _ => throw new AssertionError(s"invalid tpe: $tpe")
       }
     }
@@ -281,20 +330,88 @@ trait GenWitInterop[G <: Global with Singleton] extends SubComponent {
     }
   }
 
-  private lazy val ScalaJSWitUnsignedPackageModule =
-    rootMirror.getPackageObject("scala.scalajs.wit.unsigned")
+  private def resourceTypeOf(sym: Symbol, ownership: ResourceOwnership): wit.ResourceType =
+    wit.ResourceType(encodeClassName(sym), ownership)
 
-  private lazy val WitUnsigned_UByte =
-    getTypeMember(ScalaJSWitUnsignedPackageModule, newTermName("UByte"))
+  private def resourceRefOf(sym: Symbol): wit.ResourceRef = {
+    val (scope, name) = sym.getAnnotation(WitResourceImportAnnotation).flatMap { annotation =>
+      for {
+        scope <- jsInterop.witScopeArg(annotation, 0)
+        name <- annotation.stringArg(1)
+      } yield (scope, name)
+    }.getOrElse {
+      throw new AssertionError(
+          s"@WitResourceImport on $sym requires a literal WitScope and a literal name")
+    }
+    wit.ResourceRef(encodeClassName(sym), scope, name)
+  }
 
-  private lazy val WitUnsigned_UShort =
-    getTypeMember(ScalaJSWitUnsignedPackageModule, newTermName("UShort"))
+  private def witIdOf(tsym: Symbol, annotation: Symbol): (WitScope, String) = {
+    val annotationName = "@" + annotation.name
+    tsym.getAnnotation(annotation).flatMap { annot =>
+      for {
+        scope <- jsInterop.witScopeArg(annot, 0)
+        name <- annot.stringArg(1)
+      } yield (scope, name)
+    }.getOrElse {
+      throw new AssertionError(
+          s"$annotationName on $tsym requires a literal WitScope and a literal name")
+    }
+  }
 
-  private lazy val WitUnsigned_UInt =
-    getTypeMember(ScalaJSWitUnsignedPackageModule, newTermName("UInt"))
+  private def witEnumCasesOf(tsym: Symbol): List[wit.CaseType] = {
+    // Sort by declaration order, we need to know which index corresponds to which type.
+    tsym.sealedChildren.toList.sortBy(_.pos.line) map { child =>
+      if (!child.isModuleClass) {
+        throw new AssertionError(
+            s"@WitEnum on $tsym is not valid: it has payload cases")
+      }
+      wit.CaseType(
+        encodeClassName(child),
+        witNameOf(child),
+        None
+      )
+    }
+  }
 
-  private lazy val WitUnsigned_ULong =
-    getTypeMember(ScalaJSWitUnsignedPackageModule, newTermName("ULong"))
+  private def witVariantCasesOf(tsym: Symbol): List[wit.CaseType] = {
+    // Sort by declaration order, we need to know which index corresponds to which type.
+    tsym.sealedChildren.toList.sortBy(_.pos.line) map { child =>
+      val valueType = witVariantValueTypeOf(child)
+      val caseTyp =
+        if (toIRType(valueType) == jstpe.VoidType) None
+        else Some(toWIT(valueType))
+      wit.CaseType(
+        encodeClassName(child),
+        witNameOf(child),
+        caseTyp
+      )
+    }
+  }
+
+  private def witNameOf(sym: Symbol): String = {
+    sym.getAnnotation(WitNameAnnotation).flatMap(_.stringArg(0)).getOrElse {
+      throw new AssertionError(s"missing literal @WitName on $sym")
+    }
+  }
+
+  private def witFlagsInfo(tsym: Symbol,
+      annot: AnnotationInfo): ((WitScope, String), List[String]) = {
+    val id = {
+      for {
+        scope <- jsInterop.witScopeArg(annot, 0)
+        name <- annot.stringArg(1)
+      } yield (scope, name)
+    }.getOrElse {
+      throw new AssertionError(
+          s"@WitFlags on $tsym requires a literal WitScope and a literal name")
+    }
+    val names = jsInterop.literalStringArrayArg(annot, 2).getOrElse {
+      throw new AssertionError(
+          s"@WitFlags on $tsym requires a literal Array of literal strings")
+    }
+    (id, names)
+  }
 
   private lazy val unsigned2WIT: Map[Symbol, wit.ValType] = Map(
     WitUnsigned_UByte -> wit.U8Type,

--- a/compiler/src/main/scala/org/scalajs/nscplugin/JSDefinitions.scala
+++ b/compiler/src/main/scala/org/scalajs/nscplugin/JSDefinitions.scala
@@ -83,6 +83,15 @@ trait JSDefinitions {
     lazy val WitRecordAnnotation = getRequiredClass("scala.scalajs.wit.annotation.WitRecord")
     lazy val WitVariantAnnotation = getRequiredClass("scala.scalajs.wit.annotation.WitVariant")
     lazy val WitFlagsAnnotation  = getRequiredClass("scala.scalajs.wit.annotation.WitFlags")
+    lazy val WitEnumAnnotation   = getRequiredClass("scala.scalajs.wit.annotation.WitEnum")
+    lazy val WitNameAnnotation   = getRequiredClass("scala.scalajs.wit.annotation.WitName")
+
+    lazy val WitBorrowAlias = getTypeMember(ScalaJSWitPackageModule, newTermName("Borrow"))
+    lazy val WitScopeModule = getRequiredModule("scala.scalajs.wit.annotation.WitScope")
+    lazy val WitScope_apply = getMemberMethod(WitScopeModule, nme.apply)
+    lazy val WitScope_unversioned = getMemberMethod(WitScopeModule, newTermName("unversioned"))
+    lazy val WitScope_root = getMemberMethod(WitScopeModule, newTermName("root"))
+    lazy val WitScope_inline = getMemberMethod(WitScopeModule, newTermName("inline"))
     lazy val WitImplementationAnnotation = getRequiredClass("scala.scalajs.wit.annotation.WitImplementation")
     lazy val WitExportInterfaceAnnotation = getRequiredClass("scala.scalajs.wit.annotation.WitExportInterface")
 

--- a/compiler/src/main/scala/org/scalajs/nscplugin/JSGlobalAddons.scala
+++ b/compiler/src/main/scala/org/scalajs/nscplugin/JSGlobalAddons.scala
@@ -18,6 +18,8 @@ import scala.collection.mutable
 
 import org.scalajs.ir.Trees.JSNativeLoadSpec
 import org.scalajs.ir.{Trees => js}
+import org.scalajs.ir.WitScope
+import org.scalajs.ir.{WasmInterfaceTypes => wit}
 
 /** Additions to Global meaningful for the JavaScript backend
  *
@@ -119,7 +121,7 @@ trait JSGlobalAddons extends JSDefinitions with CompatComponent {
         val pos: Position)
         extends ExportInfo
 
-    case class WitExportInfo(moduleName: String, name: String)(
+    case class WitExportInfo(scope: WitScope, name: String)(
         val pos: Position)
         extends ExportInfo
 
@@ -285,6 +287,57 @@ trait JSGlobalAddons extends JSDefinitions with CompatComponent {
 
     def witExportOf(sym: Symbol): Option[WitExportInfo] =
       witExports.get(sym)
+
+    def witScopeArg(annot: AnnotationInfo, index: Int): Option[WitScope] = {
+      def literalString(tree: Tree): Option[String] = tree match {
+        case Literal(Constant(s: String)) => Some(s)
+        case _                            => None
+      }
+      annot.args.lift(index).flatMap {
+        case Apply(fun, args) if fun.symbol == WitScope_apply =>
+          args.map(literalString) match {
+            case List(Some(namespace), Some(packageName), Some(name), Some(version)) =>
+              Some(WitScope.Interface(namespace, packageName, name, Some(version)))
+            case _ =>
+              None
+          }
+        case Apply(fun, args) if fun.symbol == WitScope_unversioned =>
+          args.map(literalString) match {
+            case List(Some(namespace), Some(packageName), Some(name)) =>
+              Some(WitScope.Interface(namespace, packageName, name, None))
+            case _ =>
+              None
+          }
+        case Apply(fun, List(arg)) if fun.symbol == WitScope_inline =>
+          literalString(arg).map(WitScope.Inline(_))
+        case tree if tree.symbol == WitScope_root =>
+          Some(WitScope.Root)
+        case _ =>
+          None
+      }
+    }
+
+    def literalStringArrayArg(annot: AnnotationInfo,
+        index: Int): Option[List[String]] = {
+      def strings(elems: List[Tree]): Option[List[String]] = {
+        val values = elems.map {
+          case Literal(Constant(s: String)) => Some(s)
+          case _                            => None
+        }
+        if (values.forall(_.isDefined)) Some(values.map(_.get))
+        else None
+      }
+
+      annot.args.lift(index).flatMap {
+        case Apply(Apply(fun, elems), _)
+            if fun.symbol == ArrayModule_genericApply =>
+          strings(elems)
+        case Apply(fun, elems) if fun.symbol == ArrayModule_genericApply =>
+          strings(elems)
+        case _ =>
+          None
+      }
+    }
 
     def registerWitExport(sym: Symbol, info: WitExportInfo): Unit = {
       assert(!witExports.contains(sym), s"symbol exported twice: $sym")

--- a/compiler/src/main/scala/org/scalajs/nscplugin/PrepJSExports.scala
+++ b/compiler/src/main/scala/org/scalajs/nscplugin/PrepJSExports.scala
@@ -12,6 +12,8 @@
 
 package org.scalajs.nscplugin
 
+import org.scalajs.ir.WitScope
+
 import scala.collection.mutable
 
 import scala.tools.nsc.Global
@@ -44,7 +46,7 @@ trait PrepJSExports[G <: Global with Singleton] { this: PrepJSInterop[G] =>
     /** Export at the top-level. */
     case class TopLevel(moduleID: String) extends ExportDestination
 
-    case class WasmComponent(functionName: String) extends ExportDestination
+    case class WasmComponent(scope: WitScope) extends ExportDestination
 
     /** Export as a static member of the companion class. */
     case object Static extends ExportDestination
@@ -125,8 +127,8 @@ trait PrepJSExports[G <: Global with Singleton] { this: PrepJSInterop[G] =>
       jsInterop.registerStaticExports(sym, static)
 
     val wasmComponent = exports.collect {
-      case info @ ExportInfo(moduleName, ExportDestination.WasmComponent(name)) =>
-        jsInterop.WitExportInfo(moduleName, name)(info.pos)
+      case info @ ExportInfo(name, ExportDestination.WasmComponent(scope)) =>
+        jsInterop.WitExportInfo(scope, name)(info.pos)
     }
 
     // TODO: Remove this trait no-op once wit-bindgen stops generating export
@@ -203,7 +205,13 @@ trait PrepJSExports[G <: Global with Singleton] { this: PrepJSInterop[G] =>
           "Found a wasm component export without an explicit name at " + annot.pos)
 
       val name = {
-        if (hasExplicitName) {
+        if (isWitExport) {
+          annot.stringArg(1).getOrElse {
+            reporter.error(annot.args(1).pos,
+                s"The name argument to ${annot.symbol.name} must be a literal string")
+            "dummy"
+          }
+        } else if (hasExplicitName) {
           annot.stringArg(0).getOrElse {
             reporter.error(annot.args(0).pos,
                 s"The argument to ${annot.symbol.name} must be a literal string")
@@ -237,12 +245,13 @@ trait PrepJSExports[G <: Global with Singleton] { this: PrepJSInterop[G] =>
 
           ExportDestination.TopLevel(moduleID)
         } else if (isWitExport) {
-          val functionName = annot.stringArg(1).getOrElse {
-            reporter.error(annot.args(1).pos,
-                "functionName must be a literal string")
-            "" // dummy
+          val scope = jsInterop.witScopeArg(annot, 0).getOrElse {
+            reporter.error(annot.args(0).pos,
+                "The scope argument to @WitExport must be a literal " +
+                "WitScope expression")
+            WitScope.Root // dummy
           }
-          ExportDestination.WasmComponent(functionName)
+          ExportDestination.WasmComponent(scope)
         } else if (isStaticExport) {
           ExportDestination.Static
         } else {

--- a/compiler/src/main/scala/org/scalajs/nscplugin/PrepJSInterop.scala
+++ b/compiler/src/main/scala/org/scalajs/nscplugin/PrepJSInterop.scala
@@ -169,7 +169,7 @@ abstract class PrepJSInterop[G <: Global with Singleton](val global: G)
 
       checkJSCallingConventionAnnots(sym)
 
-      if (sym.hasAnnotation(WitVariantAnnotation))
+      if (sym.hasAnnotation(WitVariantAnnotation) || sym.hasAnnotation(WitEnumAnnotation))
         checkWitVariantTrait(tree.pos, sym)
       else if (sym.hasAnnotation(WitRecordAnnotation))
         checkWitRecord(sym)
@@ -843,7 +843,10 @@ abstract class PrepJSInterop[G <: Global with Singleton](val global: G)
           // Validate parameter types and check for repeated/default parameters
           val paramTypes = if (sym.tpe.paramss.isEmpty) Nil else sym.tpe.paramss.head
           for (param <- paramTypes) {
-            if (isScalaRepeatedParamType(param.tpe)) {
+            if (!hasWitName(param)) {
+              reporter.error(param.pos,
+                  s"Parameter '${param.name}' must have a @WitName annotation")
+            } else if (isScalaRepeatedParamType(param.tpe)) {
               reporter.error(pos,
                   s"$annot methods may not have repeated parameters")
             } else if (param.hasFlag(reflect.internal.Flags.DEFAULTPARAM)) {
@@ -944,14 +947,17 @@ abstract class PrepJSInterop[G <: Global with Singleton](val global: G)
 
           if (hasResourceMethodAnnotation) {
             val methodType = member.tpe
-            val paramTypes =
-              if (methodType.paramss.isEmpty) Nil else methodType.paramss.head.map(_.tpe)
+            val params =
+              if (methodType.paramss.isEmpty) Nil else methodType.paramss.head
             val returnType = methodType.resultType
 
-            paramTypes.foreach { paramType =>
-              if (!isComponentModelCompatible(paramType)) {
+            params.foreach { param =>
+              if (!hasWitName(param)) {
+                reporter.error(param.pos,
+                    s"Parameter '${param.name}' in method '${member.name}' must have a @WitName annotation")
+              } else if (!isComponentModelCompatible(param.tpe)) {
                 reporter.error(member.pos,
-                    s"Parameter type '${paramType}' in method '${member.name}' is not compatible with Component Model")
+                    s"Parameter type '${param.tpe}' in method '${member.name}' is not compatible with Component Model")
               }
             }
 
@@ -993,6 +999,15 @@ abstract class PrepJSInterop[G <: Global with Singleton](val global: G)
                   "@WitResourceConstructor can only be used on apply method")
             }
 
+            val params =
+              if (member.tpe.paramss.isEmpty) Nil else member.tpe.paramss.head
+            params.foreach { param =>
+              if (!hasWitName(param)) {
+                reporter.error(param.pos,
+                    s"Parameter '${param.name}' in method '${member.name}' must have a @WitName annotation")
+              }
+            }
+
             // Public methods in companion must have @WitResourceConstructor or @WitResourceStaticMethod
             if (!hasConstructorAnnot &&
                 !hasStaticMethodAnnot &&
@@ -1027,6 +1042,11 @@ abstract class PrepJSInterop[G <: Global with Singleton](val global: G)
     }
 
     private def validateWitVariantCase(caseSym: Symbol): Unit = {
+      if (!hasWitName(caseSym)) {
+        reporter.error(caseSym.pos,
+            s"Component variant case '${caseSym.name}' must have a @WitName annotation")
+      }
+
       if (caseSym.isModuleClass) {
         // Regular object (enum case without payload)
       } else if (caseSym.isClass && caseSym.isFinal && !caseSym.isTrait) {
@@ -1096,6 +1116,7 @@ abstract class PrepJSInterop[G <: Global with Singleton](val global: G)
         dealiased.typeArgs.forall(isComponentModelCompatible)
       } else if (sym.hasAnnotation(WitRecordAnnotation) ||
           sym.hasAnnotation(WitVariantAnnotation) ||
+          sym.hasAnnotation(WitEnumAnnotation) ||
           sym.hasAnnotation(WitFlagsAnnotation) ||
           sym.hasAnnotation(WitResourceImportAnnotation)) {
         true
@@ -1117,13 +1138,19 @@ abstract class PrepJSInterop[G <: Global with Singleton](val global: G)
         val params = primaryCtor.paramss.flatten
         for (param <- params) {
           val fieldType = param.tpe
-          if (!isComponentModelCompatible(fieldType)) {
+          if (!hasWitName(param)) {
+            reporter.error(param.pos,
+                s"Field '${param.name}' must have a @WitName annotation")
+          } else if (!isComponentModelCompatible(fieldType)) {
             reporter.error(param.pos,
                 s"Field '${param.name}' has type '${fieldType}' which is not compatible with Component Model")
           }
         }
       }
     }
+
+    private def hasWitName(sym: Symbol): Boolean =
+      sym.hasAnnotation(WitNameAnnotation)
 
     private def checkWitFlags(sym: Symbol): Unit = {
       if (!sym.isClass || sym.isTrait || sym.isModuleClass) {
@@ -1154,14 +1181,24 @@ abstract class PrepJSInterop[G <: Global with Singleton](val global: G)
               s"@WitFlags class parameter must be named 'value', found '${param.name.decoded}'")
         }
 
-        sym.getAnnotation(WitFlagsAnnotation).flatMap(_.intArg(0)) match {
-          case Some(numFlags) if numFlags > 0 =>
-          case Some(numFlags)                 =>
-            reporter.error(sym.pos,
-                s"@WitFlags numFlags parameter must be positive, found $numFlags")
+        sym.getAnnotation(WitFlagsAnnotation) match {
+          case Some(annot) =>
+            if (jsInterop.witScopeArg(annot, 0).isEmpty) {
+              reporter.error(sym.pos,
+                  "The scope argument to @WitFlags must be a literal WitScope expression")
+            }
+            if (annot.stringArg(1).isEmpty) {
+              reporter.error(sym.pos,
+                  "The name argument to @WitFlags must be a literal string")
+            }
+            if (jsInterop.literalStringArrayArg(annot, 2).isEmpty) {
+              reporter.error(annot.args.lift(2).fold(sym.pos)(_.pos),
+                  "The flagNames argument to @WitFlags must be a literal " +
+                  "Array(...) of literal strings")
+            }
           case None =>
             reporter.error(sym.pos,
-                "@WitFlags annotation must specify the number of flags as a parameter")
+                "@WitFlags annotation not found")
         }
       }
     }

--- a/compiler/src/test/scala/org/scalajs/nscplugin/test/WitInteropTest.scala
+++ b/compiler/src/test/scala/org/scalajs/nscplugin/test/WitInteropTest.scala
@@ -27,7 +27,7 @@ class WitInteropTest extends DirectTest with TestHelpers {
 
   @Test def resourceImportMustBeOnFinalClass: Unit = {
     """
-    @WitResourceImport("test:module", "resource")
+    @WitResourceImport(WitScope.unversioned("test", "test", "module"), "resource")
     class MyResource
     """ hasErrors
     """
@@ -37,7 +37,7 @@ class WitInteropTest extends DirectTest with TestHelpers {
     """
 
     """
-    @WitResourceImport("test:module", "resource")
+    @WitResourceImport(WitScope.unversioned("test", "test", "module"), "resource")
     object MyResource
     """ hasErrors
     """
@@ -47,7 +47,7 @@ class WitInteropTest extends DirectTest with TestHelpers {
     """
 
     """
-    @WitResourceImport("test:module", "resource")
+    @WitResourceImport(WitScope.unversioned("test", "test", "module"), "resource")
     trait MyResource
     """ hasErrors
     """
@@ -59,7 +59,7 @@ class WitInteropTest extends DirectTest with TestHelpers {
 
   @Test def resourceImportCannotBeSealed: Unit = {
     """
-    @WitResourceImport("test:module", "resource")
+    @WitResourceImport(WitScope.unversioned("test", "test", "module"), "resource")
     sealed final class MyResource private () extends Object
     """ hasErrors
     """
@@ -71,7 +71,7 @@ class WitInteropTest extends DirectTest with TestHelpers {
 
   @Test def resourceMethodsMustHaveAnnotation: Unit = {
     """
-    @WitResourceImport("test:module", "resource")
+    @WitResourceImport(WitScope.unversioned("test", "test", "module"), "resource")
     final class MyResource private () extends Object {
       def doSomething(): Unit = ???
     }
@@ -83,7 +83,7 @@ class WitInteropTest extends DirectTest with TestHelpers {
     """
 
     """
-    @WitResourceImport("test:module", "resource")
+    @WitResourceImport(WitScope.unversioned("test", "test", "module"), "resource")
     final class MyResource private () extends Object {
       def method1(): Unit = ???
       def method2(x: Int): String = ???
@@ -99,7 +99,7 @@ class WitInteropTest extends DirectTest with TestHelpers {
     """
 
     """
-    @WitResourceImport("test:module", "resource")
+    @WitResourceImport(WitScope.unversioned("test", "test", "module"), "resource")
     final class MyResource private () extends Object {
       @WitResourceMethod("annotated")
       def annotated(): Unit = wm.native
@@ -118,15 +118,15 @@ class WitInteropTest extends DirectTest with TestHelpers {
     """
     class NotCompatible
 
-    @WitResourceImport("test:module", "resource")
+    @WitResourceImport(WitScope.unversioned("test", "test", "module"), "resource")
     final class MyResource private () extends Object {
       @WitResourceMethod("invalid")
-      def invalidMethod(x: NotCompatible): Unit = wm.native
+      def invalidMethod(@WitName("x") x: NotCompatible): Unit = wm.native
     }
     """ hasErrors
     """
       |newSource1.scala:11: error: Parameter type 'NotCompatible' in method 'invalidMethod' is not compatible with Component Model
-      |      def invalidMethod(x: NotCompatible): Unit = wm.native
+      |      def invalidMethod(@WitName("x") x: NotCompatible): Unit = wm.native
       |          ^
     """
   }
@@ -135,7 +135,7 @@ class WitInteropTest extends DirectTest with TestHelpers {
     """
     class NotCompatible
 
-    @WitResourceImport("test:module", "resource")
+    @WitResourceImport(WitScope.unversioned("test", "test", "module"), "resource")
     final class MyResource private () extends Object {
       @WitResourceMethod("invalid")
       def invalidMethod(): NotCompatible = wm.native
@@ -150,7 +150,7 @@ class WitInteropTest extends DirectTest with TestHelpers {
 
   @Test def resourceCompanionObjectMethodsMustHaveAnnotation: Unit = {
     """
-    @WitResourceImport("test:module", "resource")
+    @WitResourceImport(WitScope.unversioned("test", "test", "module"), "resource")
     final class MyResource private () extends Object {
       @WitResourceMethod("do-something")
       def doSomething(): Unit = wm.native
@@ -168,20 +168,20 @@ class WitInteropTest extends DirectTest with TestHelpers {
 
   @Test def resourceDropMustHaveNoParametersAndReturnUnit: Unit = {
     """
-    @WitResourceImport("test:module", "resource")
+    @WitResourceImport(WitScope.unversioned("test", "test", "module"), "resource")
     final class MyResource private () extends Object {
       @WitResourceDrop
-      def close(x: Int): Unit = wm.native
+      def close(@WitName("x") x: Int): Unit = wm.native
     }
     """ hasErrors
     """
       |newSource1.scala:9: error: @WitResourceDrop method must take no parameters
-      |      def close(x: Int): Unit = wm.native
+      |      def close(@WitName("x") x: Int): Unit = wm.native
       |          ^
     """
 
     """
-    @WitResourceImport("test:module", "resource")
+    @WitResourceImport(WitScope.unversioned("test", "test", "module"), "resource")
     final class MyResource private () extends Object {
       @WitResourceDrop
       def close(): Int = wm.native
@@ -196,7 +196,7 @@ class WitInteropTest extends DirectTest with TestHelpers {
 
   @Test def resourceCanHaveAtMostOneDropMethod: Unit = {
     """
-    @WitResourceImport("test:module", "resource")
+    @WitResourceImport(WitScope.unversioned("test", "test", "module"), "resource")
     final class MyResource private () extends Object {
       @WitResourceDrop
       def close(): Unit = wm.native
@@ -214,7 +214,7 @@ class WitInteropTest extends DirectTest with TestHelpers {
 
   @Test def resourceConstructorOnlyInCompanionObject: Unit = {
     """
-    @WitResourceImport("test:module", "resource")
+    @WitResourceImport(WitScope.unversioned("test", "test", "module"), "resource")
     final class MyResource private () extends Object {
       @WitResourceConstructor
       def create(): MyResource = wm.native
@@ -229,7 +229,7 @@ class WitInteropTest extends DirectTest with TestHelpers {
 
   @Test def resourceStaticMethodOnlyInCompanionObject: Unit = {
     """
-    @WitResourceImport("test:module", "resource")
+    @WitResourceImport(WitScope.unversioned("test", "test", "module"), "resource")
     final class MyResource private () extends Object {
       @WitResourceStaticMethod("factory")
       def factory(): MyResource = wm.native
@@ -244,7 +244,7 @@ class WitInteropTest extends DirectTest with TestHelpers {
 
   @Test def resourceConstructorMustBeOnApply: Unit = {
     """
-    @WitResourceImport("test:module", "resource")
+    @WitResourceImport(WitScope.unversioned("test", "test", "module"), "resource")
     final class MyResource private () extends Object
     object MyResource {
       @WitResourceConstructor
@@ -312,23 +312,23 @@ class WitInteropTest extends DirectTest with TestHelpers {
 
   @Test def resourceValidExample: Unit = {
     """
-    @WitResourceImport("test:io/streams", "input-stream")
+    @WitResourceImport(WitScope.unversioned("test", "io", "streams"), "input-stream")
     final class InputStream private () extends Object {
       @WitResourceMethod("read")
-      def read(len: ULong): wm.Result[Array[UByte], String] = wm.native
+      def read(@WitName("len") len: ULong): wm.Result[Array[UByte], String] = wm.native
 
       @WitResourceMethod("blocking-read")
-      def blockingRead(len: ULong): wm.Result[Array[UByte], String] = wm.native
+      def blockingRead(@WitName("len") len: ULong): wm.Result[Array[UByte], String] = wm.native
 
       @WitResourceDrop
       def close(): Unit = wm.native
     }
     object InputStream {}
 
-    @WitResourceImport("test:io/streams", "output-stream")
+    @WitResourceImport(WitScope.unversioned("test", "io", "streams"), "output-stream")
     final class OutputStream private () extends Object {
       @WitResourceMethod("write")
-      def write(data: Array[UByte]): wm.Result[Unit, String] = wm.native
+      def write(@WitName("data") data: Array[UByte]): wm.Result[Unit, String] = wm.native
 
       @WitResourceMethod("flush")
       def flush(): wm.Result[Unit, String] = wm.native
@@ -341,7 +341,7 @@ class WitInteropTest extends DirectTest with TestHelpers {
       def apply(): OutputStream = wm.native
 
       @WitResourceConstructor
-      def apply(x: Int): OutputStream = wm.native
+      def apply(@WitName("x") x: Int): OutputStream = wm.native
     }
     """.hasNoWarns()
   }
@@ -350,7 +350,7 @@ class WitInteropTest extends DirectTest with TestHelpers {
 
   @Test def variantMustBeSealed: Unit = {
     """
-    @WitVariant
+    @WitVariant(WitScope.root, "my-variant")
     trait NotSealed
     """ hasErrors
     """
@@ -362,7 +362,7 @@ class WitInteropTest extends DirectTest with TestHelpers {
 
   @Test def variantMustHaveAtLeastOneCase: Unit = {
     """
-    @WitVariant
+    @WitVariant(WitScope.root, "my-variant")
     sealed trait Empty
     """ hasErrors
     """
@@ -374,14 +374,15 @@ class WitInteropTest extends DirectTest with TestHelpers {
 
   @Test def variantCasesMustBeCaseClassOrObject: Unit = {
     """
-    @WitVariant
+    @WitVariant(WitScope.root, "my-variant")
     sealed trait MyVariant
     object MyVariant {
+      @WitName("not-a-case")
       class NotACase extends MyVariant
     }
     """ hasErrors
     """
-      |newSource1.scala:9: error: Component variant case 'NotACase' must be a final class or object
+      |newSource1.scala:10: error: Component variant case 'NotACase' must be a final class or object
       |      class NotACase extends MyVariant
       |            ^
     """
@@ -389,14 +390,15 @@ class WitInteropTest extends DirectTest with TestHelpers {
 
   @Test def variantCaseClassMustHaveAtMostOneField: Unit = {
     """
-    @WitVariant
+    @WitVariant(WitScope.root, "my-variant")
     sealed trait MyVariant
     object MyVariant {
+      @WitName("too-many-fields")
       final case class TooManyFields(x: Int, y: String) extends MyVariant
     }
     """ hasErrors
     """
-      |newSource1.scala:9: error: Component variant case 'TooManyFields' must have exactly one field, found 2.
+      |newSource1.scala:10: error: Component variant case 'TooManyFields' must have exactly one field, found 2.
       |      final case class TooManyFields(x: Int, y: String) extends MyVariant
       |                       ^
     """
@@ -404,14 +406,15 @@ class WitInteropTest extends DirectTest with TestHelpers {
 
   @Test def variantCaseFieldMustBeNamedValue: Unit = {
     """
-    @WitVariant
+    @WitVariant(WitScope.root, "my-variant")
     sealed trait MyVariant
     object MyVariant {
+      @WitName("wrong-name")
       final case class WrongName(data: Int) extends MyVariant
     }
     """ hasErrors
     """
-      |newSource1.scala:9: error: Component variant case 'WrongName' field must be named 'value', found 'data'.
+      |newSource1.scala:10: error: Component variant case 'WrongName' field must be named 'value', found 'data'.
       |      final case class WrongName(data: Int) extends MyVariant
       |                                 ^
     """
@@ -421,14 +424,15 @@ class WitInteropTest extends DirectTest with TestHelpers {
     """
     class NotCompatible
 
-    @WitVariant
+    @WitVariant(WitScope.root, "my-variant")
     sealed trait MyVariant
     object MyVariant {
+      @WitName("invalid-type")
       final case class InvalidType(value: NotCompatible) extends MyVariant
     }
     """ hasErrors
     """
-      |newSource1.scala:11: error: Field 'value' has type 'NotCompatible' which is not compatible with Component Model.
+      |newSource1.scala:12: error: Field 'value' has type 'NotCompatible' which is not compatible with Component Model.
       |      final case class InvalidType(value: NotCompatible) extends MyVariant
       |                                   ^
     """
@@ -436,21 +440,39 @@ class WitInteropTest extends DirectTest with TestHelpers {
 
   @Test def variantValidCaseClassWithValue: Unit = {
     """
-    @WitVariant
+    @WitVariant(WitScope.root, "my-variant")
     sealed trait MyVariant
     object MyVariant {
+      @WitName("int-value")
       final case class IntValue(value: Int) extends MyVariant
+      @WitName("string-value")
       final case class StringValue(value: String) extends MyVariant
+      @WitName("none")
       final case object None extends MyVariant
     }
     """.hasNoWarns()
+  }
+
+  @Test def variantCasesMustHaveWitName: Unit = {
+    """
+    @WitVariant(WitScope.root, "my-variant")
+    sealed trait MyVariant
+    object MyVariant {
+      final case class MissingName(value: Int) extends MyVariant
+    }
+    """ hasErrors
+    """
+      |newSource1.scala:9: error: Component variant case 'MissingName' must have a @WitName annotation
+      |      final case class MissingName(value: Int) extends MyVariant
+      |                       ^
+    """
   }
 
   // --- Component Record Tests ---
 
   @Test def recordMustBeCaseClass: Unit = {
     """
-    @WitRecord
+    @WitRecord(WitScope.root, "record")
     class NotCaseClass(x: Int, y: Int)
     """ hasErrors
     """
@@ -460,7 +482,7 @@ class WitInteropTest extends DirectTest with TestHelpers {
     """
 
     """
-    @WitRecord
+    @WitRecord(WitScope.root, "record")
     trait NotCaseClass
     """ hasErrors
     """
@@ -470,7 +492,7 @@ class WitInteropTest extends DirectTest with TestHelpers {
     """
 
     """
-    @WitRecord
+    @WitRecord(WitScope.root, "record")
     object NotCaseClass
     """ hasErrors
     """
@@ -482,7 +504,7 @@ class WitInteropTest extends DirectTest with TestHelpers {
 
   @Test def recordMustBeFinal: Unit = {
     """
-    @WitRecord
+    @WitRecord(WitScope.root, "record")
     case class NotFinal(x: Int, y: Int)
     """ hasErrors
     """
@@ -496,49 +518,61 @@ class WitInteropTest extends DirectTest with TestHelpers {
     """
     class NotCompatible
 
-    @WitRecord
-    final case class InvalidRecord(x: Int, y: NotCompatible)
+    @WitRecord(WitScope.root, "record")
+    final case class InvalidRecord(@WitName("x") x: Int, @WitName("y") y: NotCompatible)
     """ hasErrors
     """
       |newSource1.scala:9: error: Field 'y' has type 'NotCompatible' which is not compatible with Component Model
-      |    final case class InvalidRecord(x: Int, y: NotCompatible)
-      |                                           ^
+      |    final case class InvalidRecord(@WitName("x") x: Int, @WitName("y") y: NotCompatible)
+      |                                                                       ^
     """
 
     """
     class NotCompatible
 
-    @WitRecord
-    final case class MultipleInvalid(a: NotCompatible, b: String, c: NotCompatible)
+    @WitRecord(WitScope.root, "record")
+    final case class MultipleInvalid(@WitName("a") a: NotCompatible, @WitName("b") b: String, @WitName("c") c: NotCompatible)
     """ hasErrors
     """
       |newSource1.scala:9: error: Field 'a' has type 'NotCompatible' which is not compatible with Component Model
-      |    final case class MultipleInvalid(a: NotCompatible, b: String, c: NotCompatible)
-      |                                     ^
+      |    final case class MultipleInvalid(@WitName("a") a: NotCompatible, @WitName("b") b: String, @WitName("c") c: NotCompatible)
+      |                                                   ^
       |newSource1.scala:9: error: Field 'c' has type 'NotCompatible' which is not compatible with Component Model
-      |    final case class MultipleInvalid(a: NotCompatible, b: String, c: NotCompatible)
-      |                                                                  ^
+      |    final case class MultipleInvalid(@WitName("a") a: NotCompatible, @WitName("b") b: String, @WitName("c") c: NotCompatible)
+      |                                                                                                            ^
     """
   }
 
   @Test def recordValidExamples: Unit = {
     """
-    @WitRecord
-    final case class Point(x: Int, y: Int)
+    @WitRecord(WitScope.root, "point")
+    final case class Point(@WitName("x") x: Int, @WitName("y") y: Int)
 
-    @WitRecord
-    final case class Person(name: String, age: Int)
+    @WitRecord(WitScope.root, "person")
+    final case class Person(@WitName("name") name: String, @WitName("age") age: Int)
 
-    @WitRecord
+    @WitRecord(WitScope.root, "empty")
     final case class Empty()
     """.hasNoWarns()
+  }
+
+  @Test def recordFieldsMustHaveWitName: Unit = {
+    """
+    @WitRecord(WitScope.root, "record")
+    final case class MissingName(x: Int)
+    """ hasErrors
+    """
+      |newSource1.scala:7: error: Field 'x' must have a @WitName annotation
+      |    final case class MissingName(x: Int)
+      |                                 ^
+    """
   }
 
   // --- Component Flags Tests ---
 
   @Test def flagsMustBeCaseClass: Unit = {
     """
-    @WitFlags(1)
+    @WitFlags(WitScope.root, "flags", Array("a"))
     class NotCaseClass(value: Int)
     """ hasErrors
     """
@@ -548,7 +582,7 @@ class WitInteropTest extends DirectTest with TestHelpers {
     """
 
     """
-    @WitFlags(1)
+    @WitFlags(WitScope.root, "flags", Array("a"))
     trait NotCaseClass
     """ hasErrors
     """
@@ -560,7 +594,7 @@ class WitInteropTest extends DirectTest with TestHelpers {
 
   @Test def flagsMustBeFinal: Unit = {
     """
-    @WitFlags(1)
+    @WitFlags(WitScope.root, "flags", Array("a"))
     case class NotFinal(value: Int)
     """ hasErrors
     """
@@ -572,7 +606,7 @@ class WitInteropTest extends DirectTest with TestHelpers {
 
   @Test def flagsMustNotExtendAnyVal: Unit = {
     """
-    @WitFlags(1)
+    @WitFlags(WitScope.root, "flags", Array("a"))
     final case class ValueClass(value: Int) extends AnyVal
     """ hasErrors
     """
@@ -584,7 +618,7 @@ class WitInteropTest extends DirectTest with TestHelpers {
 
   @Test def flagsMustHaveOneParameter: Unit = {
     """
-    @WitFlags(1)
+    @WitFlags(WitScope.root, "flags", Array("a"))
     final case class NoParameters()
     """ hasErrors
     """
@@ -594,7 +628,7 @@ class WitInteropTest extends DirectTest with TestHelpers {
     """
 
     """
-    @WitFlags(2)
+    @WitFlags(WitScope.root, "flags", Array("a", "b"))
     final case class TwoParameters(value: Int, other: Int)
     """ hasErrors
     """
@@ -606,7 +640,7 @@ class WitInteropTest extends DirectTest with TestHelpers {
 
   @Test def flagsParameterMustBeIntNamedValue: Unit = {
     """
-    @WitFlags(1)
+    @WitFlags(WitScope.root, "flags", Array("a"))
     final case class WrongType(value: String)
     """ hasErrors
     """
@@ -616,7 +650,7 @@ class WitInteropTest extends DirectTest with TestHelpers {
     """
 
     """
-    @WitFlags(1)
+    @WitFlags(WitScope.root, "flags", Array("a"))
     final case class WrongName(data: Int)
     """ hasErrors
     """
@@ -628,7 +662,7 @@ class WitInteropTest extends DirectTest with TestHelpers {
 
   @Test def flagsValidExamples: Unit = {
     """
-    @WitFlags(3)
+    @WitFlags(WitScope.root, "my-flags", Array("flag0", "flag1", "flag2"))
     final case class MyFlags(value: Int) {
       def |(other: MyFlags): MyFlags = MyFlags(value | other.value)
       def &(other: MyFlags): MyFlags = MyFlags(value & other.value)
@@ -639,7 +673,7 @@ class WitInteropTest extends DirectTest with TestHelpers {
       val Flag2 = MyFlags(1 << 2)
     }
 
-    @WitFlags(2)
+    @WitFlags(WitScope.root, "simple-flags", Array("a", "b"))
     final case class SimpleFlags(value: Int)
     object SimpleFlags {
       val A = SimpleFlags(1 << 0)
@@ -653,36 +687,36 @@ class WitInteropTest extends DirectTest with TestHelpers {
   @Test def witImportMustBeInPublicObject: Unit = {
     """
     class MyClass {
-      @WitImport("test:module", "in-class")
+      @WitImport(WitScope.unversioned("test", "test", "module"), "in-class")
       def inClass(x: Int): Int = wm.native
     }
     """ hasErrors
     """
-      |newSource1.scala:8: error: scala.scalajs.wit.annotation.WitImport("test:module", "in-class") methods must be defined in a public object
+      |newSource1.scala:8: error: scala.scalajs.wit.annotation.WitImport(scala.scalajs.wit.annotation.WitScope.unversioned("test", "test", "module"), "in-class") methods must be defined in a public object
       |      def inClass(x: Int): Int = wm.native
       |          ^
     """
 
     """
     trait MyTrait {
-      @WitImport("test:module", "in-trait")
+      @WitImport(WitScope.unversioned("test", "test", "module"), "in-trait")
       def inTrait(x: Int): Int = wm.native
     }
     """ hasErrors
     """
-      |newSource1.scala:8: error: scala.scalajs.wit.annotation.WitImport("test:module", "in-trait") methods must be defined in a public object
+      |newSource1.scala:8: error: scala.scalajs.wit.annotation.WitImport(scala.scalajs.wit.annotation.WitScope.unversioned("test", "test", "module"), "in-trait") methods must be defined in a public object
       |      def inTrait(x: Int): Int = wm.native
       |          ^
     """
 
     """
     private object PrivateObject {
-      @WitImport("test:module", "in-private")
+      @WitImport(WitScope.unversioned("test", "test", "module"), "in-private")
       def inPrivate(x: Int): Int = wm.native
     }
     """ hasErrors
     """
-      |newSource1.scala:8: error: scala.scalajs.wit.annotation.WitImport("test:module", "in-private") methods must be defined in a public object
+      |newSource1.scala:8: error: scala.scalajs.wit.annotation.WitImport(scala.scalajs.wit.annotation.WitScope.unversioned("test", "test", "module"), "in-private") methods must be defined in a public object
       |      def inPrivate(x: Int): Int = wm.native
       |          ^
     """
@@ -691,24 +725,24 @@ class WitInteropTest extends DirectTest with TestHelpers {
   @Test def witImportMustBePublic: Unit = {
     """
     object MyFunctions {
-      @WitImport("test:module", "private-func")
+      @WitImport(WitScope.unversioned("test", "test", "module"), "private-func")
       private def privateFunc(x: Int): Int = wm.native
     }
     """ hasErrors
     """
-      |newSource1.scala:8: error: scala.scalajs.wit.annotation.WitImport("test:module", "private-func") methods must be public
+      |newSource1.scala:8: error: scala.scalajs.wit.annotation.WitImport(scala.scalajs.wit.annotation.WitScope.unversioned("test", "test", "module"), "private-func") methods must be public
       |      private def privateFunc(x: Int): Int = wm.native
       |                  ^
     """
 
     """
     object MyFunctions {
-      @WitImport("test:module", "protected-func")
+      @WitImport(WitScope.unversioned("test", "test", "module"), "protected-func")
       protected def protectedFunc(x: Int): Int = wm.native
     }
     """ hasErrors
     """
-      |newSource1.scala:8: error: scala.scalajs.wit.annotation.WitImport("test:module", "protected-func") methods must be public
+      |newSource1.scala:8: error: scala.scalajs.wit.annotation.WitImport(scala.scalajs.wit.annotation.WitScope.unversioned("test", "test", "module"), "protected-func") methods must be public
       |      protected def protectedFunc(x: Int): Int = wm.native
       |                    ^
     """
@@ -717,12 +751,12 @@ class WitInteropTest extends DirectTest with TestHelpers {
   @Test def witImportCannotHaveTypeParameters: Unit = {
     """
     object MyFunctions {
-      @WitImport("test:module", "generic-func")
+      @WitImport(WitScope.unversioned("test", "test", "module"), "generic-func")
       def genericFunc[T](x: T): Int = wm.native
     }
     """ hasErrors
     """
-      |newSource1.scala:8: error: scala.scalajs.wit.annotation.WitImport("test:module", "generic-func") methods cannot have type parameters
+      |newSource1.scala:8: error: scala.scalajs.wit.annotation.WitImport(scala.scalajs.wit.annotation.WitScope.unversioned("test", "test", "module"), "generic-func") methods cannot have type parameters
       |      def genericFunc[T](x: T): Int = wm.native
       |          ^
     """
@@ -731,13 +765,13 @@ class WitInteropTest extends DirectTest with TestHelpers {
   @Test def witImportCannotHaveRepeatedParameters: Unit = {
     """
     object MyFunctions {
-      @WitImport("test:module", "varargs-func")
-      def varargsFunc(xs: Int*): Unit = wm.native
+      @WitImport(WitScope.unversioned("test", "test", "module"), "varargs-func")
+      def varargsFunc(@WitName("xs") xs: Int*): Unit = wm.native
     }
     """ hasErrors
     """
-      |newSource1.scala:8: error: scala.scalajs.wit.annotation.WitImport("test:module", "varargs-func") methods may not have repeated parameters
-      |      def varargsFunc(xs: Int*): Unit = wm.native
+      |newSource1.scala:8: error: scala.scalajs.wit.annotation.WitImport(scala.scalajs.wit.annotation.WitScope.unversioned("test", "test", "module"), "varargs-func") methods may not have repeated parameters
+      |      def varargsFunc(@WitName("xs") xs: Int*): Unit = wm.native
       |          ^
     """
   }
@@ -745,13 +779,13 @@ class WitInteropTest extends DirectTest with TestHelpers {
   @Test def witImportCannotHaveDefaultParameters: Unit = {
     """
     object MyFunctions {
-      @WitImport("test:module", "default-param")
-      def defaultParam(x: Int = 42): Int = wm.native
+      @WitImport(WitScope.unversioned("test", "test", "module"), "default-param")
+      def defaultParam(@WitName("x") x: Int = 42): Int = wm.native
     }
     """ hasErrors
     """
-      |newSource1.scala:8: error: scala.scalajs.wit.annotation.WitImport("test:module", "default-param") methods may not have default parameters
-      |      def defaultParam(x: Int = 42): Int = wm.native
+      |newSource1.scala:8: error: scala.scalajs.wit.annotation.WitImport(scala.scalajs.wit.annotation.WitScope.unversioned("test", "test", "module"), "default-param") methods may not have default parameters
+      |      def defaultParam(@WitName("x") x: Int = 42): Int = wm.native
       |          ^
     """
   }
@@ -761,13 +795,13 @@ class WitInteropTest extends DirectTest with TestHelpers {
     class NotCompatible
 
     object MyFunctions {
-      @WitImport("test:module", "invalid-param")
-      def invalidParam(x: NotCompatible): Unit = wm.native
+      @WitImport(WitScope.unversioned("test", "test", "module"), "invalid-param")
+      def invalidParam(@WitName("x") x: NotCompatible): Unit = wm.native
     }
     """ hasErrors
     """
       |newSource1.scala:10: error: Parameter 'x' has type 'NotCompatible' which is not compatible with Component Model
-      |      def invalidParam(x: NotCompatible): Unit = wm.native
+      |      def invalidParam(@WitName("x") x: NotCompatible): Unit = wm.native
       |          ^
     """
   }
@@ -777,13 +811,13 @@ class WitInteropTest extends DirectTest with TestHelpers {
     class NotCompatible
 
     object MyFunctions {
-      @WitImport("test:module", "invalid-return")
-      def invalidReturn(x: Int): NotCompatible = wm.native
+      @WitImport(WitScope.unversioned("test", "test", "module"), "invalid-return")
+      def invalidReturn(@WitName("x") x: Int): NotCompatible = wm.native
     }
     """ hasErrors
     """
       |newSource1.scala:10: error: Return type 'NotCompatible' is not compatible with Component Model
-      |      def invalidReturn(x: Int): NotCompatible = wm.native
+      |      def invalidReturn(@WitName("x") x: Int): NotCompatible = wm.native
       |          ^
     """
   }
@@ -795,12 +829,12 @@ class WitInteropTest extends DirectTest with TestHelpers {
     }
 
     object MyFunctions extends Base {
-      @WitImport("test:module", "override-func")
+      @WitImport(WitScope.unversioned("test", "test", "module"), "override-func")
       def baseMethod(): Int = wm.native
     }
     """ hasErrors
     """
-      |newSource1.scala:12: error: An scala.scalajs.wit.annotation.WitImport("test:module", "override-func") member cannot implement the inherited member Base.baseMethod
+      |newSource1.scala:12: error: An scala.scalajs.wit.annotation.WitImport(scala.scalajs.wit.annotation.WitScope.unversioned("test", "test", "module"), "override-func") member cannot implement the inherited member Base.baseMethod
       |      def baseMethod(): Int = wm.native
       |          ^
     """
@@ -810,13 +844,13 @@ class WitInteropTest extends DirectTest with TestHelpers {
     """
     object MyFunctions {
       def outer(): Unit = {
-        @WitImport("test:module", "local-func")
+        @WitImport(WitScope.unversioned("test", "test", "module"), "local-func")
         def localFunc(x: Int): Int = wm.native
       }
     }
     """ hasErrors
     """
-      |newSource1.scala:9: error: scala.scalajs.wit.annotation.WitImport("test:module", "local-func") is not allowed on local definitions
+      |newSource1.scala:9: error: scala.scalajs.wit.annotation.WitImport(scala.scalajs.wit.annotation.WitScope.unversioned("test", "test", "module"), "local-func") is not allowed on local definitions
       |        def localFunc(x: Int): Int = wm.native
       |            ^
     """
@@ -825,28 +859,28 @@ class WitInteropTest extends DirectTest with TestHelpers {
   @Test def witImportValidExamples: Unit = {
     """
     object MyImports {
-      @WitImport("test:module", "add")
-      def add(a: Int, b: Int): Int = wm.native
+      @WitImport(WitScope.unversioned("test", "test", "module"), "add")
+      def add(@WitName("a") a: Int, @WitName("b") b: Int): Int = wm.native
 
-      @WitImport("test:module", "greet")
-      def greet(name: String): String = wm.native
+      @WitImport(WitScope.unversioned("test", "test", "module"), "greet")
+      def greet(@WitName("name") name: String): String = wm.native
 
-      @WitImport("test:module", "process")
-      def process(data: Array[UByte]): wm.Result[Unit, String] = wm.native
+      @WitImport(WitScope.unversioned("test", "test", "module"), "process")
+      def process(@WitName("data") data: Array[UByte]): wm.Result[Unit, String] = wm.native
 
-      @WitImport("test:module", "no-params")
+      @WitImport(WitScope.unversioned("test", "test", "module"), "no-params")
       def noParams(): Unit = wm.native
 
-      @WitImport("test:module", "returns-optional")
-      def returnsOptional(x: Int): java.util.Optional[String] = wm.native
+      @WitImport(WitScope.unversioned("test", "test", "module"), "returns-optional")
+      def returnsOptional(@WitName("x") x: Int): java.util.Optional[String] = wm.native
     }
 
-    @WitRecord
-    final case class Point(x: Int, y: Int)
+    @WitRecord(WitScope.root, "record")
+    final case class Point(@WitName("x") x: Int, @WitName("y") y: Int)
 
     object MoreImports {
-      @WitImport("test:geom", "distance")
-      def distance(p1: Point, p2: Point): Double = wm.native
+      @WitImport(WitScope.unversioned("test", "test", "geom"), "distance")
+      def distance(@WitName("p1") p1: Point, @WitName("p2") p2: Point): Double = wm.native
     }
     """.hasNoWarns()
   }
@@ -856,27 +890,27 @@ class WitInteropTest extends DirectTest with TestHelpers {
   @Test def witExportMustBeInStaticObject: Unit = {
     """
     class NotStatic {
-      @WitExport("test:module", "method")
+      @WitExport(WitScope.unversioned("test", "test", "module"), "method")
       def method(): Unit = ???
     }
     """ hasErrors
     """
       |newSource1.scala:7: error: @WitExport can only be used in static objects.
-      |      @WitExport("test:module", "method")
+      |      @WitExport(WitScope.unversioned("test", "test", "module"), "method")
       |       ^
     """
 
     """
     class Owner {
       object Nested {
-        @WitExport("test:module", "method")
+        @WitExport(WitScope.unversioned("test", "test", "module"), "method")
         def method(): Unit = ()
       }
     }
     """ hasErrors
     """
       |newSource1.scala:8: error: @WitExport can only be used in static objects.
-      |        @WitExport("test:module", "method")
+      |        @WitExport(WitScope.unversioned("test", "test", "module"), "method")
       |         ^
     """
   }
@@ -884,7 +918,7 @@ class WitInteropTest extends DirectTest with TestHelpers {
   @Test def witExportTraitMethodsAreTemporarilyIgnored: Unit = {
     """
     trait GeneratedExports {
-      @WitExport("test:module", "method")
+      @WitExport(WitScope.unversioned("test", "test", "module"), "method")
       def method(): Unit
     }
     """.hasNoWarns()
@@ -895,7 +929,7 @@ class WitInteropTest extends DirectTest with TestHelpers {
     object DirectRunImpl {
       val foo = "bar"
 
-      @WitExport("wasi:cli/run@0.2.0", "run")
+      @WitExport(WitScope("wasi", "cli", "run", "0.2.0"), "run")
       def run(): wm.Result[Unit, Unit] = {
         println(foo)
         new wm.Ok(())
@@ -905,19 +939,19 @@ class WitInteropTest extends DirectTest with TestHelpers {
     }
 
     object MyAPIImpl {
-      @WitExport("test:api", "get-data")
-      def getData(id: Int): wm.Result[String, String] =
+      @WitExport(WitScope.unversioned("test", "test", "api"), "get-data")
+      def getData(@WitName("id") id: Int): wm.Result[String, String] =
         new wm.Ok(s"data-$id")
 
-      @WitExport("test:api", "process")
-      def process(data: Array[UByte]): Unit = {
+      @WitExport(WitScope.unversioned("test", "test", "api"), "process")
+      def process(@WitName("data") data: Array[UByte]): Unit = {
         // Process data
       }
     }
 
     object Outer {
       object Nested {
-        @WitExport("test:nested", "method")
+        @WitExport(WitScope.unversioned("test", "test", "nested"), "method")
         def method(): Unit = ()
       }
     }

--- a/examples/helloworld-component-model/Makefile
+++ b/examples/helloworld-component-model/Makefile
@@ -5,9 +5,6 @@ SCALA_MODULE := .$(SCALA_VERSION)/target/scala-$(SCALA_VERSION)/helloworld-compo
 RUST_MODULE := rust-greeter/target/wasm32-wasip1/release/rust_greeter.wasm
 OUT := out.wasm
 
-fetch:
-	wkg wit fetch
-
 build-rust:
 	cd rust-greeter; cargo component build -r
 
@@ -20,5 +17,5 @@ run: component
 clean:
 	rm -f $(OUT)
 
-.PHONY: fetch build-rust component run clean
+.PHONY: build-rust component run clean
 

--- a/examples/helloworld-component-model/rust-greeter/Cargo.toml
+++ b/examples/helloworld-component-model/rust-greeter/Cargo.toml
@@ -27,7 +27,3 @@ path = "../wit"
 [package.metadata.component.target.dependencies]
 "wasi:cli" = { path = "../wit/deps/wasi-cli-0.2.0" }
 "wasi:io" = { path = "../wit/deps/wasi-io-0.2.0" }
-"wasi:clocks" = { path = "../wit/deps/wasi-clocks-0.2.0" }
-"wasi:filesystem" = { path = "../wit/deps/wasi-filesystem-0.2.0" }
-"wasi:sockets" = { path = "../wit/deps/wasi-sockets-0.2.0" }
-"wasi:random" = { path = "../wit/deps/wasi-random-0.2.0" }

--- a/examples/helloworld-component-model/src/main/scala/helloworld/scala_wasm/helloworld/greeter.scala
+++ b/examples/helloworld-component-model/src/main/scala/helloworld/scala_wasm/helloworld/greeter.scala
@@ -6,7 +6,7 @@ import scala.scalajs.wit.annotation._
 package object greeter {
 
   // Functions
-  @WitImport("scala-wasm:helloworld/greeter", "greet")
-  def greet(name: String): String = wit.native
+  @WitImport(WitScope.unversioned("scala-wasm", "helloworld", "greeter"), "greet")
+  def greet(@WitName("name") name: String): String = wit.native
 
 }

--- a/examples/helloworld-component-model/src/main/scala/helloworld/wasi/cli/stdout.scala
+++ b/examples/helloworld-component-model/src/main/scala/helloworld/wasi/cli/stdout.scala
@@ -1,12 +1,12 @@
 package helloworld.wasi.cli
 
+import helloworld.wasi.io.streams.OutputStream
+import scala.scalajs.wit.annotation.{WitImport, WitScope}
+import scala.scalajs.wit.native
+
 package object stdout {
 
-  // Type definitions
-  type OutputStream = helloworld.wasi.io.streams.OutputStream
-
-  // Functions
-  @scala.scalajs.wit.annotation.WitImport("wasi:cli/stdout@0.2.0", "get-stdout")
-  def getStdout(): OutputStream = scala.scalajs.wit.native
+  @WitImport(WitScope("wasi", "cli", "stdout", "0.2.0"), "get-stdout")
+  def getStdout(): OutputStream = native
 
 }

--- a/examples/helloworld-component-model/src/main/scala/helloworld/wasi/io/error.scala
+++ b/examples/helloworld-component-model/src/main/scala/helloworld/wasi/io/error.scala
@@ -1,15 +1,17 @@
 package helloworld.wasi.io
 
+import scala.scalajs.wit.annotation.{WitResourceDrop, WitResourceImport, WitResourceMethod, WitScope}
+import scala.scalajs.wit.native
+
 package object error {
 
-  // Resources
-  @scala.scalajs.wit.annotation.WitResourceImport("wasi:io/error@0.2.0", "error")
+  @WitResourceImport(WitScope("wasi", "io", "error", "0.2.0"), "error")
   final class Error private () extends Object {
-    @scala.scalajs.wit.annotation.WitResourceMethod("to-debug-string")
-    def toDebugString(): String = scala.scalajs.wit.native
+    @WitResourceMethod("to-debug-string")
+    def toDebugString(): String = native
 
-    @scala.scalajs.wit.annotation.WitResourceDrop
-    def close(): Unit = scala.scalajs.wit.native
+    @WitResourceDrop
+    def close(): Unit = native
   }
 
   object Error {}

--- a/examples/helloworld-component-model/src/main/scala/helloworld/wasi/io/poll.scala
+++ b/examples/helloworld-component-model/src/main/scala/helloworld/wasi/io/poll.scala
@@ -1,24 +1,33 @@
 package helloworld.wasi.io
 
+import scala.scalajs.wit.annotation.{
+  WitImport,
+  WitName,
+  WitResourceDrop,
+  WitResourceImport,
+  WitResourceMethod,
+  WitScope
+}
+import scala.scalajs.wit.native
+import scala.scalajs.wit.unsigned.UInt
+
 package object poll {
 
-  // Resources
-  @scala.scalajs.wit.annotation.WitResourceImport("wasi:io/poll@0.2.0", "pollable")
+  @WitResourceImport(WitScope("wasi", "io", "poll", "0.2.0"), "pollable")
   final class Pollable private () extends Object {
-    @scala.scalajs.wit.annotation.WitResourceMethod("ready")
-    def ready(): Boolean = scala.scalajs.wit.native
+    @WitResourceMethod("ready")
+    def ready(): Boolean = native
 
-    @scala.scalajs.wit.annotation.WitResourceMethod("block")
-    def block(): Unit = scala.scalajs.wit.native
+    @WitResourceMethod("block")
+    def block(): Unit = native
 
-    @scala.scalajs.wit.annotation.WitResourceDrop
-    def close(): Unit = scala.scalajs.wit.native
+    @WitResourceDrop
+    def close(): Unit = native
   }
 
   object Pollable {}
 
-  // Functions
-  @scala.scalajs.wit.annotation.WitImport("wasi:io/poll@0.2.0", "poll")
-  def poll(in: Array[Pollable]): Array[scala.scalajs.wit.unsigned.UInt] = scala.scalajs.wit.native
+  @WitImport(WitScope("wasi", "io", "poll", "0.2.0"), "poll")
+  def poll(@WitName("in") in: Array[Pollable]): Array[UInt] = native
 
 }

--- a/examples/helloworld-component-model/src/main/scala/helloworld/wasi/io/streams.scala
+++ b/examples/helloworld-component-model/src/main/scala/helloworld/wasi/io/streams.scala
@@ -1,17 +1,27 @@
 package helloworld.wasi.io
 
+import helloworld.wasi.io.error.Error
+import helloworld.wasi.io.poll.Pollable
+import scala.scalajs.wit.Result
+import scala.scalajs.wit.annotation.{
+  WitName,
+  WitResourceDrop,
+  WitResourceImport,
+  WitResourceMethod,
+  WitScope,
+  WitVariant
+}
+import scala.scalajs.wit.native
+import scala.scalajs.wit.unsigned.{UByte, ULong}
+
 package object streams {
 
-  // Type definitions
-  type Error = helloworld.wasi.io.error.Error
-
-  type Pollable = helloworld.wasi.io.poll.Pollable
-
-  @scala.scalajs.wit.annotation.WitVariant
+  @WitVariant(WitScope("wasi", "io", "streams", "0.2.0"), "stream-error")
   sealed trait StreamError
 
   object StreamError {
-    final class LastOperationFailed(val value: Error) extends StreamError {
+    @WitName("last-operation-failed")
+    final class LastOperationFailed(@WitName("value") val value: Error) extends StreamError {
       override def equals(other: Any): Boolean = other match {
         case that: LastOperationFailed => this.value == that.value
         case _                         => false
@@ -28,86 +38,73 @@ package object streams {
       def unapply(arg: LastOperationFailed): Some[Error] = Some(arg.value)
     }
 
+    @WitName("closed")
     object Closed extends StreamError {
       override def toString(): String = "Closed"
     }
   }
 
-  // Resources
-  @scala.scalajs.wit.annotation.WitResourceImport("wasi:io/streams@0.2.0", "input-stream")
+  @WitResourceImport(WitScope("wasi", "io", "streams", "0.2.0"), "input-stream")
   final class InputStream private () extends Object {
-    @scala.scalajs.wit.annotation.WitResourceMethod("read")
-    def read(len: scala.scalajs.wit.unsigned.ULong): scala.scalajs.wit.Result[
-        Array[scala.scalajs.wit.unsigned.UByte], StreamError] = scala.scalajs.wit.native
+    @WitResourceMethod("read")
+    def read(@WitName("len") len: ULong): Result[Array[UByte], StreamError] = native
 
-    @scala.scalajs.wit.annotation.WitResourceMethod("blocking-read")
-    def blockingRead(len: scala.scalajs.wit.unsigned.ULong): scala.scalajs.wit.Result[
-        Array[scala.scalajs.wit.unsigned.UByte], StreamError] = scala.scalajs.wit.native
+    @WitResourceMethod("blocking-read")
+    def blockingRead(@WitName("len") len: ULong): Result[Array[UByte], StreamError] = native
 
-    @scala.scalajs.wit.annotation.WitResourceMethod("skip")
-    def skip(len: scala.scalajs.wit.unsigned.ULong): scala.scalajs.wit.Result[
-        scala.scalajs.wit.unsigned.ULong, StreamError] = scala.scalajs.wit.native
+    @WitResourceMethod("skip")
+    def skip(@WitName("len") len: ULong): Result[ULong, StreamError] = native
 
-    @scala.scalajs.wit.annotation.WitResourceMethod("blocking-skip")
-    def blockingSkip(len: scala.scalajs.wit.unsigned.ULong): scala.scalajs.wit.Result[
-        scala.scalajs.wit.unsigned.ULong, StreamError] = scala.scalajs.wit.native
+    @WitResourceMethod("blocking-skip")
+    def blockingSkip(@WitName("len") len: ULong): Result[ULong, StreamError] = native
 
-    @scala.scalajs.wit.annotation.WitResourceMethod("subscribe")
-    def subscribe(): Pollable = scala.scalajs.wit.native
+    @WitResourceMethod("subscribe")
+    def subscribe(): Pollable = native
 
-    @scala.scalajs.wit.annotation.WitResourceDrop
-    def close(): Unit = scala.scalajs.wit.native
+    @WitResourceDrop
+    def close(): Unit = native
   }
 
   object InputStream {}
 
-  @scala.scalajs.wit.annotation.WitResourceImport("wasi:io/streams@0.2.0", "output-stream")
+  @WitResourceImport(WitScope("wasi", "io", "streams", "0.2.0"), "output-stream")
   final class OutputStream private () extends Object {
-    @scala.scalajs.wit.annotation.WitResourceMethod("check-write")
-    def checkWrite(): scala.scalajs.wit.Result[scala.scalajs.wit.unsigned.ULong, StreamError] =
-      scala.scalajs.wit.native
+    @WitResourceMethod("check-write")
+    def checkWrite(): Result[ULong, StreamError] = native
 
-    @scala.scalajs.wit.annotation.WitResourceMethod("write")
-    def write(contents: Array[scala.scalajs.wit.unsigned.UByte]): scala.scalajs.wit.Result[Unit,
-        StreamError] = scala.scalajs.wit.native
+    @WitResourceMethod("write")
+    def write(@WitName("contents") contents: Array[UByte]): Result[Unit, StreamError] = native
 
-    @scala.scalajs.wit.annotation.WitResourceMethod("blocking-write-and-flush")
+    @WitResourceMethod("blocking-write-and-flush")
     def blockingWriteAndFlush(
-        contents: Array[scala.scalajs.wit.unsigned.UByte]): scala.scalajs.wit.Result[Unit,
-        StreamError] = scala.scalajs.wit.native
+        @WitName("contents") contents: Array[UByte]): Result[Unit, StreamError] = native
 
-    @scala.scalajs.wit.annotation.WitResourceMethod("flush")
-    def flush(): scala.scalajs.wit.Result[Unit, StreamError] = scala.scalajs.wit.native
+    @WitResourceMethod("flush")
+    def flush(): Result[Unit, StreamError] = native
 
-    @scala.scalajs.wit.annotation.WitResourceMethod("blocking-flush")
-    def blockingFlush(): scala.scalajs.wit.Result[Unit, StreamError] = scala.scalajs.wit.native
+    @WitResourceMethod("blocking-flush")
+    def blockingFlush(): Result[Unit, StreamError] = native
 
-    @scala.scalajs.wit.annotation.WitResourceMethod("subscribe")
-    def subscribe(): Pollable = scala.scalajs.wit.native
+    @WitResourceMethod("subscribe")
+    def subscribe(): Pollable = native
 
-    @scala.scalajs.wit.annotation.WitResourceMethod("write-zeroes")
-    def writeZeroes(
-        len: scala.scalajs.wit.unsigned.ULong): scala.scalajs.wit.Result[Unit, StreamError] = {
-      scala.scalajs.wit.native
-    }
+    @WitResourceMethod("write-zeroes")
+    def writeZeroes(@WitName("len") len: ULong): Result[Unit, StreamError] = native
 
-    @scala.scalajs.wit.annotation.WitResourceMethod("blocking-write-zeroes-and-flush")
+    @WitResourceMethod("blocking-write-zeroes-and-flush")
     def blockingWriteZeroesAndFlush(
-        len: scala.scalajs.wit.unsigned.ULong): scala.scalajs.wit.Result[Unit, StreamError] = {
-      scala.scalajs.wit.native
-    }
+        @WitName("len") len: ULong): Result[Unit, StreamError] = native
 
-    @scala.scalajs.wit.annotation.WitResourceMethod("splice")
-    def splice(src: InputStream, len: scala.scalajs.wit.unsigned.ULong): scala.scalajs.wit.Result[
-        scala.scalajs.wit.unsigned.ULong, StreamError] = scala.scalajs.wit.native
+    @WitResourceMethod("splice")
+    def splice(@WitName("src") src: InputStream,
+        @WitName("len") len: ULong): Result[ULong, StreamError] = native
 
-    @scala.scalajs.wit.annotation.WitResourceMethod("blocking-splice")
-    def blockingSplice(src: InputStream,
-        len: scala.scalajs.wit.unsigned.ULong): scala.scalajs.wit.Result[
-        scala.scalajs.wit.unsigned.ULong, StreamError] = scala.scalajs.wit.native
+    @WitResourceMethod("blocking-splice")
+    def blockingSplice(@WitName("src") src: InputStream,
+        @WitName("len") len: ULong): Result[ULong, StreamError] = native
 
-    @scala.scalajs.wit.annotation.WitResourceDrop
-    def close(): Unit = scala.scalajs.wit.native
+    @WitResourceDrop
+    def close(): Unit = native
   }
 
   object OutputStream {}

--- a/examples/helloworld-wasi/Makefile
+++ b/examples/helloworld-wasi/Makefile
@@ -1,9 +1,6 @@
 # Scala version: 2.12 or 2.13 (default: 2.13)
 SCALA_VERSION ?= 2.13
 
-fetch:
-	wkg wit fetch
-
 opt:
 	wasm-opt .$(SCALA_VERSION)/target/scala-$(SCALA_VERSION)/helloworld-wasi-fastopt/main.wasm --enable-tail-call --enable-multivalue --enable-gc --enable-reference-types --enable-exception-handling --enable-bulk-memory --enable-nontrapping-float-to-int --closed-world --inline-functions-with-loops --traps-never-happen --fast-math --type-ssa -O3 -O3 --gufa -O3 --type-merging -O3 -Oz -o main.wasm
 
@@ -16,4 +13,4 @@ run-opt: opt
 clean:
 	rm -f main.wasm
 
-.PHONY: fetch opt run run-opt clean
+.PHONY: opt run run-opt clean

--- a/examples/helloworld-wasi/src/main/scala/helloworld/wasi/cli/stdout.scala
+++ b/examples/helloworld-wasi/src/main/scala/helloworld/wasi/cli/stdout.scala
@@ -1,12 +1,12 @@
 package helloworld.wasi.cli
 
+import helloworld.wasi.io.streams.OutputStream
+import scala.scalajs.wit.annotation.{WitImport, WitScope}
+import scala.scalajs.wit.native
+
 package object stdout {
 
-  // Type definitions
-  type OutputStream = helloworld.wasi.io.streams.OutputStream
-
-  // Functions
-  @scala.scalajs.wit.annotation.WitImport("wasi:cli/stdout@0.2.0", "get-stdout")
-  def getStdout(): OutputStream = scala.scalajs.wit.native
+  @WitImport(WitScope("wasi", "cli", "stdout", "0.2.0"), "get-stdout")
+  def getStdout(): OutputStream = native
 
 }

--- a/examples/helloworld-wasi/src/main/scala/helloworld/wasi/io/error.scala
+++ b/examples/helloworld-wasi/src/main/scala/helloworld/wasi/io/error.scala
@@ -1,15 +1,17 @@
 package helloworld.wasi.io
 
+import scala.scalajs.wit.annotation.{WitResourceDrop, WitResourceImport, WitResourceMethod, WitScope}
+import scala.scalajs.wit.native
+
 package object error {
 
-  // Resources
-  @scala.scalajs.wit.annotation.WitResourceImport("wasi:io/error@0.2.0", "error")
+  @WitResourceImport(WitScope("wasi", "io", "error", "0.2.0"), "error")
   final class Error private () extends Object {
-    @scala.scalajs.wit.annotation.WitResourceMethod("to-debug-string")
-    def toDebugString(): String = scala.scalajs.wit.native
+    @WitResourceMethod("to-debug-string")
+    def toDebugString(): String = native
 
-    @scala.scalajs.wit.annotation.WitResourceDrop
-    def close(): Unit = scala.scalajs.wit.native
+    @WitResourceDrop
+    def close(): Unit = native
   }
 
   object Error {}

--- a/examples/helloworld-wasi/src/main/scala/helloworld/wasi/io/poll.scala
+++ b/examples/helloworld-wasi/src/main/scala/helloworld/wasi/io/poll.scala
@@ -1,24 +1,33 @@
 package helloworld.wasi.io
 
+import scala.scalajs.wit.annotation.{
+  WitImport,
+  WitName,
+  WitResourceDrop,
+  WitResourceImport,
+  WitResourceMethod,
+  WitScope
+}
+import scala.scalajs.wit.native
+import scala.scalajs.wit.unsigned.UInt
+
 package object poll {
 
-  // Resources
-  @scala.scalajs.wit.annotation.WitResourceImport("wasi:io/poll@0.2.0", "pollable")
+  @WitResourceImport(WitScope("wasi", "io", "poll", "0.2.0"), "pollable")
   final class Pollable private () extends Object {
-    @scala.scalajs.wit.annotation.WitResourceMethod("ready")
-    def ready(): Boolean = scala.scalajs.wit.native
+    @WitResourceMethod("ready")
+    def ready(): Boolean = native
 
-    @scala.scalajs.wit.annotation.WitResourceMethod("block")
-    def block(): Unit = scala.scalajs.wit.native
+    @WitResourceMethod("block")
+    def block(): Unit = native
 
-    @scala.scalajs.wit.annotation.WitResourceDrop
-    def close(): Unit = scala.scalajs.wit.native
+    @WitResourceDrop
+    def close(): Unit = native
   }
 
   object Pollable {}
 
-  // Functions
-  @scala.scalajs.wit.annotation.WitImport("wasi:io/poll@0.2.0", "poll")
-  def poll(in: Array[Pollable]): Array[scala.scalajs.wit.unsigned.UInt] = scala.scalajs.wit.native
+  @WitImport(WitScope("wasi", "io", "poll", "0.2.0"), "poll")
+  def poll(@WitName("in") in: Array[Pollable]): Array[UInt] = native
 
 }

--- a/examples/helloworld-wasi/src/main/scala/helloworld/wasi/io/streams.scala
+++ b/examples/helloworld-wasi/src/main/scala/helloworld/wasi/io/streams.scala
@@ -1,17 +1,27 @@
 package helloworld.wasi.io
 
+import helloworld.wasi.io.error.Error
+import helloworld.wasi.io.poll.Pollable
+import scala.scalajs.wit.Result
+import scala.scalajs.wit.annotation.{
+  WitName,
+  WitResourceDrop,
+  WitResourceImport,
+  WitResourceMethod,
+  WitScope,
+  WitVariant
+}
+import scala.scalajs.wit.native
+import scala.scalajs.wit.unsigned.{UByte, ULong}
+
 package object streams {
 
-  // Type definitions
-  type Error = helloworld.wasi.io.error.Error
-
-  type Pollable = helloworld.wasi.io.poll.Pollable
-
-  @scala.scalajs.wit.annotation.WitVariant
+  @WitVariant(WitScope("wasi", "io", "streams", "0.2.0"), "stream-error")
   sealed trait StreamError
 
   object StreamError {
-    final class LastOperationFailed(val value: Error) extends StreamError {
+    @WitName("last-operation-failed")
+    final class LastOperationFailed(@WitName("value") val value: Error) extends StreamError {
       override def equals(other: Any): Boolean = other match {
         case that: LastOperationFailed => this.value == that.value
         case _                         => false
@@ -28,86 +38,73 @@ package object streams {
       def unapply(arg: LastOperationFailed): Some[Error] = Some(arg.value)
     }
 
+    @WitName("closed")
     object Closed extends StreamError {
       override def toString(): String = "Closed"
     }
   }
 
-  // Resources
-  @scala.scalajs.wit.annotation.WitResourceImport("wasi:io/streams@0.2.0", "input-stream")
+  @WitResourceImport(WitScope("wasi", "io", "streams", "0.2.0"), "input-stream")
   final class InputStream private () extends Object {
-    @scala.scalajs.wit.annotation.WitResourceMethod("read")
-    def read(len: scala.scalajs.wit.unsigned.ULong): scala.scalajs.wit.Result[
-        Array[scala.scalajs.wit.unsigned.UByte], StreamError] = scala.scalajs.wit.native
+    @WitResourceMethod("read")
+    def read(@WitName("len") len: ULong): Result[Array[UByte], StreamError] = native
 
-    @scala.scalajs.wit.annotation.WitResourceMethod("blocking-read")
-    def blockingRead(len: scala.scalajs.wit.unsigned.ULong): scala.scalajs.wit.Result[
-        Array[scala.scalajs.wit.unsigned.UByte], StreamError] = scala.scalajs.wit.native
+    @WitResourceMethod("blocking-read")
+    def blockingRead(@WitName("len") len: ULong): Result[Array[UByte], StreamError] = native
 
-    @scala.scalajs.wit.annotation.WitResourceMethod("skip")
-    def skip(len: scala.scalajs.wit.unsigned.ULong): scala.scalajs.wit.Result[
-        scala.scalajs.wit.unsigned.ULong, StreamError] = scala.scalajs.wit.native
+    @WitResourceMethod("skip")
+    def skip(@WitName("len") len: ULong): Result[ULong, StreamError] = native
 
-    @scala.scalajs.wit.annotation.WitResourceMethod("blocking-skip")
-    def blockingSkip(len: scala.scalajs.wit.unsigned.ULong): scala.scalajs.wit.Result[
-        scala.scalajs.wit.unsigned.ULong, StreamError] = scala.scalajs.wit.native
+    @WitResourceMethod("blocking-skip")
+    def blockingSkip(@WitName("len") len: ULong): Result[ULong, StreamError] = native
 
-    @scala.scalajs.wit.annotation.WitResourceMethod("subscribe")
-    def subscribe(): Pollable = scala.scalajs.wit.native
+    @WitResourceMethod("subscribe")
+    def subscribe(): Pollable = native
 
-    @scala.scalajs.wit.annotation.WitResourceDrop
-    def close(): Unit = scala.scalajs.wit.native
+    @WitResourceDrop
+    def close(): Unit = native
   }
 
   object InputStream {}
 
-  @scala.scalajs.wit.annotation.WitResourceImport("wasi:io/streams@0.2.0", "output-stream")
+  @WitResourceImport(WitScope("wasi", "io", "streams", "0.2.0"), "output-stream")
   final class OutputStream private () extends Object {
-    @scala.scalajs.wit.annotation.WitResourceMethod("check-write")
-    def checkWrite(): scala.scalajs.wit.Result[scala.scalajs.wit.unsigned.ULong, StreamError] =
-      scala.scalajs.wit.native
+    @WitResourceMethod("check-write")
+    def checkWrite(): Result[ULong, StreamError] = native
 
-    @scala.scalajs.wit.annotation.WitResourceMethod("write")
-    def write(contents: Array[scala.scalajs.wit.unsigned.UByte]): scala.scalajs.wit.Result[Unit,
-        StreamError] = scala.scalajs.wit.native
+    @WitResourceMethod("write")
+    def write(@WitName("contents") contents: Array[UByte]): Result[Unit, StreamError] = native
 
-    @scala.scalajs.wit.annotation.WitResourceMethod("blocking-write-and-flush")
+    @WitResourceMethod("blocking-write-and-flush")
     def blockingWriteAndFlush(
-        contents: Array[scala.scalajs.wit.unsigned.UByte]): scala.scalajs.wit.Result[Unit,
-        StreamError] = scala.scalajs.wit.native
+        @WitName("contents") contents: Array[UByte]): Result[Unit, StreamError] = native
 
-    @scala.scalajs.wit.annotation.WitResourceMethod("flush")
-    def flush(): scala.scalajs.wit.Result[Unit, StreamError] = scala.scalajs.wit.native
+    @WitResourceMethod("flush")
+    def flush(): Result[Unit, StreamError] = native
 
-    @scala.scalajs.wit.annotation.WitResourceMethod("blocking-flush")
-    def blockingFlush(): scala.scalajs.wit.Result[Unit, StreamError] = scala.scalajs.wit.native
+    @WitResourceMethod("blocking-flush")
+    def blockingFlush(): Result[Unit, StreamError] = native
 
-    @scala.scalajs.wit.annotation.WitResourceMethod("subscribe")
-    def subscribe(): Pollable = scala.scalajs.wit.native
+    @WitResourceMethod("subscribe")
+    def subscribe(): Pollable = native
 
-    @scala.scalajs.wit.annotation.WitResourceMethod("write-zeroes")
-    def writeZeroes(
-        len: scala.scalajs.wit.unsigned.ULong): scala.scalajs.wit.Result[Unit, StreamError] = {
-      scala.scalajs.wit.native
-    }
+    @WitResourceMethod("write-zeroes")
+    def writeZeroes(@WitName("len") len: ULong): Result[Unit, StreamError] = native
 
-    @scala.scalajs.wit.annotation.WitResourceMethod("blocking-write-zeroes-and-flush")
+    @WitResourceMethod("blocking-write-zeroes-and-flush")
     def blockingWriteZeroesAndFlush(
-        len: scala.scalajs.wit.unsigned.ULong): scala.scalajs.wit.Result[Unit, StreamError] = {
-      scala.scalajs.wit.native
-    }
+        @WitName("len") len: ULong): Result[Unit, StreamError] = native
 
-    @scala.scalajs.wit.annotation.WitResourceMethod("splice")
-    def splice(src: InputStream, len: scala.scalajs.wit.unsigned.ULong): scala.scalajs.wit.Result[
-        scala.scalajs.wit.unsigned.ULong, StreamError] = scala.scalajs.wit.native
+    @WitResourceMethod("splice")
+    def splice(@WitName("src") src: InputStream,
+        @WitName("len") len: ULong): Result[ULong, StreamError] = native
 
-    @scala.scalajs.wit.annotation.WitResourceMethod("blocking-splice")
-    def blockingSplice(src: InputStream,
-        len: scala.scalajs.wit.unsigned.ULong): scala.scalajs.wit.Result[
-        scala.scalajs.wit.unsigned.ULong, StreamError] = scala.scalajs.wit.native
+    @WitResourceMethod("blocking-splice")
+    def blockingSplice(@WitName("src") src: InputStream,
+        @WitName("len") len: ULong): Result[ULong, StreamError] = native
 
-    @scala.scalajs.wit.annotation.WitResourceDrop
-    def close(): Unit = scala.scalajs.wit.native
+    @WitResourceDrop
+    def close(): Unit = native
   }
 
   object OutputStream {}

--- a/examples/test-component-model/Makefile
+++ b/examples/test-component-model/Makefile
@@ -1,9 +1,6 @@
 # Scala version: 2.12 or 2.13 (default: 2.13)
 SCALA_VERSION ?= 2.13
 
-fetch:
-	wkg wit fetch
-
 build:
 	cd rust-exports; cargo component build --target wasm32-wasip2 -r
 	cd rust-run; cargo component build --target wasm32-wasip2 -r
@@ -18,4 +15,4 @@ run: compose
 clean:
 	rm -f scala.wasm out.wasm
 
-.PHONY: fetch build compose run clean
+.PHONY: build compose run clean

--- a/examples/test-component-model/src/main/scala/componentmodel/RootImpl.scala
+++ b/examples/test-component-model/src/main/scala/componentmodel/RootImpl.scala
@@ -5,10 +5,10 @@ import scala.scalajs.wit.annotation._
 
 object RootImpl {
 
-  @WitExport("", "bare-multiply")
-  def bareMultiply(a: Int, b: Int): Int = a * b
+  @WitExport(WitScope.root, "bare-multiply")
+  def bareMultiply(@WitName("a") a: Int, @WitName("b") b: Int): Int = a * b
 
-  @WitExport("", "bare-uppercase")
-  def bareUppercase(text: String): String = text.toUpperCase()
+  @WitExport(WitScope.root, "bare-uppercase")
+  def bareUppercase(@WitName("text") text: String): String = text.toUpperCase()
 
 }

--- a/examples/test-component-model/src/main/scala/componentmodel/TestImportsImpl.scala
+++ b/examples/test-component-model/src/main/scala/componentmodel/TestImportsImpl.scala
@@ -14,7 +14,7 @@ import scala.scalajs.WitUtils.toEither
 import java.util.Optional
 
 object TestImportsImpl {
-  @WitExport("component:testing/test-imports", "run")
+  @WitExport(WitScope.unversioned("component", "testing", "test-imports"), "run")
   def run(): Unit = {
     def newCounterArray(size: Int): Array[Counter] =
       new Array[Counter](size)

--- a/examples/test-component-model/src/main/scala/componentmodel/TestsImpl.scala
+++ b/examples/test-component-model/src/main/scala/componentmodel/TestsImpl.scala
@@ -16,78 +16,81 @@ object TestsImpl {
 
   private def ignore[A](a: A): Unit = ()
 
-  @WitExport("component:testing/tests", "roundtrip-point")
-  def roundtripPoint(a: Point): Point = roundtrip(a)
+  @WitExport(WitScope.unversioned("component", "testing", "tests"), "roundtrip-point")
+  def roundtripPoint(@WitName("a") a: Point): Point = roundtrip(a)
 
-  @WitExport("component:testing/tests", "roundtrip-basics1")
-  def roundtripBasics1(a: wit.Tuple9[UByte, Byte, UShort, Short, UInt, Int, Float, Double,
+  @WitExport(WitScope.unversioned("component", "testing", "tests"), "roundtrip-basics1")
+  def roundtripBasics1(
+      @WitName("a") a: wit.Tuple9[UByte, Byte, UShort, Short, UInt, Int, Float, Double,
           Char]): wit.Tuple9[UByte, Byte, UShort, Short, UInt, Int, Float, Double, Char] = {
     roundtrip(a)
   }
 
-  @WitExport("component:testing/tests", "roundtrip-list-u16")
-  def roundtripListU16(a: Array[UShort]): Array[UShort] = roundtrip(a)
+  @WitExport(WitScope.unversioned("component", "testing", "tests"), "roundtrip-list-u16")
+  def roundtripListU16(@WitName("a") a: Array[UShort]): Array[UShort] = roundtrip(a)
 
-  @WitExport("component:testing/tests", "roundtrip-list-point")
-  def roundtripListPoint(a: Array[Point]): Array[Point] = roundtrip(a)
+  @WitExport(WitScope.unversioned("component", "testing", "tests"), "roundtrip-list-point")
+  def roundtripListPoint(@WitName("a") a: Array[Point]): Array[Point] = roundtrip(a)
 
-  @WitExport("component:testing/tests", "roundtrip-list-variant")
-  def roundtripListVariant(a: Array[C1]): Array[C1] = roundtrip(a)
+  @WitExport(WitScope.unversioned("component", "testing", "tests"), "roundtrip-list-variant")
+  def roundtripListVariant(@WitName("a") a: Array[C1]): Array[C1] = roundtrip(a)
 
-  @WitExport("component:testing/tests", "roundtrip-string")
-  def roundtripString(a: String): String = roundtrip(a)
+  @WitExport(WitScope.unversioned("component", "testing", "tests"), "roundtrip-string")
+  def roundtripString(@WitName("a") a: String): String = roundtrip(a)
 
-  @WitExport("component:testing/tests", "roundtrip-c1")
-  def roundtripC1(a: C1): C1 = roundtrip(a)
+  @WitExport(WitScope.unversioned("component", "testing", "tests"), "roundtrip-c1")
+  def roundtripC1(@WitName("a") a: C1): C1 = roundtrip(a)
 
-  @WitExport("component:testing/tests", "roundtrip-z1")
-  def roundtripZ1(a: Z1): Z1 = roundtrip(a)
+  @WitExport(WitScope.unversioned("component", "testing", "tests"), "roundtrip-z1")
+  def roundtripZ1(@WitName("a") a: Z1): Z1 = roundtrip(a)
 
-  @WitExport("component:testing/tests", "test-c1")
-  def testC1(a: C1): Unit = ignore(a)
+  @WitExport(WitScope.unversioned("component", "testing", "tests"), "test-c1")
+  def testC1(@WitName("a") a: C1): Unit = ignore(a)
 
-  @WitExport("component:testing/tests", "roundtrip-enum")
-  def roundtripEnum(a: E1): E1 = roundtrip(a)
+  @WitExport(WitScope.unversioned("component", "testing", "tests"), "roundtrip-enum")
+  def roundtripEnum(@WitName("a") a: E1): E1 = roundtrip(a)
 
-  @WitExport("component:testing/tests", "roundtrip-tuple")
-  def roundtripTuple(a: wit.Tuple2[C1, Z1]): wit.Tuple2[C1, Z1] = roundtrip(a)
+  @WitExport(WitScope.unversioned("component", "testing", "tests"), "roundtrip-tuple")
+  def roundtripTuple(@WitName("a") a: wit.Tuple2[C1, Z1]): wit.Tuple2[C1, Z1] = roundtrip(a)
 
-  @WitExport("component:testing/tests", "roundtrip-option")
-  def roundtripOption(a: Optional[String]): Optional[String] = roundtrip(a)
+  @WitExport(WitScope.unversioned("component", "testing", "tests"), "roundtrip-option")
+  def roundtripOption(@WitName("a") a: Optional[String]): Optional[String] = roundtrip(a)
 
-  @WitExport("component:testing/tests", "roundtrip-double-option")
-  def roundtripDoubleOption(a: Optional[Optional[String]]): Optional[Optional[String]] =
+  @WitExport(WitScope.unversioned("component", "testing", "tests"), "roundtrip-double-option")
+  def roundtripDoubleOption(
+      @WitName("a") a: Optional[Optional[String]]): Optional[Optional[String]] = {
+    roundtrip(a)
+  }
+
+  @WitExport(WitScope.unversioned("component", "testing", "tests"), "roundtrip-result")
+  def roundtripResult(@WitName("a") a: wit.Result[Unit, Unit]): wit.Result[Unit, Unit] = roundtrip(a)
+
+  @WitExport(WitScope.unversioned("component", "testing", "tests"), "roundtrip-string-error")
+  def roundtripStringError(@WitName("a") a: wit.Result[Float, String]): wit.Result[Float, String] =
     roundtrip(a)
 
-  @WitExport("component:testing/tests", "roundtrip-result")
-  def roundtripResult(a: wit.Result[Unit, Unit]): wit.Result[Unit, Unit] = roundtrip(a)
+  @WitExport(WitScope.unversioned("component", "testing", "tests"), "roundtrip-enum-error")
+  def roundtripEnumError(@WitName("a") a: wit.Result[C1, E1]): wit.Result[C1, E1] = roundtrip(a)
 
-  @WitExport("component:testing/tests", "roundtrip-string-error")
-  def roundtripStringError(a: wit.Result[Float, String]): wit.Result[Float, String] =
+  @WitExport(WitScope.unversioned("component", "testing", "tests"), "roundtrip-f1")
+  def roundtripF1(@WitName("a") a: F1): F1 = roundtrip(a)
+
+  @WitExport(WitScope.unversioned("component", "testing", "tests"), "roundtrip-f2")
+  def roundtripF2(@WitName("a") a: F2): F2 = roundtrip(a)
+
+  @WitExport(WitScope.unversioned("component", "testing", "tests"), "roundtrip-f3")
+  def roundtripF3(@WitName("a") a: F3): F3 = roundtrip(a)
+
+  @WitExport(WitScope.unversioned("component", "testing", "tests"), "roundtrip-flags")
+  def roundtripFlags(@WitName("a") a: wit.Tuple2[F1, F1]): wit.Tuple2[F1, F1] = roundtrip(a)
+
+  @WitExport(WitScope.unversioned("component", "testing", "tests"), "roundtrip-tuple2")
+  def roundtripTuple2(@WitName("a") a: wit.Tuple2[Int, String]): wit.Tuple2[Int, String] =
     roundtrip(a)
 
-  @WitExport("component:testing/tests", "roundtrip-enum-error")
-  def roundtripEnumError(a: wit.Result[C1, E1]): wit.Result[C1, E1] = roundtrip(a)
-
-  @WitExport("component:testing/tests", "roundtrip-f1")
-  def roundtripF1(a: F1): F1 = roundtrip(a)
-
-  @WitExport("component:testing/tests", "roundtrip-f2")
-  def roundtripF2(a: F2): F2 = roundtrip(a)
-
-  @WitExport("component:testing/tests", "roundtrip-f3")
-  def roundtripF3(a: F3): F3 = roundtrip(a)
-
-  @WitExport("component:testing/tests", "roundtrip-flags")
-  def roundtripFlags(a: wit.Tuple2[F1, F1]): wit.Tuple2[F1, F1] = roundtrip(a)
-
-  @WitExport("component:testing/tests", "roundtrip-tuple2")
-  def roundtripTuple2(a: wit.Tuple2[Int, String]): wit.Tuple2[Int, String] =
-    roundtrip(a)
-
-  @WitExport("component:testing/tests", "roundtrip-tuple3")
+  @WitExport(WitScope.unversioned("component", "testing", "tests"), "roundtrip-tuple3")
   def roundtripTuple3(
-      a: wit.Tuple3[Int, String, Boolean]): wit.Tuple3[Int, String, Boolean] = {
+      @WitName("a") a: wit.Tuple3[Int, String, Boolean]): wit.Tuple3[Int, String, Boolean] = {
     roundtrip(a)
   }
 

--- a/examples/test-component-model/src/main/scala/componentmodel/component/testing/basics.scala
+++ b/examples/test-component-model/src/main/scala/componentmodel/component/testing/basics.scala
@@ -6,37 +6,37 @@ import scala.scalajs.wit.annotation._
 package object basics {
 
   // Functions
-  @WitImport("component:testing/basics", "roundtrip-u8")
-  def roundtripU8(a: wit.unsigned.UByte): wit.unsigned.UByte = wit.native
+  @WitImport(WitScope.unversioned("component", "testing", "basics"), "roundtrip-u8")
+  def roundtripU8(@WitName("a") a: wit.unsigned.UByte): wit.unsigned.UByte = wit.native
 
-  @WitImport("component:testing/basics", "roundtrip-s8")
-  def roundtripS8(a: Byte): Byte = wit.native
+  @WitImport(WitScope.unversioned("component", "testing", "basics"), "roundtrip-s8")
+  def roundtripS8(@WitName("a") a: Byte): Byte = wit.native
 
-  @WitImport("component:testing/basics", "roundtrip-u16")
-  def roundtripU16(a: wit.unsigned.UShort): wit.unsigned.UShort = wit.native
+  @WitImport(WitScope.unversioned("component", "testing", "basics"), "roundtrip-u16")
+  def roundtripU16(@WitName("a") a: wit.unsigned.UShort): wit.unsigned.UShort = wit.native
 
-  @WitImport("component:testing/basics", "roundtrip-s16")
-  def roundtripS16(a: Short): Short = wit.native
+  @WitImport(WitScope.unversioned("component", "testing", "basics"), "roundtrip-s16")
+  def roundtripS16(@WitName("a") a: Short): Short = wit.native
 
-  @WitImport("component:testing/basics", "roundtrip-u32")
-  def roundtripU32(a: wit.unsigned.UInt): wit.unsigned.UInt = wit.native
+  @WitImport(WitScope.unversioned("component", "testing", "basics"), "roundtrip-u32")
+  def roundtripU32(@WitName("a") a: wit.unsigned.UInt): wit.unsigned.UInt = wit.native
 
-  @WitImport("component:testing/basics", "roundtrip-s32")
-  def roundtripS32(a: Int): Int = wit.native
+  @WitImport(WitScope.unversioned("component", "testing", "basics"), "roundtrip-s32")
+  def roundtripS32(@WitName("a") a: Int): Int = wit.native
 
-  @WitImport("component:testing/basics", "roundtrip-u64")
-  def roundtripU64(a: wit.unsigned.ULong): wit.unsigned.ULong = wit.native
+  @WitImport(WitScope.unversioned("component", "testing", "basics"), "roundtrip-u64")
+  def roundtripU64(@WitName("a") a: wit.unsigned.ULong): wit.unsigned.ULong = wit.native
 
-  @WitImport("component:testing/basics", "roundtrip-s64")
-  def roundtripS64(a: Long): Long = wit.native
+  @WitImport(WitScope.unversioned("component", "testing", "basics"), "roundtrip-s64")
+  def roundtripS64(@WitName("a") a: Long): Long = wit.native
 
-  @WitImport("component:testing/basics", "roundtrip-f32")
-  def roundtripF32(a: Float): Float = wit.native
+  @WitImport(WitScope.unversioned("component", "testing", "basics"), "roundtrip-f32")
+  def roundtripF32(@WitName("a") a: Float): Float = wit.native
 
-  @WitImport("component:testing/basics", "roundtrip-f64")
-  def roundtripF64(a: Double): Double = wit.native
+  @WitImport(WitScope.unversioned("component", "testing", "basics"), "roundtrip-f64")
+  def roundtripF64(@WitName("a") a: Double): Double = wit.native
 
-  @WitImport("component:testing/basics", "roundtrip-char")
-  def roundtripChar(a: Char): Char = wit.native
+  @WitImport(WitScope.unversioned("component", "testing", "basics"), "roundtrip-char")
+  def roundtripChar(@WitName("a") a: Char): Char = wit.native
 
 }

--- a/examples/test-component-model/src/main/scala/componentmodel/component/testing/countable.scala
+++ b/examples/test-component-model/src/main/scala/componentmodel/component/testing/countable.scala
@@ -6,7 +6,7 @@ import scala.scalajs.wit.annotation._
 package object countable {
 
   // Resources
-  @WitResourceImport("component:testing/countable", "counter")
+  @WitResourceImport(WitScope.unversioned("component", "testing", "countable"), "counter")
   final class Counter private () extends Object {
     @WitResourceMethod("up")
     def up(): Unit = wit.native
@@ -23,20 +23,20 @@ package object countable {
 
   object Counter {
     @WitResourceConstructor
-    def apply(i: Int): Counter = wit.native
+    def apply(@WitName("i") i: Int): Counter = wit.native
 
     /** TODO: make a and b borrow<bounter>
      *  otherwise ownership moves, and cannot use a,b afterwards
      */
     @WitResourceStaticMethod("sum")
-    def sum(a: Counter, b: Counter): Counter = wit.native
+    def sum(@WitName("a") a: Counter, @WitName("b") b: Counter): Counter = wit.native
   }
 
   // Functions
-  @WitImport("component:testing/countable", "try-create-counter")
-  def tryCreateCounter(value: Int): wit.Result[Counter, String] = wit.native
+  @WitImport(WitScope.unversioned("component", "testing", "countable"), "try-create-counter")
+  def tryCreateCounter(@WitName("value") value: Int): wit.Result[Counter, String] = wit.native
 
-  @WitImport("component:testing/countable", "maybe-get-counter")
+  @WitImport(WitScope.unversioned("component", "testing", "countable"), "maybe-get-counter")
   def maybeGetCounter(): java.util.Optional[Counter] = wit.native
 
 }

--- a/examples/test-component-model/src/main/scala/componentmodel/component/testing/tests.scala
+++ b/examples/test-component-model/src/main/scala/componentmodel/component/testing/tests.scala
@@ -6,8 +6,8 @@ import scala.scalajs.wit.annotation._
 package object tests {
 
   // Type definitions
-  @WitRecord
-  final class Point(val x: Int, val y: Int) {
+  @WitRecord(WitScope.unversioned("component", "testing", "tests"), "point")
+  final class Point(@WitName("x") val x: Int, @WitName("y") val y: Int) {
     override def equals(other: Any): Boolean = other match {
       case that: Point => this.x == that.x && this.y == that.y
       case _           => false
@@ -28,11 +28,12 @@ package object tests {
     def unapply(arg: Point): Some[(Int, Int)] = Some((arg.x, arg.y))
   }
 
-  @WitVariant
+  @WitVariant(WitScope.unversioned("component", "testing", "tests"), "c1")
   sealed trait C1
 
   object C1 {
-    final class A(val value: Int) extends C1 {
+    @WitName("a")
+    final class A(@WitName("value") val value: Int) extends C1 {
       override def equals(other: Any): Boolean = other match {
         case that: A => this.value == that.value
         case _       => false
@@ -49,7 +50,8 @@ package object tests {
       def unapply(arg: A): Some[Int] = Some(arg.value)
     }
 
-    final class B(val value: Float) extends C1 {
+    @WitName("b")
+    final class B(@WitName("value") val value: Float) extends C1 {
       override def equals(other: Any): Boolean = other match {
         case that: B => this.value == that.value
         case _       => false
@@ -67,11 +69,12 @@ package object tests {
     }
   }
 
-  @WitVariant
+  @WitVariant(WitScope.unversioned("component", "testing", "tests"), "z1")
   sealed trait Z1
 
   object Z1 {
-    final class A(val value: Int) extends Z1 {
+    @WitName("a")
+    final class A(@WitName("value") val value: Int) extends Z1 {
       override def equals(other: Any): Boolean = other match {
         case that: A => this.value == that.value
         case _       => false
@@ -88,29 +91,34 @@ package object tests {
       def unapply(arg: A): Some[Int] = Some(arg.value)
     }
 
+    @WitName("b")
     object B extends Z1 {
       override def toString(): String = "B"
     }
   }
 
-  @WitVariant
+  @WitEnum(WitScope.unversioned("component", "testing", "tests"), "e1")
   sealed trait E1
 
   object E1 {
+    @WitName("a")
     object A extends E1 {
       override def toString(): String = "A"
     }
 
+    @WitName("b")
     object B extends E1 {
       override def toString(): String = "B"
     }
 
+    @WitName("c")
     object C extends E1 {
       override def toString(): String = "C"
     }
   }
 
-  @WitFlags(8)
+  @WitFlags(WitScope.unversioned("component", "testing", "tests"), "f1",
+      Array("b0", "b1", "b2", "b3", "b4", "b5", "b6", "b7"))
   final class F1(val value: Int) {
     def |(other: F1): F1 = new F1(value | other.value)
     def &(other: F1): F1 = new F1(value & other.value)
@@ -142,7 +150,9 @@ package object tests {
     val b7 = new F1(1 << 7)
   }
 
-  @WitFlags(16)
+  @WitFlags(WitScope.unversioned("component", "testing", "tests"), "f2",
+      Array("b0", "b1", "b2", "b3", "b4", "b5", "b6", "b7",
+          "b8", "b9", "b10", "b11", "b12", "b13", "b14", "b15"))
   final class F2(val value: Int) {
     def |(other: F2): F2 = new F2(value | other.value)
     def &(other: F2): F2 = new F2(value & other.value)
@@ -182,7 +192,11 @@ package object tests {
     val b15 = new F2(1 << 15)
   }
 
-  @WitFlags(32)
+  @WitFlags(WitScope.unversioned("component", "testing", "tests"), "f3",
+      Array("b0", "b1", "b2", "b3", "b4", "b5", "b6", "b7",
+          "b8", "b9", "b10", "b11", "b12", "b13", "b14", "b15",
+          "b16", "b17", "b18", "b19", "b20", "b21", "b22", "b23",
+          "b24", "b25", "b26", "b27", "b28", "b29", "b30", "b31"))
   final class F3(val value: Int) {
     def |(other: F3): F3 = new F3(value | other.value)
     def &(other: F3): F3 = new F3(value & other.value)
@@ -242,74 +256,82 @@ package object tests {
   /** roundtrip-basics0: func(a: tuple<u32, s32>)
    *    -> tuple<u32, s32>;
    */
-  @WitImport("component:testing/tests", "roundtrip-basics1")
-  def roundtripBasics1(a: wit.Tuple9[wit.unsigned.UByte, Byte, wit.unsigned.UShort, Short,
+  @WitImport(WitScope.unversioned("component", "testing", "tests"), "roundtrip-basics1")
+  def roundtripBasics1(
+      @WitName("a") a: wit.Tuple9[wit.unsigned.UByte, Byte, wit.unsigned.UShort, Short,
           wit.unsigned.UInt, Int, Float, Double, Char]): wit.Tuple9[wit.unsigned.UByte, Byte,
       wit.unsigned.UShort, Short, wit.unsigned.UInt, Int, Float, Double, Char] = wit.native
 
-  @WitImport("component:testing/tests", "roundtrip-string")
-  def roundtripString(a: String): String = wit.native
+  @WitImport(WitScope.unversioned("component", "testing", "tests"), "roundtrip-string")
+  def roundtripString(@WitName("a") a: String): String = wit.native
 
-  @WitImport("component:testing/tests", "roundtrip-point")
-  def roundtripPoint(a: Point): Point = wit.native
+  @WitImport(WitScope.unversioned("component", "testing", "tests"), "roundtrip-point")
+  def roundtripPoint(@WitName("a") a: Point): Point = wit.native
 
-  @WitImport("component:testing/tests", "roundtrip-list-u16")
-  def roundtripListU16(a: Array[wit.unsigned.UShort]): Array[wit.unsigned.UShort] = wit.native
+  @WitImport(WitScope.unversioned("component", "testing", "tests"), "roundtrip-list-u16")
+  def roundtripListU16(@WitName("a") a: Array[wit.unsigned.UShort]): Array[wit.unsigned.UShort] =
+    wit.native
 
-  @WitImport("component:testing/tests", "roundtrip-list-point")
-  def roundtripListPoint(a: Array[Point]): Array[Point] = wit.native
+  @WitImport(WitScope.unversioned("component", "testing", "tests"), "roundtrip-list-point")
+  def roundtripListPoint(@WitName("a") a: Array[Point]): Array[Point] = wit.native
 
-  @WitImport("component:testing/tests", "roundtrip-list-variant")
-  def roundtripListVariant(a: Array[C1]): Array[C1] = wit.native
+  @WitImport(WitScope.unversioned("component", "testing", "tests"), "roundtrip-list-variant")
+  def roundtripListVariant(@WitName("a") a: Array[C1]): Array[C1] = wit.native
 
-  @WitImport("component:testing/tests", "test-c1")
-  def testC1(a: C1): Unit = wit.native
+  @WitImport(WitScope.unversioned("component", "testing", "tests"), "test-c1")
+  def testC1(@WitName("a") a: C1): Unit = wit.native
 
-  @WitImport("component:testing/tests", "roundtrip-c1")
-  def roundtripC1(a: C1): C1 = wit.native
+  @WitImport(WitScope.unversioned("component", "testing", "tests"), "roundtrip-c1")
+  def roundtripC1(@WitName("a") a: C1): C1 = wit.native
 
-  @WitImport("component:testing/tests", "roundtrip-z1")
-  def roundtripZ1(a: Z1): Z1 = wit.native
+  @WitImport(WitScope.unversioned("component", "testing", "tests"), "roundtrip-z1")
+  def roundtripZ1(@WitName("a") a: Z1): Z1 = wit.native
 
-  @WitImport("component:testing/tests", "roundtrip-enum")
-  def roundtripEnum(a: E1): E1 = wit.native
+  @WitImport(WitScope.unversioned("component", "testing", "tests"), "roundtrip-enum")
+  def roundtripEnum(@WitName("a") a: E1): E1 = wit.native
 
-  @WitImport("component:testing/tests", "roundtrip-tuple")
-  def roundtripTuple(a: wit.Tuple2[C1, Z1]): wit.Tuple2[C1, Z1] = wit.native
+  @WitImport(WitScope.unversioned("component", "testing", "tests"), "roundtrip-tuple")
+  def roundtripTuple(@WitName("a") a: wit.Tuple2[C1, Z1]): wit.Tuple2[C1, Z1] = wit.native
 
-  @WitImport("component:testing/tests", "roundtrip-option")
-  def roundtripOption(a: java.util.Optional[String]): java.util.Optional[String] = wit.native
+  @WitImport(WitScope.unversioned("component", "testing", "tests"), "roundtrip-option")
+  def roundtripOption(@WitName("a") a: java.util.Optional[String]): java.util.Optional[String] =
+    wit.native
 
-  @WitImport("component:testing/tests", "roundtrip-double-option")
-  def roundtripDoubleOption(a: java.util.Optional[java.util.Optional[String]]): java.util.Optional[
+  @WitImport(WitScope.unversioned("component", "testing", "tests"), "roundtrip-double-option")
+  def roundtripDoubleOption(
+      @WitName("a") a: java.util.Optional[java.util.Optional[String]]): java.util.Optional[
       java.util.Optional[String]] = wit.native
 
-  @WitImport("component:testing/tests", "roundtrip-f1")
-  def roundtripF1(a: F1): F1 = wit.native
+  @WitImport(WitScope.unversioned("component", "testing", "tests"), "roundtrip-f1")
+  def roundtripF1(@WitName("a") a: F1): F1 = wit.native
 
-  @WitImport("component:testing/tests", "roundtrip-f2")
-  def roundtripF2(a: F2): F2 = wit.native
+  @WitImport(WitScope.unversioned("component", "testing", "tests"), "roundtrip-f2")
+  def roundtripF2(@WitName("a") a: F2): F2 = wit.native
 
-  @WitImport("component:testing/tests", "roundtrip-f3")
-  def roundtripF3(a: F3): F3 = wit.native
+  @WitImport(WitScope.unversioned("component", "testing", "tests"), "roundtrip-f3")
+  def roundtripF3(@WitName("a") a: F3): F3 = wit.native
 
-  @WitImport("component:testing/tests", "roundtrip-flags")
-  def roundtripFlags(a: wit.Tuple2[F1, F1]): wit.Tuple2[F1, F1] = wit.native
+  @WitImport(WitScope.unversioned("component", "testing", "tests"), "roundtrip-flags")
+  def roundtripFlags(@WitName("a") a: wit.Tuple2[F1, F1]): wit.Tuple2[F1, F1] = wit.native
 
-  @WitImport("component:testing/tests", "roundtrip-result")
-  def roundtripResult(a: wit.Result[Unit, Unit]): wit.Result[Unit, Unit] = wit.native
+  @WitImport(WitScope.unversioned("component", "testing", "tests"), "roundtrip-result")
+  def roundtripResult(@WitName("a") a: wit.Result[Unit, Unit]): wit.Result[Unit, Unit] = wit.native
 
-  @WitImport("component:testing/tests", "roundtrip-string-error")
-  def roundtripStringError(a: wit.Result[Float, String]): wit.Result[Float, String] = wit.native
-
-  @WitImport("component:testing/tests", "roundtrip-enum-error")
-  def roundtripEnumError(a: wit.Result[C1, E1]): wit.Result[C1, E1] = wit.native
-
-  @WitImport("component:testing/tests", "roundtrip-tuple2")
-  def roundtripTuple2(a: wit.Tuple2[Int, String]): wit.Tuple2[Int, String] = wit.native
-
-  @WitImport("component:testing/tests", "roundtrip-tuple3")
-  def roundtripTuple3(a: wit.Tuple3[Int, String, Boolean]): wit.Tuple3[Int, String, Boolean] =
+  @WitImport(WitScope.unversioned("component", "testing", "tests"), "roundtrip-string-error")
+  def roundtripStringError(@WitName("a") a: wit.Result[Float, String]): wit.Result[Float, String] =
     wit.native
+
+  @WitImport(WitScope.unversioned("component", "testing", "tests"), "roundtrip-enum-error")
+  def roundtripEnumError(@WitName("a") a: wit.Result[C1, E1]): wit.Result[C1, E1] = wit.native
+
+  @WitImport(WitScope.unversioned("component", "testing", "tests"), "roundtrip-tuple2")
+  def roundtripTuple2(@WitName("a") a: wit.Tuple2[Int, String]): wit.Tuple2[Int, String] =
+    wit.native
+
+  @WitImport(WitScope.unversioned("component", "testing", "tests"), "roundtrip-tuple3")
+  def roundtripTuple3(
+      @WitName("a") a: wit.Tuple3[Int, String, Boolean]): wit.Tuple3[Int, String, Boolean] = {
+    wit.native
+  }
 
 }

--- a/examples/test-component-model/src/main/scala/componentmodel/package.scala
+++ b/examples/test-component-model/src/main/scala/componentmodel/package.scala
@@ -7,10 +7,10 @@ package object root {
 
   // World-level functions
   /** world level function imports */
-  @WitImport("$root", "bare-add")
-  def bareAdd(a: Int, b: Int): Int = wit.native
+  @WitImport(WitScope.root, "bare-add")
+  def bareAdd(@WitName("a") a: Int, @WitName("b") b: Int): Int = wit.native
 
-  @WitImport("$root", "bare-greet")
-  def bareGreet(name: String): String = wit.native
+  @WitImport(WitScope.root, "bare-greet")
+  def bareGreet(@WitName("name") name: String): String = wit.native
 
 }

--- a/examples/test-component-model/src/main/scala/componentmodel/wasi/cli/stdout.scala
+++ b/examples/test-component-model/src/main/scala/componentmodel/wasi/cli/stdout.scala
@@ -1,12 +1,12 @@
 package componentmodel.wasi.cli
 
+import componentmodel.wasi.io.streams.OutputStream
+import scala.scalajs.wit.annotation.{WitImport, WitScope}
+import scala.scalajs.wit.native
+
 package object stdout {
 
-  // Type definitions
-  type OutputStream = componentmodel.wasi.io.streams.OutputStream
-
-  // Functions
-  @scala.scalajs.wit.annotation.WitImport("wasi:cli/stdout@0.2.0", "get-stdout")
-  def getStdout(): OutputStream = scala.scalajs.wit.native
+  @WitImport(WitScope("wasi", "cli", "stdout", "0.2.0"), "get-stdout")
+  def getStdout(): OutputStream = native
 
 }

--- a/examples/test-component-model/src/main/scala/componentmodel/wasi/clocks/wall_clock.scala
+++ b/examples/test-component-model/src/main/scala/componentmodel/wasi/clocks/wall_clock.scala
@@ -1,11 +1,15 @@
 package componentmodel.wasi.clocks
 
+import scala.scalajs.wit.annotation.{WitImport, WitName, WitRecord, WitScope}
+import scala.scalajs.wit.native
+import scala.scalajs.wit.unsigned.{UInt, ULong}
+
 package object wall_clock {
 
-  // Type definitions
-  @scala.scalajs.wit.annotation.WitRecord
-  final class Datetime(val seconds: scala.scalajs.wit.unsigned.ULong,
-      val nanoseconds: scala.scalajs.wit.unsigned.UInt) {
+  @WitRecord(WitScope("wasi", "clocks", "wall-clock", "0.2.0"), "datetime")
+  final class Datetime(
+      @WitName("seconds") val seconds: ULong,
+      @WitName("nanoseconds") val nanoseconds: UInt) {
     override def equals(other: Any): Boolean = other match {
       case that: Datetime => this.seconds == that.seconds && this.nanoseconds == that.nanoseconds
       case _              => false
@@ -22,20 +26,16 @@ package object wall_clock {
   }
 
   object Datetime {
-    def apply(seconds: scala.scalajs.wit.unsigned.ULong,
-        nanoseconds: scala.scalajs.wit.unsigned.UInt): Datetime = new Datetime(seconds, nanoseconds)
+    def apply(seconds: ULong, nanoseconds: UInt): Datetime = new Datetime(seconds, nanoseconds)
 
-    def unapply(
-        arg: Datetime): Some[(scala.scalajs.wit.unsigned.ULong, scala.scalajs.wit.unsigned.UInt)] = {
+    def unapply(arg: Datetime): Some[(ULong, UInt)] =
       Some((arg.seconds, arg.nanoseconds))
-    }
   }
 
-  // Functions
-  @scala.scalajs.wit.annotation.WitImport("wasi:clocks/wall-clock@0.2.0", "now")
-  def now(): Datetime = scala.scalajs.wit.native
+  @WitImport(WitScope("wasi", "clocks", "wall-clock", "0.2.0"), "now")
+  def now(): Datetime = native
 
-  @scala.scalajs.wit.annotation.WitImport("wasi:clocks/wall-clock@0.2.0", "resolution")
-  def resolution(): Datetime = scala.scalajs.wit.native
+  @WitImport(WitScope("wasi", "clocks", "wall-clock", "0.2.0"), "resolution")
+  def resolution(): Datetime = native
 
 }

--- a/examples/test-component-model/src/main/scala/componentmodel/wasi/io/error.scala
+++ b/examples/test-component-model/src/main/scala/componentmodel/wasi/io/error.scala
@@ -1,15 +1,17 @@
 package componentmodel.wasi.io
 
+import scala.scalajs.wit.annotation.{WitResourceDrop, WitResourceImport, WitResourceMethod, WitScope}
+import scala.scalajs.wit.native
+
 package object error {
 
-  // Resources
-  @scala.scalajs.wit.annotation.WitResourceImport("wasi:io/error@0.2.0", "error")
+  @WitResourceImport(WitScope("wasi", "io", "error", "0.2.0"), "error")
   final class Error private () extends Object {
-    @scala.scalajs.wit.annotation.WitResourceMethod("to-debug-string")
-    def toDebugString(): String = scala.scalajs.wit.native
+    @WitResourceMethod("to-debug-string")
+    def toDebugString(): String = native
 
-    @scala.scalajs.wit.annotation.WitResourceDrop
-    def close(): Unit = scala.scalajs.wit.native
+    @WitResourceDrop
+    def close(): Unit = native
   }
 
   object Error {}

--- a/examples/test-component-model/src/main/scala/componentmodel/wasi/io/poll.scala
+++ b/examples/test-component-model/src/main/scala/componentmodel/wasi/io/poll.scala
@@ -1,24 +1,33 @@
 package componentmodel.wasi.io
 
+import scala.scalajs.wit.annotation.{
+  WitImport,
+  WitName,
+  WitResourceDrop,
+  WitResourceImport,
+  WitResourceMethod,
+  WitScope
+}
+import scala.scalajs.wit.native
+import scala.scalajs.wit.unsigned.UInt
+
 package object poll {
 
-  // Resources
-  @scala.scalajs.wit.annotation.WitResourceImport("wasi:io/poll@0.2.0", "pollable")
+  @WitResourceImport(WitScope("wasi", "io", "poll", "0.2.0"), "pollable")
   final class Pollable private () extends Object {
-    @scala.scalajs.wit.annotation.WitResourceMethod("ready")
-    def ready(): Boolean = scala.scalajs.wit.native
+    @WitResourceMethod("ready")
+    def ready(): Boolean = native
 
-    @scala.scalajs.wit.annotation.WitResourceMethod("block")
-    def block(): Unit = scala.scalajs.wit.native
+    @WitResourceMethod("block")
+    def block(): Unit = native
 
-    @scala.scalajs.wit.annotation.WitResourceDrop
-    def close(): Unit = scala.scalajs.wit.native
+    @WitResourceDrop
+    def close(): Unit = native
   }
 
   object Pollable {}
 
-  // Functions
-  @scala.scalajs.wit.annotation.WitImport("wasi:io/poll@0.2.0", "poll")
-  def poll(in: Array[Pollable]): Array[scala.scalajs.wit.unsigned.UInt] = scala.scalajs.wit.native
+  @WitImport(WitScope("wasi", "io", "poll", "0.2.0"), "poll")
+  def poll(@WitName("in") in: Array[Pollable]): Array[UInt] = native
 
 }

--- a/examples/test-component-model/src/main/scala/componentmodel/wasi/io/streams.scala
+++ b/examples/test-component-model/src/main/scala/componentmodel/wasi/io/streams.scala
@@ -1,17 +1,27 @@
 package componentmodel.wasi.io
 
+import componentmodel.wasi.io.error.Error
+import componentmodel.wasi.io.poll.Pollable
+import scala.scalajs.wit.Result
+import scala.scalajs.wit.annotation.{
+  WitName,
+  WitResourceDrop,
+  WitResourceImport,
+  WitResourceMethod,
+  WitScope,
+  WitVariant
+}
+import scala.scalajs.wit.native
+import scala.scalajs.wit.unsigned.{UByte, ULong}
+
 package object streams {
 
-  // Type definitions
-  type Error = componentmodel.wasi.io.error.Error
-
-  type Pollable = componentmodel.wasi.io.poll.Pollable
-
-  @scala.scalajs.wit.annotation.WitVariant
+  @WitVariant(WitScope("wasi", "io", "streams", "0.2.0"), "stream-error")
   sealed trait StreamError
 
   object StreamError {
-    final class LastOperationFailed(val value: Error) extends StreamError {
+    @WitName("last-operation-failed")
+    final class LastOperationFailed(@WitName("value") val value: Error) extends StreamError {
       override def equals(other: Any): Boolean = other match {
         case that: LastOperationFailed => this.value == that.value
         case _                         => false
@@ -28,86 +38,73 @@ package object streams {
       def unapply(arg: LastOperationFailed): Some[Error] = Some(arg.value)
     }
 
+    @WitName("closed")
     object Closed extends StreamError {
       override def toString(): String = "Closed"
     }
   }
 
-  // Resources
-  @scala.scalajs.wit.annotation.WitResourceImport("wasi:io/streams@0.2.0", "input-stream")
+  @WitResourceImport(WitScope("wasi", "io", "streams", "0.2.0"), "input-stream")
   final class InputStream private () extends Object {
-    @scala.scalajs.wit.annotation.WitResourceMethod("read")
-    def read(len: scala.scalajs.wit.unsigned.ULong): scala.scalajs.wit.Result[
-        Array[scala.scalajs.wit.unsigned.UByte], StreamError] = scala.scalajs.wit.native
+    @WitResourceMethod("read")
+    def read(@WitName("len") len: ULong): Result[Array[UByte], StreamError] = native
 
-    @scala.scalajs.wit.annotation.WitResourceMethod("blocking-read")
-    def blockingRead(len: scala.scalajs.wit.unsigned.ULong): scala.scalajs.wit.Result[
-        Array[scala.scalajs.wit.unsigned.UByte], StreamError] = scala.scalajs.wit.native
+    @WitResourceMethod("blocking-read")
+    def blockingRead(@WitName("len") len: ULong): Result[Array[UByte], StreamError] = native
 
-    @scala.scalajs.wit.annotation.WitResourceMethod("skip")
-    def skip(len: scala.scalajs.wit.unsigned.ULong): scala.scalajs.wit.Result[
-        scala.scalajs.wit.unsigned.ULong, StreamError] = scala.scalajs.wit.native
+    @WitResourceMethod("skip")
+    def skip(@WitName("len") len: ULong): Result[ULong, StreamError] = native
 
-    @scala.scalajs.wit.annotation.WitResourceMethod("blocking-skip")
-    def blockingSkip(len: scala.scalajs.wit.unsigned.ULong): scala.scalajs.wit.Result[
-        scala.scalajs.wit.unsigned.ULong, StreamError] = scala.scalajs.wit.native
+    @WitResourceMethod("blocking-skip")
+    def blockingSkip(@WitName("len") len: ULong): Result[ULong, StreamError] = native
 
-    @scala.scalajs.wit.annotation.WitResourceMethod("subscribe")
-    def subscribe(): Pollable = scala.scalajs.wit.native
+    @WitResourceMethod("subscribe")
+    def subscribe(): Pollable = native
 
-    @scala.scalajs.wit.annotation.WitResourceDrop
-    def close(): Unit = scala.scalajs.wit.native
+    @WitResourceDrop
+    def close(): Unit = native
   }
 
   object InputStream {}
 
-  @scala.scalajs.wit.annotation.WitResourceImport("wasi:io/streams@0.2.0", "output-stream")
+  @WitResourceImport(WitScope("wasi", "io", "streams", "0.2.0"), "output-stream")
   final class OutputStream private () extends Object {
-    @scala.scalajs.wit.annotation.WitResourceMethod("check-write")
-    def checkWrite(): scala.scalajs.wit.Result[scala.scalajs.wit.unsigned.ULong, StreamError] =
-      scala.scalajs.wit.native
+    @WitResourceMethod("check-write")
+    def checkWrite(): Result[ULong, StreamError] = native
 
-    @scala.scalajs.wit.annotation.WitResourceMethod("write")
-    def write(contents: Array[scala.scalajs.wit.unsigned.UByte]): scala.scalajs.wit.Result[Unit,
-        StreamError] = scala.scalajs.wit.native
+    @WitResourceMethod("write")
+    def write(@WitName("contents") contents: Array[UByte]): Result[Unit, StreamError] = native
 
-    @scala.scalajs.wit.annotation.WitResourceMethod("blocking-write-and-flush")
+    @WitResourceMethod("blocking-write-and-flush")
     def blockingWriteAndFlush(
-        contents: Array[scala.scalajs.wit.unsigned.UByte]): scala.scalajs.wit.Result[Unit,
-        StreamError] = scala.scalajs.wit.native
+        @WitName("contents") contents: Array[UByte]): Result[Unit, StreamError] = native
 
-    @scala.scalajs.wit.annotation.WitResourceMethod("flush")
-    def flush(): scala.scalajs.wit.Result[Unit, StreamError] = scala.scalajs.wit.native
+    @WitResourceMethod("flush")
+    def flush(): Result[Unit, StreamError] = native
 
-    @scala.scalajs.wit.annotation.WitResourceMethod("blocking-flush")
-    def blockingFlush(): scala.scalajs.wit.Result[Unit, StreamError] = scala.scalajs.wit.native
+    @WitResourceMethod("blocking-flush")
+    def blockingFlush(): Result[Unit, StreamError] = native
 
-    @scala.scalajs.wit.annotation.WitResourceMethod("subscribe")
-    def subscribe(): Pollable = scala.scalajs.wit.native
+    @WitResourceMethod("subscribe")
+    def subscribe(): Pollable = native
 
-    @scala.scalajs.wit.annotation.WitResourceMethod("write-zeroes")
-    def writeZeroes(
-        len: scala.scalajs.wit.unsigned.ULong): scala.scalajs.wit.Result[Unit, StreamError] = {
-      scala.scalajs.wit.native
-    }
+    @WitResourceMethod("write-zeroes")
+    def writeZeroes(@WitName("len") len: ULong): Result[Unit, StreamError] = native
 
-    @scala.scalajs.wit.annotation.WitResourceMethod("blocking-write-zeroes-and-flush")
+    @WitResourceMethod("blocking-write-zeroes-and-flush")
     def blockingWriteZeroesAndFlush(
-        len: scala.scalajs.wit.unsigned.ULong): scala.scalajs.wit.Result[Unit, StreamError] = {
-      scala.scalajs.wit.native
-    }
+        @WitName("len") len: ULong): Result[Unit, StreamError] = native
 
-    @scala.scalajs.wit.annotation.WitResourceMethod("splice")
-    def splice(src: InputStream, len: scala.scalajs.wit.unsigned.ULong): scala.scalajs.wit.Result[
-        scala.scalajs.wit.unsigned.ULong, StreamError] = scala.scalajs.wit.native
+    @WitResourceMethod("splice")
+    def splice(@WitName("src") src: InputStream,
+        @WitName("len") len: ULong): Result[ULong, StreamError] = native
 
-    @scala.scalajs.wit.annotation.WitResourceMethod("blocking-splice")
-    def blockingSplice(src: InputStream,
-        len: scala.scalajs.wit.unsigned.ULong): scala.scalajs.wit.Result[
-        scala.scalajs.wit.unsigned.ULong, StreamError] = scala.scalajs.wit.native
+    @WitResourceMethod("blocking-splice")
+    def blockingSplice(@WitName("src") src: InputStream,
+        @WitName("len") len: ULong): Result[ULong, StreamError] = native
 
-    @scala.scalajs.wit.annotation.WitResourceDrop
-    def close(): Unit = scala.scalajs.wit.native
+    @WitResourceDrop
+    def close(): Unit = native
   }
 
   object OutputStream {}

--- a/ir/shared/src/main/scala/org/scalajs/ir/Hashers.scala
+++ b/ir/shared/src/main/scala/org/scalajs/ir/Hashers.scala
@@ -134,7 +134,8 @@ object Hashers {
     val newTopLevelExportDefs = topLevelExportDefs.map(hashTopLevelExportDef(_))
     ClassDef(name, originalName, kind, jsClassCaptures, superClass, interfaces,
         jsSuperClass, jsNativeLoadSpec, fields, newMethods, newJSConstructorDef,
-        newExportedMembers, jsNativeMembers, witNativeMembers, newTopLevelExportDefs)(
+        newExportedMembers, jsNativeMembers, witTypeDef, witNativeMembers,
+        newTopLevelExportDefs)(
         optimizerHints)
   }
 

--- a/ir/shared/src/main/scala/org/scalajs/ir/Printers.scala
+++ b/ir/shared/src/main/scala/org/scalajs/ir/Printers.scala
@@ -1127,13 +1127,13 @@ object Printers {
           print(" loadfrom ")
           print(jsNativeLoadSpec)
 
-        case WitNativeMemberDef(flags, module, name,
-                method, tpe) =>
+        case WitNativeMemberDef(flags, scope, name,
+                method, signature) =>
           print(flags.namespace.prefixString)
           print("wit ")
           print(method)
           print(" importfrom \"")
-          printEscapeJS(module, out)
+          printEscapeJS(WitScope.importModuleName(scope), out)
           print("\" ")
           printWitFunctionName(name)
       }
@@ -1165,7 +1165,7 @@ object Printers {
           printEscapeJS(exportName, out)
           print("\"")
 
-        case WitExportDef(moduleName, name, methodDef, signature) =>
+        case WitExportDef(scope, name, methodDef, signature) =>
           // TODO
           // var first = true
           // for (ty <- paramTypes) {

--- a/ir/shared/src/main/scala/org/scalajs/ir/ScalaJSVersions.scala
+++ b/ir/shared/src/main/scala/org/scalajs/ir/ScalaJSVersions.scala
@@ -20,7 +20,7 @@ import Nullables._
 
 object ScalaJSVersions extends VersionChecks(
       current = "1.22.1-wasm.4-SNAPSHOT",
-      binaryEmitted = "1.22"
+      binaryEmitted = "1.22+wasm"
     ) {
   final val organization = "io.github.scala-wasm"
 }
@@ -85,8 +85,8 @@ class VersionChecks private[ir] (
 }
 
 private object VersionChecks {
-  private val fullRE = """^([0-9]+)\.([0-9]+)\.([0-9]+)(-.*)?$""".r
-  private val binaryRE = """^([0-9]+)\.([0-9]+)(-.*)?$""".r
+  private val fullRE = """^([0-9]+)\.([0-9]+)\.([0-9]+)(-[^+]+)?(\+.*)?$""".r
+  private val binaryRE = """^([0-9]+)\.([0-9]+)(-[^+]+)?(\+.*)?$""".r
 
   private def parseBinary(v: String): (Int, Int, Option[String]) = {
     val m = mustMatch(binaryRE, v)

--- a/ir/shared/src/main/scala/org/scalajs/ir/Serializers.scala
+++ b/ir/shared/src/main/scala/org/scalajs/ir/Serializers.scala
@@ -679,6 +679,8 @@ object Serializers {
       writeClassIdents(interfaces)
       writeOptTree(jsSuperClass)
       writeJSNativeLoadSpec(jsNativeLoadSpec)
+      writeBoolean(witTypeDef.isDefined)
+      witTypeDef.foreach(writeWITTypeDef)
       writeMemberDefs(
           fields ::: methods ::: jsConstructor.toList ::: jsMethodProps ::: jsNativeMembers
           ::: witNativeMembers)
@@ -798,11 +800,11 @@ object Serializers {
           writeMethodIdent(name)
           writeJSNativeLoadSpec(Some(jsNativeLoadSpec))
 
-        case WitNativeMemberDef(flags, moduleName, name,
+        case WitNativeMemberDef(flags, scope, name,
                 method, signature) =>
           writeByte(TagWitNativeMemberDef)
           writeInt(MemberFlags.toBits(flags))
-          writeString(moduleName)
+          writeWitScope(scope)
           writeWitFunctionName(name)
           writeMethodIdent(method)
           writeWITType(signature)
@@ -834,9 +836,9 @@ object Serializers {
           writeByte(TagTopLevelFieldExportDef)
           writeString(moduleID); writeString(exportName); writeFieldIdentForEnclosingClass(field)
 
-        case WitExportDef(moduleName, name, methodDef, signature) =>
+        case WitExportDef(scope, name, methodDef, signature) =>
           writeByte(TagWitExportDef)
-          writeString(moduleName)
+          writeWitScope(scope)
           writeWitFunctionName(name)
           writeMemberDef(methodDef)
           writeWITType(signature)
@@ -991,6 +993,21 @@ object Serializers {
       tpes.foreach(writeType)
     }
 
+    def writeWitScope(scope: WitScope): Unit = scope match {
+      case WitScope.Interface(namespace, packageName, name, version) =>
+        buffer.writeByte(TagWitScopeInterface)
+        writeString(namespace)
+        writeString(packageName)
+        writeString(name)
+        buffer.writeBoolean(version.isDefined)
+        version.foreach(writeString)
+      case WitScope.Inline(name) =>
+        buffer.writeByte(TagWitScopeInline)
+        writeString(name)
+      case WitScope.Root =>
+        buffer.writeByte(TagWitScopeRoot)
+    }
+
     def writeWITType(tpe: wit.WasmInterfaceType): Unit = tpe match {
       case wit.BoolType                   => buffer.writeByte(TagWITBoolType)
       case wit.U8Type                     => buffer.writeByte(TagWITU8Type)
@@ -1010,32 +1027,21 @@ object Serializers {
         writeWITType(elemType)
         buffer.writeBoolean(length.isDefined)
         length.foreach(buffer.writeInt)
-      case wit.RecordType(className, fields) =>
+      case wit.RecordTypeRef(className) =>
         buffer.writeByte(TagWITRecordType)
         writeName(className)
-        buffer.writeInt(fields.size)
-        for (f <- fields) {
-          writeFieldName(f.label)
-          writeWITType(f.tpe)
-        }
       case wit.TupleType(fields) =>
         buffer.writeByte(TagWITTupleType)
         buffer.writeInt(fields.size)
         for (f <- fields) {
           writeWITType(f)
         }
-      case wit.VariantType(className, cases) =>
+      case wit.VariantTypeRef(className) =>
         buffer.writeByte(TagWITVariantType)
         writeName(className)
-        buffer.writeInt(cases.length)
-        for (c <- cases) {
-          writeName(c.className)
-          buffer.writeBoolean(c.tpe.isDefined)
-          c.tpe.foreach(writeWITType)
-        }
-      case wit.EnumType(_) =>
+      case wit.EnumTypeRef(className) =>
         buffer.writeByte(TagWITEnumType)
-        ???
+        writeName(className)
       case wit.OptionType(t) =>
         buffer.writeByte(TagWITOptionType)
         writeWITType(t)
@@ -1045,17 +1051,23 @@ object Serializers {
         ok.foreach(writeWITType)
         buffer.writeBoolean(err.isDefined)
         err.foreach(writeWITType)
-      case wit.FlagsType(className, numFlags) =>
+      case wit.FlagsTypeRef(className) =>
         buffer.writeByte(TagWITFlagsType)
         writeName(className)
-        buffer.writeInt(numFlags)
-      case wit.ResourceType(className) =>
+      case wit.ResourceType(className, ownership) =>
         buffer.writeByte(TagWITResourceType)
         writeName(className)
+        buffer.writeByte(ownership match {
+          case ResourceOwnership.Own    => 0
+          case ResourceOwnership.Borrow => 1
+        })
       case wit.FuncType(params, result) =>
         buffer.writeByte(TagWITFuncType)
         buffer.writeInt(params.length)
-        for (p <- params) writeWITType(p)
+        for (p <- params) {
+          writeString(p.name)
+          writeWITType(p.tpe)
+        }
         result match {
           case Some(result) =>
             buffer.writeBoolean(true)
@@ -1063,6 +1075,54 @@ object Serializers {
           case None =>
             buffer.writeBoolean(false)
         }
+    }
+
+    def writeWITTypeDef(tpe: WitTypeDef): Unit = tpe match {
+      case WitTypeDef.Record(className, scope, name, fields) =>
+        buffer.writeByte(TagWITRecordTypeDef)
+        writeName(className)
+        writeWitScope(scope)
+        writeString(name)
+        buffer.writeInt(fields.size)
+        for (f <- fields) {
+          writeFieldName(f.label)
+          writeString(f.name)
+          writeWITType(f.tpe)
+        }
+      case WitTypeDef.Variant(className, scope, name, cases) =>
+        buffer.writeByte(TagWITVariantTypeDef)
+        writeName(className)
+        writeWitScope(scope)
+        writeString(name)
+        buffer.writeInt(cases.length)
+        for (c <- cases) {
+          writeName(c.className)
+          writeString(c.name)
+          buffer.writeBoolean(c.tpe.isDefined)
+          c.tpe.foreach(writeWITType)
+        }
+      case WitTypeDef.Enum(className, scope, name, cases) =>
+        buffer.writeByte(TagWITEnumTypeDef)
+        writeName(className)
+        writeWitScope(scope)
+        writeString(name)
+        buffer.writeInt(cases.size)
+        for (c <- cases) {
+          writeName(c.className)
+          writeString(c.name)
+        }
+      case WitTypeDef.Flags(className, scope, name, names) =>
+        buffer.writeByte(TagWITFlagsTypeDef)
+        writeName(className)
+        writeWitScope(scope)
+        writeString(name)
+        buffer.writeInt(names.size)
+        names.foreach(writeString)
+      case WitTypeDef.Resource(resource) =>
+        buffer.writeByte(TagWITResourceTypeDef)
+        writeName(resource.className)
+        writeWitScope(resource.scope)
+        writeString(resource.name)
     }
 
     def writeTypeRef(typeRef: TypeRef): Unit = typeRef match {
@@ -1900,6 +1960,11 @@ object Serializers {
       val jsSuperClass = readOptTree()
 
       val jsNativeLoadSpec = readJSNativeLoadSpec()
+      val witTypeDef = {
+        if (!hacks.isWasmIR) None
+        else if (readBoolean()) Some(readWITTypeDef())
+        else None
+      }
 
       // Read member defs
       val fieldsBuilder = List.newBuilder[AnyFieldDef]
@@ -1956,7 +2021,7 @@ object Serializers {
 
       val classDef = ClassDef(name, originalName, kind, jsClassCaptures, superClass, parents,
           jsSuperClass, jsNativeLoadSpec, fields, methods, jsConstructor,
-          jsMethodProps, jsNativeMembers, witNativeMembers, topLevelExportDefs)(
+          jsMethodProps, jsNativeMembers, witTypeDef, witNativeMembers, topLevelExportDefs)(
           optimizerHints)
 
       if (hacks.useBelow(19))
@@ -2332,6 +2397,7 @@ object Serializers {
           jsConstructor,
           jsMethodProps,
           jsNativeMembers,
+          witTypeDef,
           witNativeMembers,
           topLevelExportDefs
         )(OptimizerHints.empty)(pos) // throws away the `@inline`
@@ -2531,11 +2597,11 @@ object Serializers {
 
     private def readWitNativeMemberDef()(implicit pos: Position): WitNativeMemberDef = {
       val flags = MemberFlags.fromBits(readInt())
-      val moduleName = readString()
+      val scope = readWitScope()
       val name = readWitFunctionName()
       val methodIdent = readMethodIdent()
       val signature = readWITFuncType()
-      WitNativeMemberDef(flags, moduleName, name, methodIdent, signature)
+      WitNativeMemberDef(flags, scope, name, methodIdent, signature)
     }
 
     /* #4442 and #4601: Patch Labeled, If, Match and TryCatch nodes in
@@ -2627,7 +2693,7 @@ object Serializers {
           TopLevelFieldExportDef(readModuleID(), readString(), readFieldIdentForEnclosingClass())
 
         case TagWitExportDef =>
-          val moduleName = readString()
+          val scope = readWitScope()
           val name = readWitFunctionName()
           // read methoddef
           val methodPos = readPosition()
@@ -2636,7 +2702,7 @@ object Serializers {
           val methodDef = readMethodDef(owner, ownerKind)(methodPos)
 
           val signature = readWITFuncType()
-          WitExportDef(moduleName, name, methodDef, signature)
+          WitExportDef(scope, name, methodDef, signature)
       }
     }
 
@@ -2731,9 +2797,27 @@ object Serializers {
       val tag = readByte()
       assert(tag == TagWITFuncType)
       wit.FuncType(
-        List.fill(readInt())(readWITType()),
+        List.fill(readInt()) {
+          val name = readString()
+          wit.ParamType(name, readWITType())
+        },
         if (readBoolean()) Some(readWITType()) else None
       )
+    }
+
+    private def readWitScope(): WitScope = {
+      readByte() match {
+        case TagWitScopeInterface =>
+          val namespace = readString()
+          val packageName = readString()
+          val name = readString()
+          val version = if (readBoolean()) Some(readString()) else None
+          WitScope.Interface(namespace, packageName, name, version)
+        case TagWitScopeInline =>
+          WitScope.Inline(readString())
+        case TagWitScopeRoot =>
+          WitScope.Root
+      }
     }
 
     private def readWITType(): wit.ValType = {
@@ -2763,21 +2847,11 @@ object Serializers {
           )
 
         case TagWITRecordType =>
-          wit.RecordType(
-            readClassName(),
-            List.fill(readInt())(wit.FieldType(readFieldName(), readWITType()))
-          )
+          wit.RecordTypeRef(readClassName())
         case TagWITVariantType =>
-          wit.VariantType(
-            readClassName(),
-            List.fill(readInt()) {
-              val className = readClassName()
-              val hasTpe = readBoolean()
-              val tpe = if (hasTpe) Some(readWITType()) else None
-              wit.CaseType(className, tpe)
-            }
-          )
-        case TagWITEnumType   => ???
+          wit.VariantTypeRef(readClassName())
+        case TagWITEnumType =>
+          wit.EnumTypeRef(readClassName())
         case TagWITOptionType =>
           wit.OptionType(readWITType())
         case TagWITResultType =>
@@ -2785,10 +2859,66 @@ object Serializers {
           val err = if (readBoolean()) Some(readWITType()) else None
           wit.ResultType(ok, err)
         case TagWITFlagsType =>
+          wit.FlagsTypeRef(readClassName())
+        case TagWITResourceType =>
           val className = readClassName()
-          val numFlags = readInt()
-          wit.FlagsType(className, numFlags)
-        case TagWITResourceType => wit.ResourceType(readClassName())
+          val ownership = readByte() match {
+            case 0 => ResourceOwnership.Own
+            case 1 => ResourceOwnership.Borrow
+          }
+          wit.ResourceType(className, ownership)
+      }
+    }
+
+    private def readWITTypeDef(): WitTypeDef = {
+      readByte() match {
+        case TagWITRecordTypeDef =>
+          val className = readClassName()
+          val scope = readWitScope()
+          val name = readString()
+          WitTypeDef.Record(
+            className,
+            scope,
+            name,
+            List.fill(readInt()) {
+              val label = readFieldName()
+              val name = readString()
+              wit.FieldType(label, name, readWITType())
+            }
+          )
+        case TagWITVariantTypeDef =>
+          val className = readClassName()
+          val scope = readWitScope()
+          val name = readString()
+          WitTypeDef.Variant(
+            className,
+            scope,
+            name,
+            List.fill(readInt()) {
+              val className = readClassName()
+              val name = readString()
+              val hasTpe = readBoolean()
+              val tpe = if (hasTpe) Some(readWITType()) else None
+              wit.CaseType(className, name, tpe)
+            }
+          )
+        case TagWITEnumTypeDef =>
+          val className = readClassName()
+          val scope = readWitScope()
+          val name = readString()
+          WitTypeDef.Enum(className, scope, name, List.fill(readInt()) {
+            wit.CaseType(readClassName(), readString(), None)
+          })
+        case TagWITFlagsTypeDef =>
+          val className = readClassName()
+          val scope = readWitScope()
+          val name = readString()
+          WitTypeDef.Flags(className, scope, name, List.fill(readInt())(readString()))
+        case TagWITResourceTypeDef =>
+          val className = readClassName()
+          val scope = readWitScope()
+          val name = readString()
+          WitTypeDef.Resource(wit.ResourceRef(className, scope, name))
       }
     }
 
@@ -3122,6 +3252,9 @@ object Serializers {
     /** Should we use the hacks to migrate from an IR version below `targetVersion`? */
     def useBelow(targetVersion: Int): Boolean =
       fromVersion < targetVersion
+
+    /** Whether this IR file was emitted by the scala-wasm fork. */
+    def isWasmIR: Boolean = sourceVersion.contains("+wasm")
   }
 
   /** Names needed for hacks. */

--- a/ir/shared/src/main/scala/org/scalajs/ir/Tags.scala
+++ b/ir/shared/src/main/scala/org/scalajs/ir/Tags.scala
@@ -236,6 +236,10 @@ private[ir] object Tags {
   final val TagJSNativeLoadSpecImportWithGlobalFallback = TagJSNativeLoadSpecImport + 1
 
   // Tags for Wasm Interface Types
+  final val TagWitScopeInterface = 0
+  final val TagWitScopeInline = TagWitScopeInterface + 1
+  final val TagWitScopeRoot = TagWitScopeInline + 1
+
   final val TagWITVoidType = 0
   final val TagWITBoolType = TagWITVoidType + 1
   final val TagWITU8Type = TagWITBoolType + 1
@@ -262,6 +266,11 @@ private[ir] object Tags {
   final val TagWITFlagsType = TagWITResultType + 1
   final val TagWITResourceType = TagWITFlagsType + 1
   final val TagWITFuncType = TagWITResourceType + 1
+  final val TagWITRecordTypeDef = TagWITFuncType + 1
+  final val TagWITVariantTypeDef = TagWITRecordTypeDef + 1
+  final val TagWITEnumTypeDef = TagWITVariantTypeDef + 1
+  final val TagWITFlagsTypeDef = TagWITEnumTypeDef + 1
+  final val TagWITResourceTypeDef = TagWITFlagsTypeDef + 1
 
   // Tags for wasm Component Function kind
 

--- a/ir/shared/src/main/scala/org/scalajs/ir/Transformers.scala
+++ b/ir/shared/src/main/scala/org/scalajs/ir/Transformers.scala
@@ -233,6 +233,7 @@ object Transformers {
         jsConstructor.map(transformJSConstructorDef),
         jsMethodProps.map(transformJSMethodPropDef),
         jsNativeMembers,
+        witTypeDef,
         witNativeMembers,
         topLevelExportDefs.map(transformTopLevelExportDef)
       )(

--- a/ir/shared/src/main/scala/org/scalajs/ir/Trees.scala
+++ b/ir/shared/src/main/scala/org/scalajs/ir/Trees.scala
@@ -1492,6 +1492,11 @@ object Trees {
       val jsConstructor: Option[JSConstructorDef],
       val jsMethodProps: List[JSMethodPropDef],
       val jsNativeMembers: List[JSNativeMemberDef],
+      /** WIT named type definition represented by this class.
+       *
+       *  Currently, only relevant for WIT record, variant, enum, flags and resource.
+       */
+      val witTypeDef: Option[WitTypeDef],
       val witNativeMembers: List[WitNativeMemberDef],
       val topLevelExportDefs: List[TopLevelExportDef]
   )(
@@ -1516,6 +1521,7 @@ object Trees {
         jsConstructor: Option[JSConstructorDef],
         jsMethodProps: List[JSMethodPropDef],
         jsNativeMembers: List[JSNativeMemberDef],
+        witTypeDef: Option[WitTypeDef],
         witNativeMembers: List[WitNativeMemberDef],
         topLevelExportDefs: List[TopLevelExportDef]
     )(
@@ -1523,7 +1529,7 @@ object Trees {
         implicit pos: Position): ClassDef = {
       new ClassDef(name, originalName, kind, jsClassCaptures, superClass,
           interfaces, jsSuperClass, jsNativeLoadSpec, fields, methods,
-          jsConstructor, jsMethodProps, jsNativeMembers,
+          jsConstructor, jsMethodProps, jsNativeMembers, witTypeDef,
           witNativeMembers, topLevelExportDefs)(
           optimizerHints)
     }
@@ -1600,12 +1606,38 @@ object Trees {
       extends MemberDef
 
   sealed case class WitNativeMemberDef(flags: MemberFlags,
-      moduleName: String, name: WitFunctionName, method: MethodIdent,
+      scope: WitScope, name: WitFunctionName,
+      method: MethodIdent,
       signature: WasmInterfaceTypes.FuncType)(
       implicit val pos: Position)
       extends MemberDef
 
-  sealed abstract class WitFunctionName {}
+  sealed abstract class WitFunctionName {
+
+    /** Plain WIT function (not tied to a resource). */
+    final def isFunction: Boolean = this match {
+      case _: WitFunctionName.Function => true
+      case _                           => false
+    }
+
+    /** Resource instance/static method or constructor (not drop). */
+    final def isResourceMethod: Boolean = this match {
+      case _:WitFunctionName.ResourceMethod | _:WitFunctionName.ResourceStaticMethod |
+          _:WitFunctionName.ResourceConstructor =>
+        true
+      case _ =>
+        false
+    }
+
+    /** Resource name for resource-tied functions. `None` for plain functions. */
+    final def resourceName: Option[String] = this match {
+      case WitFunctionName.ResourceMethod(_, resource)       => Some(resource)
+      case WitFunctionName.ResourceStaticMethod(_, resource) => Some(resource)
+      case WitFunctionName.ResourceConstructor(resource)     => Some(resource)
+      case WitFunctionName.ResourceDrop(resource)            => Some(resource)
+      case _: WitFunctionName.Function                       => None
+    }
+  }
 
   object WitFunctionName {
     final case class Function(func: String) extends WitFunctionName
@@ -1613,6 +1645,15 @@ object Trees {
     final case class ResourceStaticMethod(func: String, resource: String) extends WitFunctionName
     final case class ResourceConstructor(resource: String) extends WitFunctionName
     final case class ResourceDrop(resource: String) extends WitFunctionName
+
+    /** Core Wasm import/export name used for component-model linking. */
+    def wasmName(name: WitFunctionName): String = name match {
+      case Function(func)                       => func
+      case ResourceMethod(func, resource)       => s"[method]$resource.$func"
+      case ResourceStaticMethod(func, resource) => s"[static]$resource.$func"
+      case ResourceConstructor(resource)        => s"[constructor]$resource"
+      case ResourceDrop(resource)               => s"[resource-drop]$resource"
+    }
   }
 
   // Top-level export defs
@@ -1630,19 +1671,9 @@ object Trees {
         val StringLiteral(name) = propName: @unchecked // unchecked is needed for Scala 3.2+
         name
 
-      case TopLevelFieldExportDef(_, name, _)   => name
-      case WitExportDef(moduleName, name, _, _) => name match {
-          case WitFunctionName.Function(func) =>
-            s"$moduleName#$func"
-          case WitFunctionName.ResourceMethod(func, resource) =>
-            s"$moduleName#[method]$resource.$func"
-          case WitFunctionName.ResourceStaticMethod(func, resource) =>
-            s"$moduleName#[static]$resource.$func"
-          case WitFunctionName.ResourceConstructor(resource) =>
-            s"$moduleName#[constructor]$resource"
-          case WitFunctionName.ResourceDrop(resource) =>
-            s"$moduleName#[resource-drop]$resource"
-        }
+      case TopLevelFieldExportDef(_, name, _) => name
+      case WitExportDef(scope, name, _, _)    =>
+        WitScope.exportName(scope, WitFunctionName.wasmName(name))
     }
 
     val isWitExport = this.isInstanceOf[WitExportDef]
@@ -1683,7 +1714,7 @@ object Trees {
    *  This is compiled to a static forwarder for component model export that contains
    *  Canonical ABI conversion and calls the method.
    */
-  sealed case class WitExportDef(moduleName: String,
+  sealed case class WitExportDef(scope: WitScope,
       name: WitFunctionName, methodDef: MethodDef,
       signature: WasmInterfaceTypes.FuncType)(
       implicit val pos: Position)

--- a/ir/shared/src/main/scala/org/scalajs/ir/WasmInterfaceTypes.scala
+++ b/ir/shared/src/main/scala/org/scalajs/ir/WasmInterfaceTypes.scala
@@ -5,6 +5,7 @@ import WellKnownNames._
 import org.scalajs.ir.{Types => jstpe}
 
 object WasmInterfaceTypes {
+
   sealed trait WasmInterfaceType
 
   sealed trait ValType extends WasmInterfaceType {
@@ -96,10 +97,15 @@ object WasmInterfaceTypes {
   }
 
   /** label won't be used in load/store with memory or stack, used for Analyzer */
-  final case class FieldType(label: FieldName, tpe: ValType)
+  final case class FieldType(label: FieldName, name: String, tpe: ValType)
 
-  /** className is required for loading data back to Scala class */
-  final case class RecordType(className: ClassName, fields: List[FieldType]) extends FundamentalType {
+  object FieldType {
+    def apply(label: FieldName, tpe: ValType): FieldType =
+      FieldType(label, "", tpe)
+  }
+
+  /** Reference to a named WIT record. Definition is on `ClassDef.witTypeDef`. */
+  final case class RecordTypeRef(className: ClassName) extends FundamentalType {
     def toIRType(): jstpe.Type = jstpe.ClassType(className, true, false)
   }
 
@@ -108,12 +114,12 @@ object WasmInterfaceTypes {
       jstpe.ClassType(ClassName("scala.scalajs.wit.Tuple" + ts.size), true, false)
   }
 
-  final case class CaseType(className: ClassName, tpe: Option[ValType]) {
+  final case class CaseType(className: ClassName, name: String, tpe: Option[ValType]) {
     def toIRType(): jstpe.Type = jstpe.ClassType(className, true, false)
   }
 
-  final case class VariantType(className: ClassName, cases: List[CaseType])
-      extends FundamentalType {
+  /** Reference to a named WIT variant. Definition is on `ClassDef.witTypeDef`. */
+  final case class VariantTypeRef(className: ClassName) extends FundamentalType {
     def toIRType(): jstpe.Type = jstpe.ClassType(className, true, false)
   }
 
@@ -121,25 +127,50 @@ object WasmInterfaceTypes {
     def toIRType(): jstpe.Type = jstpe.ClassType(ComponentResultClass, true, false)
   }
 
-  final case class EnumType(labels: List[String]) extends SpecializedType {
-    override def toIRType(): jstpe.Type = ???
+  /** Reference to a named WIT enum. Definition is on `ClassDef.witTypeDef`. */
+  final case class EnumTypeRef(className: ClassName) extends SpecializedType {
+    override def toIRType(): jstpe.Type = jstpe.ClassType(className, true, false)
   }
 
   final case class OptionType(tpe: ValType) extends SpecializedType {
     def toIRType(): jstpe.Type = jstpe.ClassType(juOptionalClass, true, false)
   }
 
-  final case class FlagsType(className: ClassName, numFields: Int) extends FundamentalType {
+  /** Reference to a named WIT flags. Definition is on `ClassDef.witTypeDef`. */
+  final case class FlagsTypeRef(className: ClassName) extends FundamentalType {
     def toIRType(): jstpe.Type = jstpe.ClassType(className, nullable = true, exact = false)
   }
 
-  final case class ResourceType(className: ClassName) extends FundamentalType {
+  /** A WIT resource declaration, without handle ownership.
+   *
+   *  For example, `streams/input-stream` in:
+   *
+   *  ```
+   *  package wasi:io@0.2.0;
+   *  interface streams {
+   *    resource input-stream;
+   *  }
+   *  ```
+   *
+   *  Used on `WitTypeDef.Resource`. Value types use `ResourceType`.
+   */
+  final case class ResourceRef(className: ClassName, scope: WitScope, name: String)
+
+  /** A WIT resource handle value type (`own<r>` or `borrow<r>`).
+   *
+   *  Scope and WIT name live on `WitTypeDef.Resource` for `className`.
+   */
+  final case class ResourceType(className: ClassName, ownership: ResourceOwnership)
+      extends FundamentalType {
     def toIRType(): jstpe.Type = jstpe.ClassType(className, nullable = true, exact = false)
   }
 
   // ExternTypes
-  final case class FuncType(paramTypes: List[ValType], resultType: Option[ValType])
-      extends ExternType
+  final case class ParamType(name: String, tpe: ValType)
+
+  final case class FuncType(params: List[ParamType], resultType: Option[ValType]) extends ExternType {
+    def paramTypes: List[ValType] = params.map(_.tpe)
+  }
 
   // utilities
 
@@ -155,147 +186,20 @@ object WasmInterfaceTypes {
     case StringType                 => jstpe.ClassRef(BoxedStringClass)
     case ListType(elemType, length) =>
       jstpe.ArrayTypeRef.of(toTypeRef(elemType))
-    case RecordType(className, fields) => jstpe.ClassRef(className)
-    case TupleType(ts) => jstpe.ClassRef(ClassName("scala.scalajs.wit.Tuple" + ts.size))
-    case VariantType(className, cases) => jstpe.ClassRef(className)
-    case ResultType(ok, err)           => jstpe.ClassRef(ComponentResultClass)
-    case EnumType(labels)              => ???
-    case OptionType(tpe)               => jstpe.ClassRef(ClassName("java.util.Optional"))
-    case FlagsType(className, _)       => jstpe.ClassRef(className)
-    case ResourceType(className)       => jstpe.ClassRef(className)
+    case RecordTypeRef(className)  => jstpe.ClassRef(className)
+    case TupleType(ts)             => jstpe.ClassRef(ClassName("scala.scalajs.wit.Tuple" + ts.size))
+    case VariantTypeRef(className) => jstpe.ClassRef(className)
+    case ResultType(ok, err)       => jstpe.ClassRef(ComponentResultClass)
+    case EnumTypeRef(className)    => jstpe.ClassRef(className)
+    case OptionType(tpe)           => jstpe.ClassRef(ClassName("java.util.Optional"))
+    case FlagsTypeRef(className)   => jstpe.ClassRef(className)
+    case ResourceType(className, _) => jstpe.ClassRef(className)
   }
 
   def makeCtorName(tpe: Option[ValType]): MethodName = {
     tpe match {
       case None    => MethodName.constructor(Nil)
       case Some(t) => MethodName.constructor(List(toTypeRef(t)))
-    }
-  }
-
-  /** @see
-   *   [[https://github.com/WebAssembly/component-model/blob/main/design/mvp/CanonicalABI.md#despecialization]]
-   */
-  def despecialize(t: ValType): FundamentalType = t match {
-    case st: SpecializedType => st match {
-
-        case TupleType(ts) =>
-          val className = ClassName("scala.scalajs.wit.Tuple" + ts.size)
-          RecordType(
-            className,
-            ts.zipWithIndex.map { case (t, i) =>
-              FieldType(FieldName(className, SimpleFieldName(s"_${i + 1}")), t)
-            }
-          )
-
-        case EnumType(labels) =>
-          VariantType(???, labels.map(l => CaseType(???, None)))
-
-        case OptionType(t) =>
-          VariantType(
-            juOptionalClass,
-            List(
-              CaseType(juOptionalClass, None),
-              CaseType(juOptionalClass, Some(t))
-            )
-          )
-
-        case ResultType(ok, err) =>
-          VariantType(
-            ComponentResultClass,
-            List(
-              CaseType(ComponentResultOkClass, ok),
-              CaseType(ComponentResultErrClass, err)
-            )
-          )
-      }
-
-    case ft: FundamentalType => ft
-  }
-
-  def elemSize(tpe: Option[ValType]): Int = tpe match {
-    case None        => 0
-    case Some(value) => elemSize(value)
-  }
-
-  def elemSize(tpe: ValType): Int = {
-    despecialize(tpe) match {
-      case BoolType | U8Type | S8Type  => 1
-      case U16Type | S16Type           => 2
-      case U32Type | S32Type | F32Type => 4
-      case U64Type | S64Type | F64Type => 8
-      case CharType                    => 4
-      case StringType                  => 8
-      case ListType(elemType, length)  =>
-        length match {
-          case None        => 8
-          case Some(value) => elemSize(elemType) * value
-        }
-      case RecordType(_, fields) =>
-        val size = fields.foldLeft(0) { case (ptr, f) =>
-          alignTo(ptr, alignment(f.tpe)) + elemSize(f.tpe)
-        }
-        alignTo(size, alignment(tpe))
-
-      case VariantType(_, cases) =>
-        val indexSize = alignTo(elemSize(discriminantType(cases)), maxCaseAlignment(cases))
-        val size = indexSize + cases.map(c => elemSize(c.tpe)).max
-        alignTo(size, alignment(tpe))
-      case FlagsType(_, n) =>
-        assert(n > 0)
-        assert(n <= 32)
-        if (n <= 8) 1
-        else if (n <= 16) 2
-        else 4
-      case ResourceType(className) => 4
-    }
-  }
-
-  def alignment(tpe: ValType): Int = {
-    despecialize(tpe) match {
-      case BoolType | U8Type | S8Type  => 1
-      case U16Type | S16Type           => 2
-      case U32Type | S32Type | F32Type => 4
-      case U64Type | S64Type | F64Type => 8
-      case CharType                    => 4
-      case StringType                  => 4
-      case ListType(elemType, length)  =>
-        length match {
-          case None    => 4
-          case Some(_) => alignment(elemType)
-        }
-      case RecordType(_, fields) =>
-        fields.map(f => alignment(f.tpe)).max
-      case VariantType(_, cases) =>
-        val maxCaseAlign = maxCaseAlignment(cases)
-        val caseIndexAlign = alignment(discriminantType(cases))
-        if (maxCaseAlign > caseIndexAlign) maxCaseAlign else caseIndexAlign
-      case FlagsType(_, n) =>
-        assert(n > 0)
-        assert(n <= 32)
-        if (n <= 8) 1
-        else if (n <= 16) 2
-        else 4
-      case ResourceType(className) => 4
-    }
-  }
-
-  // def align_to(ptr, alignment):
-  // return math.ceil(ptr / alignment) * alignment
-  private def alignTo(ptr: Int, alignment: Int): Int =
-    ((ptr + alignment - 1) / alignment) * alignment
-
-  def maxCaseAlignment(cases: List[CaseType]): Int =
-    cases.map(c => c.tpe.map(alignment).getOrElse(1)).max
-
-  def discriminantType(cases: Seq[_]): PrimValType = {
-    val n = cases.length
-    require(0 < n && n < (1L << 32), "Number of cases must be within range.")
-    (math.ceil(math.log(n) / math.log(2) / 8)).toInt match {
-      case 0 => U8Type
-      case 1 => U8Type
-      case 2 => U16Type
-      case 3 => U32Type
-      case _ => throw new AssertionError(s"Number of cases must be within the 2^32.")
     }
   }
 

--- a/ir/shared/src/main/scala/org/scalajs/ir/WitScope.scala
+++ b/ir/shared/src/main/scala/org/scalajs/ir/WitScope.scala
@@ -1,0 +1,82 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
+package org.scalajs.ir
+
+sealed abstract class WitScope
+
+object WitScope {
+
+  /** A package-level WIT interface
+   *
+   *  `interface name` inside `package namespace:package[@version]`.
+   */
+  final case class Interface(namespace: String, packageName: String,
+      name: String, version: Option[String])
+      extends WitScope {
+
+    /** The full package identifier, e.g., `wasi:cli@0.2.0`. */
+    def witPackage: String =
+      namespace + ":" + packageName + version.fold("")("@" + _)
+
+    /** The interface identifier, e.g., `wasi:cli/stdout@0.2.0`. */
+    def witId: String =
+      namespace + ":" + packageName + "/" + name + version.fold("")("@" + _)
+  }
+
+  /** An inline WIT interface nested in a world.
+   *
+   *  `import name: interface { ... }` or `export name: interface { ... }`.
+   *
+   *  ```
+   *  world app {
+   *    import filesystem: interface {
+   *      read-file: func(path: string) -> string;
+   *    }
+   *  }
+   *  ```
+   */
+  final case class Inline(name: String) extends WitScope
+
+  /** The WIT world body itself, for top-level world imports and exports.
+   *
+   *  ```
+   *  world app {
+   *    import log: func(message: string);
+   *    export run: func();
+   *  }
+   *  ```
+   */
+  case object Root extends WitScope
+
+  implicit val ordering: Ordering[WitScope] = Ordering.by {
+    case Root             => (0, "")
+    case Inline(name)     => (1, name)
+    case iface: Interface => (2, iface.witId)
+  }
+
+  object Interface {
+    implicit val ordering: Ordering[Interface] = Ordering.by(_.witId)
+  }
+
+  def importModuleName(scope: WitScope): String = scope match {
+    case iface: WitScope.Interface => iface.witId
+    case WitScope.Inline(name)     => name
+    case WitScope.Root             => "$root"
+  }
+
+  def exportName(scope: WitScope, name: String): String = scope match {
+    case iface: WitScope.Interface => s"${iface.witId}#$name"
+    case WitScope.Inline(inline)   => s"$inline#$name"
+    case WitScope.Root             => name
+  }
+}

--- a/ir/shared/src/main/scala/org/scalajs/ir/WitTypeDef.scala
+++ b/ir/shared/src/main/scala/org/scalajs/ir/WitTypeDef.scala
@@ -1,0 +1,52 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
+package org.scalajs.ir
+
+import Names.ClassName
+import WasmInterfaceTypes.{CaseType, FieldType, ResourceRef}
+
+sealed trait ResourceOwnership
+
+object ResourceOwnership {
+  case object Own extends ResourceOwnership
+  case object Borrow extends ResourceOwnership
+}
+
+sealed trait WitTypeDef {
+  def className: ClassName
+  def scope: WitScope
+  def name: String
+}
+
+object WitTypeDef {
+  final case class Record(className: ClassName, scope: WitScope, name: String,
+      fields: List[FieldType])
+      extends WitTypeDef
+
+  final case class Variant(className: ClassName, scope: WitScope, name: String, cases: List[CaseType])
+      extends WitTypeDef
+
+  final case class Enum(className: ClassName, scope: WitScope, name: String, cases: List[CaseType])
+      extends WitTypeDef
+
+  final case class Flags(className: ClassName, scope: WitScope, name: String, names: List[String])
+      extends WitTypeDef {
+    def numFields: Int = names.size
+  }
+
+  final case class Resource(resource: ResourceRef) extends WitTypeDef {
+    def className: ClassName = resource.className
+    def scope: WitScope = resource.scope
+    def name: String = resource.name
+  }
+}

--- a/ir/shared/src/test/scala/org/scalajs/ir/PrintersTest.scala
+++ b/ir/shared/src/test/scala/org/scalajs/ir/PrintersTest.scala
@@ -1132,7 +1132,7 @@ class PrintersTest {
 
     def makeForKind(kind: ClassKind): ClassDef = {
       ClassDef("Test", NON, kind, None, Some(ObjectClass), Nil, None, None, Nil,
-          Nil, None, Nil, Nil, Nil, Nil)(
+          Nil, None, Nil, Nil, None, Nil, Nil)(
           NoOptHints)
     }
 
@@ -1204,7 +1204,7 @@ class PrintersTest {
     def makeForParents(superClass: Option[ClassIdent],
         interfaces: List[ClassIdent]): ClassDef = {
       ClassDef("Test", NON, ClassKind.Class, None, superClass, interfaces, None,
-          None, Nil, Nil, None, Nil, Nil, Nil, Nil)(
+          None, Nil, Nil, None, Nil, Nil, None, Nil, Nil)(
           NoOptHints)
     }
 
@@ -1238,7 +1238,7 @@ class PrintersTest {
         """,
         ClassDef("Test", NON, ClassKind.NativeJSClass, None, Some(ObjectClass), Nil,
             None, Some(JSNativeLoadSpec.Global("Foo", List("Bar"))), Nil, Nil, None,
-            Nil, Nil, Nil, Nil)(
+            Nil, Nil, None, Nil, Nil)(
             NoOptHints))
 
     assertPrintEquals(
@@ -1248,7 +1248,7 @@ class PrintersTest {
         """,
         ClassDef("Test", NON, ClassKind.NativeJSClass, None, Some(ObjectClass), Nil,
             None, Some(JSNativeLoadSpec.Import("foo", List("Bar"))), Nil, Nil, None,
-            Nil, Nil, Nil, Nil)(
+            Nil, Nil, None, Nil, Nil)(
             NoOptHints))
 
     assertPrintEquals(
@@ -1262,7 +1262,7 @@ class PrintersTest {
                 JSNativeLoadSpec.Import("foo", List("Bar")),
                 JSNativeLoadSpec.Global("Baz", List("Foobar")))),
             Nil, Nil, None,
-            Nil, Nil, Nil, Nil)(
+            Nil, Nil, None, Nil, Nil)(
             NoOptHints))
   }
 
@@ -1274,7 +1274,7 @@ class PrintersTest {
           |}
         """,
         ClassDef("Test", NON, ClassKind.JSClass, Some(Nil), Some(ObjectClass), Nil,
-            None, None, Nil, Nil, None, Nil, Nil, Nil, Nil)(
+            None, None, Nil, Nil, None, Nil, Nil, None, Nil, Nil)(
             NoOptHints))
 
     assertPrintEquals(
@@ -1288,7 +1288,7 @@ class PrintersTest {
               ParamDef("x", NON, IntType, mutable = false),
               ParamDef("y", TestON, StringType, mutable = false)
             )),
-            Some(ObjectClass), Nil, None, None, Nil, Nil, None, Nil, Nil, Nil, Nil)(
+            Some(ObjectClass), Nil, None, None, Nil, Nil, None, Nil, Nil, None, Nil, Nil)(
             NoOptHints))
   }
 
@@ -1302,7 +1302,7 @@ class PrintersTest {
         ClassDef("Test", NON, ClassKind.JSClass,
             Some(List(ParamDef("sup", NON, AnyType, mutable = false))),
             Some("Bar"), Nil, Some(ref("sup", AnyType)), None, Nil, Nil, None,
-            Nil, Nil, Nil, Nil)(
+            Nil, Nil, None, Nil, Nil)(
             NoOptHints))
   }
 
@@ -1313,7 +1313,7 @@ class PrintersTest {
           |}
         """,
         ClassDef("Test", NON, ClassKind.Class, None, Some(ObjectClass), Nil,
-            None, None, Nil, Nil, None, Nil, Nil, Nil, Nil)(
+            None, None, Nil, Nil, None, Nil, Nil, None, Nil, Nil)(
             NoOptHints.withInline(true)))
   }
 
@@ -1324,7 +1324,7 @@ class PrintersTest {
           |}
         """,
         ClassDef("Test", TestON, ClassKind.ModuleClass, None, Some(ObjectClass),
-            Nil, None, None, Nil, Nil, None, Nil, Nil, Nil, Nil)(
+            Nil, None, None, Nil, Nil, None, Nil, Nil, None, Nil, Nil)(
             NoOptHints))
   }
 
@@ -1355,8 +1355,10 @@ class PrintersTest {
             List(JSMethodDef(MemberFlags.empty, StringLiteral("o"), Nil, None, i(5))(NoOptHints, UNV)),
             List(JSNativeMemberDef(MemberFlags.empty.withNamespace(Static), MethodName("p", Nil, O),
                 JSNativeLoadSpec.Global("foo", Nil))),
+            None,
             List(WitNativeMemberDef(MemberFlags.empty.withNamespace(Static),
-                "wasi:io/streams", WitFunctionName.Function("get-stdout"),
+                WitScope.Interface("wasi", "io", "streams", None),
+                WitFunctionName.Function("get-stdout"),
                 MethodName("getStdout", Nil, I),
                 WasmInterfaceTypes.FuncType(Nil, Some(WasmInterfaceTypes.U32Type)))),
             List(TopLevelModuleExportDef("main", "Foo")))(

--- a/library/src/main/scala/scala/scalajs/wit/annotation/WitEnum.scala
+++ b/library/src/main/scala/scala/scalajs/wit/annotation/WitEnum.scala
@@ -15,6 +15,6 @@ package scala.scalajs.wit.annotation
 import scala.annotation.meta._
 
 @field @getter @setter
-class WitResourceImport private () extends scala.annotation.StaticAnnotation {
+class WitEnum private () extends scala.annotation.StaticAnnotation {
   def this(scope: WitScope, name: String) = this()
 }

--- a/library/src/main/scala/scala/scalajs/wit/annotation/WitExport.scala
+++ b/library/src/main/scala/scala/scalajs/wit/annotation/WitExport.scala
@@ -20,5 +20,5 @@ import scala.annotation.meta._
  */
 @field @getter @setter
 class WitExport private () extends scala.annotation.StaticAnnotation {
-  def this(moduleName: String, name: String) = this()
+  def this(scope: WitScope, name: String) = this()
 }

--- a/library/src/main/scala/scala/scalajs/wit/annotation/WitFlags.scala
+++ b/library/src/main/scala/scala/scalajs/wit/annotation/WitFlags.scala
@@ -14,22 +14,7 @@ package scala.scalajs.wit.annotation
 
 import scala.annotation.meta._
 
-/** Represents bitflags in the Component Model
- *
- *  Must be used on a final case class with a single Int parameter named "value".
- *
- *  Example:
- *  {{{
- *  @WitFlags(3)
- *  final case class MyFlags(value: Int) { ... }
- *  object MyFlags {
- *    val Flag0 = MyFlags(1 << 0)
- *    val Flag1 = MyFlags(1 << 1)
- *    val Flag2 = MyFlags(1 << 2)
- *  }
- *  }}}
- *
- *  @param numFlags The number of flags in this flags type
- */
 @field @getter @setter
-class WitFlags(val numFlags: Int) extends scala.annotation.StaticAnnotation
+class WitFlags private () extends scala.annotation.StaticAnnotation {
+  def this(scope: WitScope, name: String, flagNames: Array[String]) = this()
+}

--- a/library/src/main/scala/scala/scalajs/wit/annotation/WitImport.scala
+++ b/library/src/main/scala/scala/scalajs/wit/annotation/WitImport.scala
@@ -16,5 +16,5 @@ import scala.annotation.meta._
 
 @field @getter @setter
 class WitImport private () extends scala.annotation.StaticAnnotation {
-  def this(moduleName: String, name: String) = this()
+  def this(scope: WitScope, name: String) = this()
 }

--- a/library/src/main/scala/scala/scalajs/wit/annotation/WitName.scala
+++ b/library/src/main/scala/scala/scalajs/wit/annotation/WitName.scala
@@ -12,9 +12,4 @@
 
 package scala.scalajs.wit.annotation
 
-import scala.annotation.meta._
-
-@field @getter @setter
-class WitResourceImport private () extends scala.annotation.StaticAnnotation {
-  def this(scope: WitScope, name: String) = this()
-}
+class WitName(val name: String) extends scala.annotation.StaticAnnotation

--- a/library/src/main/scala/scala/scalajs/wit/annotation/WitRecord.scala
+++ b/library/src/main/scala/scala/scalajs/wit/annotation/WitRecord.scala
@@ -15,4 +15,6 @@ package scala.scalajs.wit.annotation
 import scala.annotation.meta._
 
 @field @getter @setter
-class WitRecord extends scala.annotation.StaticAnnotation
+class WitRecord private () extends scala.annotation.StaticAnnotation {
+  def this(scope: WitScope, name: String) = this()
+}

--- a/library/src/main/scala/scala/scalajs/wit/annotation/WitScope.scala
+++ b/library/src/main/scala/scala/scalajs/wit/annotation/WitScope.scala
@@ -1,0 +1,31 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
+package scala.scalajs.wit.annotation
+
+final class WitScope private ()
+
+object WitScope {
+  def apply(namespace: String, packageName: String, name: String,
+      version: String): WitScope = {
+    new WitScope
+  }
+
+  def unversioned(namespace: String, packageName: String,
+      name: String): WitScope = {
+    new WitScope
+  }
+
+  val root: WitScope = new WitScope
+
+  def inline(name: String): WitScope = new WitScope
+}

--- a/library/src/main/scala/scala/scalajs/wit/annotation/WitVariant.scala
+++ b/library/src/main/scala/scala/scalajs/wit/annotation/WitVariant.scala
@@ -46,4 +46,6 @@ import scala.annotation.meta._
  *  }}}
  */
 @field @getter @setter
-class WitVariant extends scala.annotation.StaticAnnotation
+class WitVariant private () extends scala.annotation.StaticAnnotation {
+  def this(scope: WitScope, name: String) = this()
+}

--- a/library/src/main/scala/scala/scalajs/wit/package.scala
+++ b/library/src/main/scala/scala/scalajs/wit/package.scala
@@ -17,6 +17,18 @@ import scala.annotation.meta._
 /** Types, methods and values for interoperability with Wasm Component Model libraries. */
 package object wit {
 
+  /** Marks a WIT resource handle as borrowed in a Component Model signature.
+   *
+   *  `Borrow[R]` is to tell Scala.js compiler to emit `borrow<r>` where
+   *  `R` represents own resource type.
+   *  For example, `Borrow[InputStream]` corresponds to:
+   *
+   *  {{{
+   *  read: func(s: borrow<input-stream>);
+   *  }}}
+   */
+  type Borrow[T] = T
+
   /** Denotes a method body as imported from Wasm Component. For use in facade types:
    *
    *  {{{

--- a/linker-interface/shared/src/main/scala/org/scalajs/linker/interface/WasmComponentModuleInitializerExport.scala
+++ b/linker-interface/shared/src/main/scala/org/scalajs/linker/interface/WasmComponentModuleInitializerExport.scala
@@ -12,12 +12,13 @@
 
 package org.scalajs.linker.interface
 
+import org.scalajs.ir.WitScope
+
 import Fingerprint.FingerprintBuilder
 
 /** The Wasm Component export name used to invoke the module initializers.
  *
- *  This only describes which export name to use. It does not generate WIT
- *  declarations, the selected WIT world must declare an export.
+ *  The linker includes this export in its generated WIT world.
  *
  *  For Wasm modules, we generate initializers in `_start` function, that runs
  *  when the module is instantiated. In the Component Model, calling WIT functions
@@ -26,19 +27,21 @@ import Fingerprint.FingerprintBuilder
  *  invoked from the configured component export instead of `_start`.
  */
 final class WasmComponentModuleInitializerExport private (
-    val moduleName: String,
+    val scope: WitScope,
     val functionName: String,
     val resultType: WasmComponentModuleInitializerExport.ResultType
 ) {
   require(functionName.nonEmpty, "functionName must not be empty")
 
-  def exportName: String =
-    if (moduleName.isEmpty) functionName
-    else s"$moduleName#$functionName"
+  def exportName: String = scope match {
+    case WitScope.Root             => functionName
+    case iface: WitScope.Interface => s"${iface.witId}#$functionName"
+    case WitScope.Inline(name)     => s"$name#$functionName"
+  }
 
   override def equals(that: Any): Boolean = that match {
     case that: WasmComponentModuleInitializerExport =>
-      this.moduleName == that.moduleName &&
+      this.scope == that.scope &&
       this.functionName == that.functionName &&
       this.resultType == that.resultType
     case _ =>
@@ -46,17 +49,17 @@ final class WasmComponentModuleInitializerExport private (
   }
 
   override def hashCode(): Int =
-    (moduleName, functionName, resultType).##
+    (scope, functionName, resultType).##
 
   override def toString(): String =
-    s"WasmComponentModuleInitializerExport($moduleName, $functionName, $resultType)"
+    s"WasmComponentModuleInitializerExport($scope, $functionName, $resultType)"
 }
 
 object WasmComponentModuleInitializerExport {
 
-  def apply(moduleName: String, functionName: String,
+  def apply(scope: WitScope, functionName: String,
       resultType: ResultType): WasmComponentModuleInitializerExport = {
-    new WasmComponentModuleInitializerExport(moduleName, functionName, resultType)
+    new WasmComponentModuleInitializerExport(scope, functionName, resultType)
   }
 
   /** WIT result types for a module-initializer export. */
@@ -82,7 +85,7 @@ object WasmComponentModuleInitializerExport {
       extends Fingerprint[WasmComponentModuleInitializerExport] {
     override def fingerprint(componentExport: WasmComponentModuleInitializerExport): String = {
       new FingerprintBuilder("WasmComponentModuleInitializerExport")
-        .addField("moduleName", componentExport.moduleName)
+        .addField("scope", componentExport.scope.toString)
         .addField("functionName", componentExport.functionName)
         .addField("resultType", componentExport.resultType)
         .build()

--- a/linker/shared/src/main/scala/org/scalajs/linker/analyzer/Analyzer.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/analyzer/Analyzer.scala
@@ -726,6 +726,14 @@ private class AnalyzerRun(config: CommonPhaseConfig, initial: Boolean,
     def wasmwitNativeMembersUsed: scala.collection.Set[MethodName] =
       _wasmwitNativeMembersUsed.keySet
 
+    private[this] val isWitTypeDefUsed = new AtomicBoolean(false)
+
+    def useWitTypeDef(moduleUnit: ModuleUnit)(implicit from: From): Unit = {
+      if (isWitTypeDefUsed.compareAndSet(false, true)) {
+        data.witTypeDef.foreach(followReachabilityInfo(_, moduleUnit))
+      }
+    }
+
     val jsNativeLoadSpec: Option[JSNativeLoadSpec] = data.jsNativeLoadSpec
 
     private[this] val _staticDependencies: mutable.Map[ClassName, Unit] = emptyThreadSafeMap
@@ -1556,6 +1564,7 @@ private class AnalyzerRun(config: CommonPhaseConfig, initial: Boolean,
     for (dataInClass <- data.byClass) {
       lookupClass(dataInClass.className) { clazz =>
         val className = dataInClass.className
+        clazz.useWitTypeDef(moduleUnit)
 
         val flags = dataInClass.flags
         if (flags != 0) {
@@ -1724,7 +1733,7 @@ private class AnalyzerRun(config: CommonPhaseConfig, initial: Boolean,
     new Infos.ClassInfo(className, ClassKind.Class, syntheticKind = None, nonExistent = true,
         superClass = superClass, interfaces = Nil, jsNativeLoadSpec = None,
         referencedFieldClasses = Map.empty, methods = methods,
-        jsNativeMembers = Map.empty, witNativeMembers = Map.empty,
+        jsNativeMembers = Map.empty, witTypeDef = None, witNativeMembers = Map.empty,
         jsMethodProps = Nil, topLevelExports = Nil)
   }
 

--- a/linker/shared/src/main/scala/org/scalajs/linker/analyzer/InfoLoader.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/analyzer/InfoLoader.scala
@@ -128,6 +128,8 @@ private[analyzer] object InfoLoader {
       val jsNativeMembers = classDef.jsNativeMembers
         .map(m => m.name.name -> m.jsNativeLoadSpec).toMap
 
+      val witTypeDef = classDef.witTypeDef.map(generator.generateWitTypeDef(_))
+
       val witNativeMembers = classDef.witNativeMembers
         .map(m => m.method.name -> generator.generateWitNativeMember(m)).toMap
 
@@ -135,7 +137,7 @@ private[analyzer] object InfoLoader {
           nonExistent = false, classDef.superClass.map(_.name),
           classDef.interfaces.map(_.name), classDef.jsNativeLoadSpec,
           referencedFieldClasses, prevMethodInfos, jsNativeMembers,
-          witNativeMembers, exportedMembers, topLevelExports)
+          witTypeDef, witNativeMembers, exportedMembers, topLevelExports)
     }
 
     /** Returns true if the cache has been used and should be kept. */

--- a/linker/shared/src/main/scala/org/scalajs/linker/analyzer/Infos.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/analyzer/Infos.scala
@@ -22,6 +22,7 @@ import org.scalajs.ir.Trees._
 import org.scalajs.ir.Types._
 import org.scalajs.ir.Version
 import org.scalajs.ir.WellKnownNames._
+import org.scalajs.ir.WitTypeDef
 import org.scalajs.ir.{WasmInterfaceTypes => wit}
 
 import org.scalajs.linker.frontend.{LinkTimeEvaluator, LinkTimeProperties, SyntheticClassKind}
@@ -67,6 +68,7 @@ object Infos {
       val referencedFieldClasses: Map[FieldName, ClassName],
       val methods: Array[Map[MethodName, MethodInfo]],
       val jsNativeMembers: Map[MethodName, JSNativeLoadSpec],
+      val witTypeDef: Option[ReachabilityInfo],
       val witNativeMembers: Map[MethodName, ReachabilityInfo],
       val jsMethodProps: List[ReachabilityInfo],
       val topLevelExports: List[TopLevelExportInfo]
@@ -638,6 +640,11 @@ object Infos {
       new GenInfoTraverser(Version.Unversioned, linkTimeProperties, registerJSInterop)
         .generateWitNativeMember(member)
     }
+
+    def generateWitTypeDef(typeDef: WitTypeDef): ReachabilityInfo = {
+      new GenInfoTraverser(Version.Unversioned, linkTimeProperties, registerJSInterop)
+        .generateWitTypeDef(typeDef)
+    }
   }
 
   private final class GenInfoTraverser(version: Version,
@@ -670,6 +677,11 @@ object Infos {
       //   }
       // }
       MethodInfo(true, reachabilityInfo)
+    }
+
+    def generateWitTypeDef(typeDef: WitTypeDef): ReachabilityInfo = {
+      generateForWITTypeDef(typeDef)
+      builder.result()
     }
 
     def generateMethodInfo(methodDef: MethodDef): MethodInfo = {
@@ -756,7 +768,7 @@ object Infos {
     private def generateForWIT(tpe: wit.WasmInterfaceType): Unit = {
       tpe match {
         case wit.FuncType(paramTypes, resultType) =>
-          for (t <- paramTypes) generateForWIT(t)
+          for (t <- paramTypes) generateForWIT(t.tpe)
           resultType.foreach(t => generateForWIT(t))
 
         case wit.TupleType(fields) =>
@@ -769,19 +781,11 @@ object Infos {
           }
           for (f <- fields) generateForWIT(f)
 
-        case wit.RecordType(className, fields) =>
-          val ctor = MethodName.constructor(fields.map(f => wit.toTypeRef(f.tpe)))
-          builder.addInstantiatedClass(className, ctor)
-          for (f <- fields) {
-            builder.addFieldRead(f.label)
-            generateForWIT(f.tpe)
-          }
+        case wit.RecordTypeRef(className) =>
+          builder.addReferencedClass(className)
 
-        case wit.FlagsType(className, _) =>
-          builder.maybeAddAccessedClassData(ClassRef(className))
-          // FlagsType is a final class with a single Int parameter
-          val ctor = MethodName.constructor(List(IntRef))
-          builder.addInstantiatedClass(className, ctor)
+        case wit.FlagsTypeRef(className) =>
+          builder.addReferencedClass(className)
 
         case wit.OptionType(t) =>
           builder.addInstantiatedClass(
@@ -792,8 +796,8 @@ object Infos {
 
         case wit.ResultType(ok, err) =>
           val cases = List(
-            wit.CaseType(ComponentResultOkClass, ok),
-            wit.CaseType(ComponentResultErrClass, err)
+            wit.CaseType(ComponentResultOkClass, "ok", ok),
+            wit.CaseType(ComponentResultErrClass, "err", err)
           )
           builder.maybeAddAccessedClassData(ClassRef(ComponentResultClass))
           for (c <- cases) {
@@ -806,8 +810,49 @@ object Infos {
             }
           }
 
-        case wit.VariantType(className, cases) =>
+        case wit.EnumTypeRef(className) =>
+          builder.addReferencedClass(className)
+
+        case wit.VariantTypeRef(className) =>
+          builder.addReferencedClass(className)
+
+        case wit.ListType(elemType, _) =>
+          generateForWIT(elemType)
+
+        case wit.ResourceType(className, _) =>
+          builder.maybeAddReferencedClass(ClassRef(className))
+
+        case _ =>
+      }
+
+    }
+
+    private def generateForWITTypeDef(typeDef: WitTypeDef): Unit = {
+      typeDef match {
+        case WitTypeDef.Record(className, _, _, fields) =>
+          val ctor = MethodName.constructor(fields.map(f => wit.toTypeRef(f.tpe)))
+          builder.addInstantiatedClass(className, ctor)
+          for (f <- fields) {
+            builder.addFieldRead(f.label)
+            generateForWIT(f.tpe)
+          }
+
+        case WitTypeDef.Flags(className, _, _, _) =>
           builder.maybeAddAccessedClassData(ClassRef(className))
+          val ctor = MethodName.constructor(List(IntRef))
+          builder.addInstantiatedClass(className, ctor)
+
+        case WitTypeDef.Enum(className, _, _, cases) =>
+          builder.maybeAddAccessedClassData(ClassRef(className))
+          // A WIT enum is closed. If the parent type appears in the WIT
+          // surface, CABI decoding may need to construct any of its cases.
+          for (c <- cases)
+            builder.addInstantiatedClass(c.className, wit.makeCtorName(c.tpe))
+
+        case WitTypeDef.Variant(className, _, _, cases) =>
+          builder.maybeAddAccessedClassData(ClassRef(className))
+          // A WIT variant is closed. If the parent type appears in the WIT
+          // surface, CABI decoding may need to construct any of its cases.
           for (c <- cases) {
             val ctor = wit.makeCtorName(c.tpe)
             builder.addInstantiatedClass(c.className, ctor)
@@ -817,15 +862,9 @@ object Infos {
             }
           }
 
-        case wit.ListType(elemType, _) =>
-          generateForWIT(elemType)
-
-        case wit.ResourceType(className) =>
-          builder.maybeAddReferencedClass(ClassRef(className))
-
-        case _ =>
+        case WitTypeDef.Resource(resource) =>
+          builder.maybeAddReferencedClass(ClassRef(resource.className))
       }
-
     }
 
     override def traverse(tree: Tree): Unit = {

--- a/linker/shared/src/main/scala/org/scalajs/linker/backend/wasmemitter/DerivedClasses.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/backend/wasmemitter/DerivedClasses.scala
@@ -147,6 +147,7 @@ object DerivedClasses {
       jsConstructorDef = None,
       exportedMembers = Nil,
       jsNativeMembers = Nil,
+      witTypeDef = None,
       witNativeMembers = Nil,
       EOH,
       pos,

--- a/linker/shared/src/main/scala/org/scalajs/linker/backend/wasmemitter/Emitter.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/backend/wasmemitter/Emitter.scala
@@ -271,8 +271,8 @@ final class Emitter(config: Emitter.Config) {
     val conflicts = topLevelExports.exists {
       case topLevelExport =>
         topLevelExport.tree match {
-          case WitExportDef(moduleName, WitFunctionName.Function(functionName), _, _) =>
-            moduleName == componentExport.moduleName &&
+          case WitExportDef(scope, WitFunctionName.Function(functionName), _, _) =>
+            scope == componentExport.scope &&
             functionName == componentExport.functionName
           case _ =>
             false
@@ -282,7 +282,7 @@ final class Emitter(config: Emitter.Config) {
     if (conflicts) {
       throw new LinkingException(
           "Wasm Component module initializer export conflicts with " +
-          s"a WIT export: ${componentExport.moduleName}#${componentExport.functionName}")
+          s"a WIT export: ${componentExport.exportName}")
     }
   }
 
@@ -292,9 +292,7 @@ final class Emitter(config: Emitter.Config) {
       implicit ctx: WasmContext): Unit = {
     implicit val pos = Position.NoPosition
 
-    val exportName =
-      if (componentExport.moduleName.isEmpty) componentExport.functionName
-      else s"${componentExport.moduleName}#${componentExport.functionName}"
+    val exportName = componentExport.exportName
     val functionID = genFunctionID.forExport(exportName)
     val fb = new FunctionBuilder(
       ctx.moduleBuilder,

--- a/linker/shared/src/main/scala/org/scalajs/linker/backend/wasmemitter/Preprocessor.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/backend/wasmemitter/Preprocessor.scala
@@ -233,6 +233,7 @@ object Preprocessor {
       hasRuntimeTypeInfo,
       clazz.jsNativeLoadSpec,
       clazz.jsNativeMembers.map(m => m.name.name -> m.jsNativeLoadSpec).toMap,
+      clazz.witTypeDef,
       staticFieldMirrors,
       specialInstanceTypes,
       resolvedMethodInfos,

--- a/linker/shared/src/main/scala/org/scalajs/linker/backend/wasmemitter/WasmContext.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/backend/wasmemitter/WasmContext.scala
@@ -18,6 +18,7 @@ import scala.collection.mutable
 import scala.collection.mutable.LinkedHashMap
 
 import org.scalajs.ir.ClassKind
+import org.scalajs.ir.WitTypeDef
 import org.scalajs.ir.Names._
 import org.scalajs.ir.OriginalName
 import org.scalajs.ir.OriginalName.NoOriginalName
@@ -55,6 +56,12 @@ final class WasmContext(
 
   private val functionTypes = LinkedHashMap.empty[watpe.FunctionType, wanme.TypeID]
   private val tableFunctionTypes = mutable.HashMap.empty[MethodName, wanme.TypeID]
+
+  private val declaredComponentImports = mutable.HashSet.empty[(String, String)]
+
+  def registerComponentImport(module: String, name: String): Boolean =
+    declaredComponentImports.add((module, name))
+
   private val closureDataTypes = LinkedHashMap.empty[List[Type], wanme.TypeID]
   private val typedClosureTypes = LinkedHashMap.empty[ClosureType, (wanme.TypeID, wanme.TypeID)]
 
@@ -113,6 +120,11 @@ final class WasmContext(
 
   def getClassInfo(name: ClassName): ClassInfo =
     classInfo.getOrElse(name, throw new Error(s"Class not found: $name"))
+
+  def getWitTypeDef(name: ClassName): WitTypeDef = {
+    getClassInfo(name).witTypeDef.getOrElse(
+        throw new Error(s"WIT type definition not found for ${name.nameString}"))
+  }
 
   def inferTypeFromTypeRef(typeRef: TypeRef): Type = typeRef match {
     case PrimRef(tpe) =>
@@ -268,6 +280,7 @@ object WasmContext {
       val hasRuntimeTypeInfo: Boolean,
       val jsNativeLoadSpec: Option[JSNativeLoadSpec],
       val jsNativeMembers: Map[MethodName, JSNativeLoadSpec],
+      val witTypeDef: Option[WitTypeDef],
       val staticFieldMirrors: Map[FieldName, List[String]],
       _specialInstanceTypes: Int, // should be `val` but there is a large Scaladoc for it below
       val resolvedMethodInfos: Map[MethodName, ConcreteMethodInfo],

--- a/linker/shared/src/main/scala/org/scalajs/linker/backend/wasmemitter/canonicalabi/CABIToScalaJS.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/backend/wasmemitter/canonicalabi/CABIToScalaJS.scala
@@ -97,10 +97,10 @@ object CABIToScalaJS {
           case Some(value) => ???
         }
 
-      case flags @ wit.FlagsType(className, _) =>
+      case flags @ wit.FlagsTypeRef(className) =>
         val ptr = fb.addLocal(NoOriginalName, watpe.Int32)
         fb += wa.LocalTee(ptr)
-        wit.elemSize(flags) match {
+        WitTypeOps.elemSize(flags) match {
           case 1 => fb += wa.I32Load8U()
           case 2 => fb += wa.I32Load16U()
           case 4 => fb += wa.I32Load()
@@ -112,17 +112,18 @@ object CABIToScalaJS {
           fb += wa.LocalGet(intValue)
         }
 
-      case wit.RecordType(className, fields) =>
+      case wit.RecordTypeRef(className) =>
+        val fields = WitTypeOps.recordFields(className)
         val typeRefs = fields.map(f => wit.toTypeRef(f.tpe))
         val ctor = MethodName.constructor(typeRefs)
         val ptr = fb.addLocal(NoOriginalName, watpe.Int32)
         fb += wa.LocalSet(ptr)
         genNewScalaClass(fb, className, ctor) {
           for (f <- fields) {
-            genAlignTo(fb, wit.alignment(f.tpe), ptr)
+            genAlignTo(fb, WitTypeOps.alignment(f.tpe), ptr)
             fb += wa.LocalGet(ptr)
             genLoadMemory(fb, f.tpe)
-            genMovePtr(fb, ptr, wit.elemSize(f.tpe))
+            genMovePtr(fb, ptr, WitTypeOps.elemSize(f.tpe))
           }
         }
         // genAlignTo(fb, wit.alignment(tpe), ptr)
@@ -134,19 +135,19 @@ object CABIToScalaJS {
         fb += wa.LocalSet(ptr)
         genNewScalaClass(fb, className, ctor) {
           for (f <- fields) {
-            genAlignTo(fb, wit.alignment(f), ptr)
+            genAlignTo(fb, WitTypeOps.alignment(f), ptr)
             fb += wa.LocalGet(ptr)
             genLoadMemory(fb, f)
             f.toIRType() match {
               case t: PrimTypeWithRef => genBox(fb, t)
               case _                  =>
             }
-            genMovePtr(fb, ptr, wit.elemSize(f))
+            genMovePtr(fb, ptr, WitTypeOps.elemSize(f))
           }
         }
         // genAlignTo(fb, wit.alignment(tpe), ptr)
 
-      case wit.ResourceType(className) =>
+      case wit.ResourceType(className, _) =>
         val resourceStructID = genTypeID.forClass(className)
         val handleLocal = fb.addLocal(NoOriginalName, watpe.Int32)
         fb += wa.I32Load()
@@ -156,12 +157,17 @@ object CABIToScalaJS {
         fb += wa.LocalGet(handleLocal) // handle
         fb += wa.StructNew(resourceStructID)
 
-      case variant @ wit.VariantType(className, cases) =>
+      case tpe: wit.VariantTypeRef =>
+        val cases = WitTypeOps.getVariantCases(tpe)
+        genLoadVariantMemory(fb, cases, false)
+
+      case tpe: wit.EnumTypeRef =>
+        val cases = WitTypeOps.getVariantCases(tpe)
         genLoadVariantMemory(fb, cases, false)
 
       case wit.OptionType(t) =>
         val optionType = watpe.RefType.nullable(genTypeID.forClass(juOptionalClass))
-        val maxCaseAlignment = wit.alignment(t)
+        val maxCaseAlignment = WitTypeOps.alignment(t)
         val ctorID = MethodName.constructor(List(ClassRef(ObjectClass)))
 
         val ptr = fb.addLocal(NoOriginalName, watpe.Int32)
@@ -192,12 +198,10 @@ object CABIToScalaJS {
 
       case result @ wit.ResultType(ok, err) =>
         val cases = List(
-          wit.CaseType(ComponentResultOkClass, ok),
-          wit.CaseType(ComponentResultErrClass, err)
+          wit.CaseType(ComponentResultOkClass, "ok", ok),
+          wit.CaseType(ComponentResultErrClass, "err", err)
         )
         genLoadVariantMemory(fb, cases, true)
-
-      case tpe => throw new AssertionError(s"unsupported tpe: $tpe")
     }
   }
 
@@ -232,7 +236,7 @@ object CABIToScalaJS {
           fb += wa.GlobalSet(genGlobalID.savedStackPointer)
         }
 
-      case wit.ResourceType(className) =>
+      case wit.ResourceType(className, _) =>
         fb += wa.GlobalGet(genGlobalID.forVTable(className)) // vtable
         fb += wa.I32Const(0) // idHashCode
         vi.next(watpe.Int32) // handle
@@ -275,13 +279,14 @@ object CABIToScalaJS {
           case Some(value) => ???
         }
 
-      case flags @ wit.FlagsType(className, _) =>
+      case wit.FlagsTypeRef(className) =>
         val ctor = MethodName.constructor(List(IntRef))
         genNewScalaClass(fb, className, ctor) {
           vi.next(watpe.Int32)
         }
 
-      case wit.RecordType(className, fields) =>
+      case wit.RecordTypeRef(className) =>
+        val fields = WitTypeOps.recordFields(className)
         val typeRefs = fields.map(f => wit.toTypeRef(f.tpe))
         val ctor = MethodName.constructor(typeRefs)
         genNewScalaClass(fb, className, ctor) {
@@ -291,13 +296,18 @@ object CABIToScalaJS {
           }
         }
 
-      case variant @ wit.VariantType(className, cases) =>
+      case tpe: wit.VariantTypeRef =>
+        val cases = WitTypeOps.getVariantCases(tpe)
         genLoadVariantStack(
           fb,
           cases,
           vi,
           boxValue = false
         )
+
+      case tpe: wit.EnumTypeRef =>
+        val cases = WitTypeOps.getVariantCases(tpe)
+        genLoadVariantStack(fb, cases, vi, boxValue = false)
 
       case wit.OptionType(t) =>
         val optionType = watpe.RefType(genTypeID.forClass(juOptionalClass))
@@ -321,8 +331,8 @@ object CABIToScalaJS {
 
       case wit.ResultType(ok, err) =>
         val cases = List(
-          wit.CaseType(ComponentResultOkClass, ok),
-          wit.CaseType(ComponentResultErrClass, err)
+          wit.CaseType(ComponentResultOkClass, "ok", ok),
+          wit.CaseType(ComponentResultErrClass, "err", err)
         )
         genLoadVariantStack(
           fb,
@@ -330,8 +340,6 @@ object CABIToScalaJS {
           vi,
           boxValue = true
         )
-
-      case _ => ???
     }
   }
 
@@ -344,7 +352,7 @@ object CABIToScalaJS {
     val arrayTypeRef = ArrayTypeRef.of(wit.toTypeRef(elemType))
     val arrayUnderlyingID = genTypeID.underlyingOf(arrayTypeRef)
     val arrayStructTypeID = genTypeID.forArrayClass(arrayTypeRef)
-    val elemSize = wit.elemSize(elemType)
+    val elemSize = WitTypeOps.elemSize(elemType)
 
     val base = fb.addLocal(NoOriginalName, watpe.Int32)
     val length = fb.addLocal(NoOriginalName, watpe.Int32)
@@ -410,9 +418,9 @@ object CABIToScalaJS {
       Sig(Nil, List(watpe.RefType(false, genTypeID.ObjectStruct)))
     ) { () =>
       fb += wa.LocalGet(ptr)
-      genLoadMemory(fb, wit.discriminantType(cases)) // load i32 (case index) from memory
-      genMovePtr(fb, ptr, wit.elemSize(wit.discriminantType(cases)))
-      genAlignTo(fb, wit.maxCaseAlignment(cases), ptr)
+      genLoadMemory(fb, WitTypeOps.discriminantType(cases)) // load i32 (case index) from memory
+      genMovePtr(fb, ptr, WitTypeOps.elemSize(WitTypeOps.discriminantType(cases)))
+      genAlignTo(fb, WitTypeOps.maxCaseAlignment(cases), ptr)
     }(
       cases.zipWithIndex.map { case (c, i) =>
         (List(i), () => {
@@ -565,8 +573,10 @@ object CABIToScalaJS {
     fb += wa.LocalSet(ptr)
   }
 
-  private def genMovePtr(fb: FunctionBuilder, ptr: wanme.LocalID, tpe: wit.ValType): Unit =
-    genMovePtr(fb, ptr, wit.elemSize(tpe))
+  private def genMovePtr(fb: FunctionBuilder, ptr: wanme.LocalID, tpe: wit.ValType)(
+      implicit ctx: WasmContext): Unit = {
+    genMovePtr(fb, ptr, WitTypeOps.elemSize(tpe))
+  }
 
   private def genMovePtr(fb: FunctionBuilder, ptr: wanme.LocalID, size: Int): Unit = {
     fb += wa.LocalGet(ptr)

--- a/linker/shared/src/main/scala/org/scalajs/linker/backend/wasmemitter/canonicalabi/InteropEmitter.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/backend/wasmemitter/canonicalabi/InteropEmitter.scala
@@ -1,8 +1,20 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package org.scalajs.linker.backend.wasmemitter.canonicalabi
 
 import org.scalajs.ir.{Names, OriginalName, Trees => js, WasmInterfaceTypes => wit}
+import org.scalajs.ir.WitScope
 import org.scalajs.ir.OriginalName.NoOriginalName
-import org.scalajs.ir.Trees.WitFunctionName._
 
 import org.scalajs.linker.standard.LinkedClass
 
@@ -23,46 +35,31 @@ import org.scalajs.linker.backend.wasmemitter.canonicalabi.ValueIterators.ValueI
 
 object InteropEmitter {
 
-  /** https://github.com/WebAssembly/component-model/blob/main/design/mvp/Explainer.md#import-and-export-definitions */
-  private def toWasmImportExportName(name: js.WitFunctionName): String = {
-    name match {
-      case Function(func)                       => func
-      case ResourceMethod(func, resource)       => s"[method]$resource.$func"
-      case ResourceStaticMethod(func, resource) => s"[static]$resource.$func"
-      case ResourceConstructor(resource)        => s"[constructor]$resource"
-      case ResourceDrop(resource)               => s"[resource-drop]$resource"
-    }
-  }
-
   def genComponentNativeInterop(clazz: LinkedClass, member: js.WitNativeMemberDef)(
       implicit ctx: WasmContext
   ): Unit = {
+    val importModuleName = WitScope.importModuleName(member.scope)
     val importFunctionID = genFunctionID.forComponentFunction(
-        member.moduleName, member.name)
-    val importName = toWasmImportExportName(member.name)
+        importModuleName, member.name)
+    val importName = js.WitFunctionName.wasmName(member.name)
     val loweredFuncType = Flatten.lowerFlattenFuncType(member.signature)
     genComponentAdapterFunction(clazz, member, importFunctionID)
 
-    // For world-level functions (moduleName is empty), use "$root" as the module namespace
-    // following the wasm-tools convention
-    val importModuleName = if (member.moduleName.isEmpty) "$root" else member.moduleName
-    val originalName = if (member.moduleName.isEmpty) {
-      s"$$root#$importName"
-    } else {
-      s"${member.moduleName}#$importName"
-    }
+    val originalName = s"$importModuleName#$importName"
 
-    ctx.moduleBuilder.addImport(
-      wamod.Import(
-        importModuleName,
-        importName,
-        wamod.ImportDesc.Func(
-          importFunctionID,
-          OriginalName(originalName),
-          ctx.moduleBuilder.functionTypeToTypeID(loweredFuncType.funcType)
+    if (ctx.registerComponentImport(importModuleName, importName)) {
+      ctx.moduleBuilder.addImport(
+        wamod.Import(
+          importModuleName,
+          importName,
+          wamod.ImportDesc.Func(
+            importFunctionID,
+            OriginalName(originalName),
+            ctx.moduleBuilder.functionTypeToTypeID(loweredFuncType.funcType)
+          )
         )
       )
-    )
+    }
   }
 
   private def genComponentAdapterFunction(clazz: LinkedClass, member: js.WitNativeMemberDef,
@@ -73,11 +70,12 @@ object InteropEmitter {
       clazz.className,
       member.method.name
     )
-    val importName = toWasmImportExportName(member.name)
+    val importName = js.WitFunctionName.wasmName(member.name)
     val fb = new FunctionBuilder(
       ctx.moduleBuilder,
       functionID,
-      OriginalName(s"${member.moduleName}#$importName-adapter"),
+      OriginalName(
+          s"${WitScope.importModuleName(member.scope)}#$importName-adapter"),
       member.pos
     )
 
@@ -116,7 +114,7 @@ object InteropEmitter {
     loweredFuncType.returnOffset match {
       case Some(_) =>
         val returnPtr = fb.addLocal(NoOriginalName, watpe.Int32)
-        val returnSize = wit.elemSize(member.signature.resultType)
+        val returnSize = WitTypeOps.elemSize(member.signature.resultType)
         fb += wa.I32Const(returnSize)
         fb += wa.Call(genFunctionID.malloc)
         fb += wa.LocalTee(returnPtr)
@@ -153,13 +151,11 @@ object InteropEmitter {
       implicit ctx: WasmContext): Unit = {
     implicit val pos = exportDef.pos
 
-    // For world level functions (moduleName is empty), use just the function name
-    // Otherwise use the wasm-tools convention: moduleName#functionName
-    // see: https://github.com/WebAssembly/component-model/issues/422
-    val exportName = if (exportDef.moduleName.isEmpty) {
-      toWasmImportExportName(exportDef.name)
-    } else {
-      s"${exportDef.moduleName}#${toWasmImportExportName(exportDef.name)}"
+    // Core export naming follows the wasm-tools convention
+    // (see https://github.com/WebAssembly/component-model/issues/422).
+    val exportName = {
+      val funcName = js.WitFunctionName.wasmName(exportDef.name)
+      WitScope.exportName(exportDef.scope, funcName)
     }
     val method = exportDef.methodDef
 
@@ -189,7 +185,7 @@ object InteropEmitter {
       val returnOffsetOpt = flatFuncType.returnOffset match {
         case Some(offsetType) =>
           val returnOffsetID = fb.addLocal("ret_addr", watpe.Int32)
-          fb += wa.I32Const(wit.elemSize(exportDef.signature.resultType))
+          fb += wa.I32Const(WitTypeOps.elemSize(exportDef.signature.resultType))
           fb += wa.Call(genFunctionID.malloc)
           fb += wa.LocalTee(returnOffsetID)
           Some(returnOffsetID)

--- a/linker/shared/src/main/scala/org/scalajs/linker/backend/wasmemitter/canonicalabi/ScalaJSToCABI.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/backend/wasmemitter/canonicalabi/ScalaJSToCABI.scala
@@ -103,7 +103,7 @@ object ScalaJSToCABI {
         fb += wa.LocalSet(ptr)
 
         for ((f, i) <- fields.zipWithIndex) {
-          genAlignTo(fb, wit.alignment(f), ptr)
+          genAlignTo(fb, WitTypeOps.alignment(f), ptr)
           fb += wa.LocalGet(ptr)
           fb += wa.LocalGet(tuple)
           fb += wa.StructGet(
@@ -115,23 +115,24 @@ object ScalaJSToCABI {
             case _                  =>
           }
           genStoreMemory(fb, f)
-          genMovePtr(fb, ptr, wit.elemSize(f))
+          genMovePtr(fb, ptr, WitTypeOps.elemSize(f))
         }
 
-      case flags @ wit.FlagsType(className, _) =>
+      case flags @ wit.FlagsTypeRef(className) =>
         val valueFieldName = FieldName(className, SimpleFieldName("value"))
         fb += wa.RefCast(watpe.RefType.nullable(genTypeID.forClass(className)))
         fb += wa.StructGet(
           genTypeID.forClass(className),
           genFieldID.forClassInstanceField(valueFieldName)
         )
-        wit.elemSize(flags) match {
+        WitTypeOps.elemSize(flags) match {
           case 1 => fb += wa.I32Store8()
           case 2 => fb += wa.I32Store16()
           case 4 => fb += wa.I32Store()
         }
 
-      case wit.RecordType(className, fields) =>
+      case wit.RecordTypeRef(className) =>
+        val fields = WitTypeOps.recordFields(className)
         val ptr = fb.addLocal(NoOriginalName, watpe.Int32)
         // TODO: NPE if null
         val record = fb.addLocal(NoOriginalName, watpe.RefType.nullable(genTypeID.forClass(className)))
@@ -140,7 +141,7 @@ object ScalaJSToCABI {
         fb += wa.LocalSet(ptr)
 
         for (f <- fields) {
-          genAlignTo(fb, wit.alignment(f.tpe), ptr)
+          genAlignTo(fb, WitTypeOps.alignment(f.tpe), ptr)
           fb += wa.LocalGet(ptr)
           fb += wa.LocalGet(record)
           fb += wa.StructGet(
@@ -148,17 +149,21 @@ object ScalaJSToCABI {
             genFieldID.forClassInstanceField(f.label)
           )
           genStoreMemory(fb, f.tpe)
-          genMovePtr(fb, ptr, wit.elemSize(f.tpe))
+          genMovePtr(fb, ptr, WitTypeOps.elemSize(f.tpe))
         }
 
-      case wit.VariantType(_, cases) =>
+      case tpe: wit.VariantTypeRef =>
+        val cases = WitTypeOps.getVariantCases(tpe)
+        genStoreVariantMemory(fb, cases, (_) => {})
+
+      case tpe: wit.EnumTypeRef =>
+        val cases = WitTypeOps.getVariantCases(tpe)
         genStoreVariantMemory(fb, cases, (_) => {})
 
       case wit.OptionType(t) =>
-        val despecialized = wit.despecialize(wit.OptionType(t)).asInstanceOf[wit.VariantType]
-        val flattened = Flatten.flattenVariant(despecialized).tail // drop discriminant
+        val flattened = Flatten.flattenVariants(List(t))
         val optionType = watpe.RefType.nullable(genTypeID.forClass(juOptionalClass))
-        val maxCaseAlignment = wit.alignment(t)
+        val maxCaseAlignment = WitTypeOps.alignment(t)
 
         val opt = fb.addLocal(NoOriginalName, optionType)
         val ptr = fb.addLocal(NoOriginalName, watpe.Int32)
@@ -198,18 +203,16 @@ object ScalaJSToCABI {
 
       case wit.ResultType(ok, err) =>
         val cases = List(
-          wit.CaseType(ComponentResultOkClass, ok),
-          wit.CaseType(ComponentResultErrClass, err)
+          wit.CaseType(ComponentResultOkClass, "ok", ok),
+          wit.CaseType(ComponentResultErrClass, "err", err)
         )
         genStoreVariantMemory(fb, cases, (tpe) => { genUnbox(fb, tpe) })
 
-      case wit.ResourceType(className) =>
+      case wit.ResourceType(className, _) =>
         val resourceStructID = genTypeID.forClass(className)
         fb += wa.RefCast(watpe.RefType(resourceStructID))
         fb += wa.StructGet(resourceStructID, genFieldID.handle)
         fb += wa.I32Store()
-
-      case _ => ???
     }
   }
 
@@ -224,7 +227,7 @@ object ScalaJSToCABI {
           wit.U64Type | wit.CharType |
           wit.F32Type | wit.F64Type =>
 
-      case wit.ResourceType(className) =>
+      case wit.ResourceType(className, _) =>
         // Unwrap: Extract i32 handle from resource struct for stack
         val resourceStructID = genTypeID.forClass(className)
         fb += wa.RefCast(watpe.RefType(resourceStructID))
@@ -244,7 +247,7 @@ object ScalaJSToCABI {
         fb += wa.LocalTee(offset)
         fb += wa.LocalGet(units)
 
-      case wit.FlagsType(className, _) =>
+      case wit.FlagsTypeRef(className) =>
         val valueFieldName = FieldName(className, SimpleFieldName("value"))
         fb += wa.RefCast(watpe.RefType.nullable(genTypeID.forClass(className)))
         fb += wa.StructGet(
@@ -270,7 +273,8 @@ object ScalaJSToCABI {
           genStoreStack(fb, f)
         }
 
-      case wit.RecordType(className, fields) =>
+      case wit.RecordTypeRef(className) =>
+        val fields = WitTypeOps.recordFields(className)
         // TODO: NPE if null
         val record = fb.addLocal(NoOriginalName, watpe.RefType.nullable(genTypeID.forClass(className)))
         fb += wa.RefCast(watpe.RefType.nullable(genTypeID.forClass(className)))
@@ -284,13 +288,17 @@ object ScalaJSToCABI {
           genStoreStack(fb, f.tpe)
         }
 
-      case wit.VariantType(_, cases) =>
+      case tpe: wit.VariantTypeRef =>
+        val cases = WitTypeOps.getVariantCases(tpe)
+        genStoreVariantStack(fb, cases, (_) => {})
+
+      case tpe: wit.EnumTypeRef =>
+        val cases = WitTypeOps.getVariantCases(tpe)
         genStoreVariantStack(fb, cases, (_) => {})
 
       case wit.OptionType(t) =>
         val optionType = watpe.RefType.nullable(genTypeID.forClass(juOptionalClass))
-        val despecialized = wit.despecialize(wit.OptionType(t)).asInstanceOf[wit.VariantType]
-        val flattened = Flatten.flattenVariant(despecialized).tail // drop discriminant
+        val flattened = Flatten.flattenVariants(List(t))
 
         val opt = fb.addLocal(NoOriginalName, optionType)
         val value = fb.addLocal(NoOriginalName, watpe.RefType.anyref)
@@ -321,13 +329,10 @@ object ScalaJSToCABI {
 
       case wit.ResultType(ok, err) =>
         val cases = List(
-          wit.CaseType(ComponentResultOkClass, ok),
-          wit.CaseType(ComponentResultErrClass, err)
+          wit.CaseType(ComponentResultOkClass, "ok", ok),
+          wit.CaseType(ComponentResultErrClass, "err", err)
         )
         genStoreVariantStack(fb, cases, (tpe) => { genUnbox(fb, tpe) })
-
-      case _ => throw new AssertionError(s"Unexpected type: $tpe")
-
     }
   }
 
@@ -351,7 +356,7 @@ object ScalaJSToCABI {
         val iLocal = fb.addLocal(NoOriginalName, watpe.Int32)
         val baseAddr = fb.addLocal(NoOriginalName, watpe.Int32)
 
-        val size = wit.elemSize(elemType)
+        val size = WitTypeOps.elemSize(elemType)
 
         fb += wa.RefCast(watpe.RefType.nullable(arrayStructTypeID))
         fb += wa.LocalTee(arr)
@@ -438,7 +443,7 @@ object ScalaJSToCABI {
           // Store discriminant (use index from position in cases list)
           fb += wa.LocalGet(ptr)
           fb += wa.I32Const(idx)
-          wit.discriminantType(cases) match {
+          WitTypeOps.discriminantType(cases) match {
             case wit.U8Type  => fb += wa.I32Store8()
             case wit.U16Type => fb += wa.I32Store16()
             case wit.U32Type => fb += wa.I32Store()
@@ -446,8 +451,8 @@ object ScalaJSToCABI {
           }
 
           c.tpe.foreach { tpe =>
-            genMovePtr(fb, ptr, wit.discriminantType(cases))
-            genAlignTo(fb, wit.maxCaseAlignment(cases), ptr)
+            genMovePtr(fb, ptr, WitTypeOps.discriminantType(cases))
+            genAlignTo(fb, WitTypeOps.maxCaseAlignment(cases), ptr)
             fb += wa.LocalGet(ptr)
             fb += wa.LocalGet(l)
 
@@ -600,8 +605,10 @@ object ScalaJSToCABI {
     fb += wa.LocalSet(ptr)
   }
 
-  private def genMovePtr(fb: FunctionBuilder, ptr: wanme.LocalID, tpe: wit.ValType): Unit =
-    genMovePtr(fb, ptr, wit.elemSize(tpe))
+  private def genMovePtr(fb: FunctionBuilder, ptr: wanme.LocalID, tpe: wit.ValType)(
+      implicit ctx: WasmContext): Unit = {
+    genMovePtr(fb, ptr, WitTypeOps.elemSize(tpe))
+  }
 
   private def genMovePtr(fb: FunctionBuilder, ptr: wanme.LocalID, size: Int): Unit = {
     fb += wa.LocalGet(ptr)
@@ -613,7 +620,7 @@ object ScalaJSToCABI {
   private def genUnbox(fb: FunctionBuilder, targetTpe: wit.ValType)(
       implicit ctx: WasmContext): Unit = {
     targetTpe match {
-      case wit.ResourceType(className) =>
+      case wit.ResourceType(className, _) =>
         // Cast from anyref (from Result/Option value field) to resource struct type
         val resourceStructType = watpe.RefType(genTypeID.forClass(className))
         fb += wa.RefCast(resourceStructType)

--- a/linker/shared/src/main/scala/org/scalajs/linker/backend/wasmemitter/canonicalabi/WitTypeOps.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/backend/wasmemitter/canonicalabi/WitTypeOps.scala
@@ -1,0 +1,166 @@
+package org.scalajs.linker.backend.wasmemitter.canonicalabi
+
+import org.scalajs.ir.Names.ClassName
+import org.scalajs.ir.WasmInterfaceTypes._
+import org.scalajs.ir.WellKnownNames._
+import org.scalajs.ir.WitTypeDef
+
+import org.scalajs.linker.backend.wasmemitter.WasmContext
+
+private[canonicalabi] object WitTypeOps {
+
+  def recordFields(className: ClassName)(
+      implicit ctx: WasmContext): List[FieldType] = {
+    val WitTypeDef.Record(_, _, _, fields) =
+      ctx.getWitTypeDef(className): @unchecked
+    fields
+  }
+
+  def elemSize(tpe: Option[ValType])(implicit ctx: WasmContext): Int = tpe match {
+    case None        => 0
+    case Some(value) => elemSize(value)
+  }
+
+  def elemSize(tpe: ValType)(implicit ctx: WasmContext): Int = tpe match {
+    case BoolType | U8Type | S8Type  => 1
+    case U16Type | S16Type           => 2
+    case U32Type | S32Type | F32Type => 4
+    case U64Type | S64Type | F64Type => 8
+    case CharType                    => 4
+    case StringType                  => 8
+    case ListType(elemType, length)  =>
+      length match {
+        case None        => 8
+        case Some(value) => elemSize(elemType) * value
+      }
+    case TupleType(ts) =>
+      val size = ts.foldLeft(0) { case (ptr, t) =>
+        alignTo(ptr, alignment(t)) + elemSize(t)
+      }
+      alignTo(size, alignment(tpe))
+    case RecordTypeRef(className) =>
+      val size = recordFields(className).foldLeft(0) { case (ptr, f) =>
+        alignTo(ptr, alignment(f.tpe)) + elemSize(f.tpe)
+      }
+      alignTo(size, alignment(tpe))
+    case tpe: VariantTypeRef =>
+      elemSizeVariant(getVariantCases(tpe))
+    case tpe: EnumTypeRef =>
+      elemSizeVariant(getVariantCases(tpe))
+    case tpe: OptionType =>
+      elemSizeVariant(getVariantCases(tpe))
+    case tpe: ResultType =>
+      elemSizeVariant(getVariantCases(tpe))
+    case FlagsTypeRef(className) =>
+      flagsSize(flagNames(className))
+    case ResourceType(_, _) =>
+      4
+  }
+
+  def alignment(tpe: ValType)(implicit ctx: WasmContext): Int = tpe match {
+    case BoolType | U8Type | S8Type  => 1
+    case U16Type | S16Type           => 2
+    case U32Type | S32Type | F32Type => 4
+    case U64Type | S64Type | F64Type => 8
+    case CharType                    => 4
+    case StringType                  => 4
+    case ListType(elemType, length)  =>
+      length match {
+        case None    => 4
+        case Some(_) => alignment(elemType)
+      }
+    case TupleType(ts) =>
+      ts.map(alignment).max
+    case RecordTypeRef(className) =>
+      recordFields(className).map(f => alignment(f.tpe)).max
+    case tpe: VariantTypeRef =>
+      alignmentVariant(getVariantCases(tpe))
+    case tpe: EnumTypeRef =>
+      alignmentVariant(getVariantCases(tpe))
+    case tpe: OptionType =>
+      alignmentVariant(getVariantCases(tpe))
+    case tpe: ResultType =>
+      alignmentVariant(getVariantCases(tpe))
+    case FlagsTypeRef(className) =>
+      flagsSize(flagNames(className))
+    case ResourceType(_, _) =>
+      4
+  }
+
+  def maxCaseAlignment(cases: List[CaseType])(
+      implicit ctx: WasmContext): Int = {
+    cases.map(c => c.tpe.map(alignment).getOrElse(1)).max
+  }
+
+  def discriminantType(cases: Seq[_]): PrimValType = {
+    val n = cases.length
+    require(0 < n && n < (1L << 32), "Number of cases must be within range.")
+    (math.ceil(math.log(n) / math.log(2) / 8)).toInt match {
+      case 0 => U8Type
+      case 1 => U8Type
+      case 2 => U16Type
+      case 3 => U32Type
+      case _ =>
+        throw new AssertionError("Number of cases must be within the 2^32.")
+    }
+  }
+
+  private def flagNames(className: ClassName)(
+      implicit ctx: WasmContext): List[String] = {
+    val WitTypeDef.Flags(_, _, _, names) =
+      ctx.getWitTypeDef(className): @unchecked
+    names
+  }
+
+  def getVariantCases(tpe: ValType)(implicit ctx: WasmContext): List[CaseType] = {
+    tpe match {
+      case VariantTypeRef(className) =>
+        val WitTypeDef.Variant(_, _, _, cases) =
+          ctx.getWitTypeDef(className): @unchecked
+        cases
+      case EnumTypeRef(className) =>
+        val WitTypeDef.Enum(_, _, _, cases) =
+          ctx.getWitTypeDef(className): @unchecked
+        cases
+      case OptionType(tpe) =>
+        List(
+          CaseType(juOptionalClass, "none", None),
+          CaseType(juOptionalClass, "some", Some(tpe))
+        )
+      case ResultType(ok, err) =>
+        List(
+          CaseType(ComponentResultOkClass, "ok", ok),
+          CaseType(ComponentResultErrClass, "err", err)
+        )
+      case _ =>
+        throw new AssertionError(s"Not a variant-like type: $tpe")
+    }
+  }
+
+  private def flagsSize(names: List[String]): Int = {
+    val n = names.size
+    assert(n > 0)
+    assert(n <= 32)
+    if (n <= 8) 1
+    else if (n <= 16) 2
+    else 4
+  }
+
+  private def elemSizeVariant(cases: List[CaseType])(
+      implicit ctx: WasmContext): Int = {
+    val indexSize =
+      alignTo(elemSize(discriminantType(cases)), maxCaseAlignment(cases))
+    val size = indexSize + cases.map(c => elemSize(c.tpe)).max
+    alignTo(size, alignmentVariant(cases))
+  }
+
+  private def alignmentVariant(cases: List[CaseType])(
+      implicit ctx: WasmContext): Int = {
+    val maxCaseAlign = maxCaseAlignment(cases)
+    val caseIndexAlign = alignment(discriminantType(cases))
+    if (maxCaseAlign > caseIndexAlign) maxCaseAlign else caseIndexAlign
+  }
+
+  private def alignTo(ptr: Int, alignment: Int): Int =
+    ((ptr + alignment - 1) / alignment) * alignment
+}

--- a/linker/shared/src/main/scala/org/scalajs/linker/backend/webassembly/component/Flatten.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/backend/webassembly/component/Flatten.scala
@@ -1,6 +1,21 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package org.scalajs.linker.backend.webassembly.component
 
 import org.scalajs.linker.backend.webassembly.{Types => watpe}
+import org.scalajs.linker.backend.wasmemitter.WasmContext
+import org.scalajs.ir.WellKnownNames._
+import org.scalajs.ir.WitTypeDef
 import org.scalajs.ir.{WasmInterfaceTypes => wit}
 
 object Flatten {
@@ -22,7 +37,8 @@ object Flatten {
     assert(!(returnOffset.isDefined && returnOffset.get != watpe.Int32))
   }
 
-  def lowerFlattenFuncType(funcType: wit.FuncType): FlatFuncType = {
+  def lowerFlattenFuncType(funcType: wit.FuncType)(
+      implicit ctx: WasmContext): FlatFuncType = {
     val flatParamTypes = funcType.paramTypes.flatMap(flattenType)
     val flatResultTypes = funcType.resultType.toList.flatMap(flattenType)
 
@@ -46,7 +62,8 @@ object Flatten {
     )
   }
 
-  def liftFlattenFuncType(funcType: wit.FuncType): FlatFuncType = {
+  def liftFlattenFuncType(funcType: wit.FuncType)(
+      implicit ctx: WasmContext): FlatFuncType = {
     val flatParamTypes = funcType.paramTypes.flatMap(flattenType)
     val flatResultTypes = funcType.resultType.toList.flatMap(flattenType)
 
@@ -70,8 +87,8 @@ object Flatten {
     )
   }
 
-  def flattenType(tpe: wit.ValType): List[watpe.Type] = {
-    wit.despecialize(tpe) match {
+  def flattenType(tpe: wit.ValType)(implicit ctx: WasmContext): List[watpe.Type] = {
+    tpe match {
       case wit.BoolType                           => List(watpe.Int32)
       case wit.U8Type | wit.U16Type | wit.U32Type => List(watpe.Int32)
       case wit.S8Type | wit.S16Type | wit.S32Type => List(watpe.Int32)
@@ -81,29 +98,54 @@ object Flatten {
       case wit.CharType                           => List(watpe.Int32)
       case wit.StringType                         => List(watpe.Int32, watpe.Int32)
       case t: wit.ListType                        => flattenList(t)
-      case t: wit.RecordType                      => flattenRecord(t)
-      case t: wit.VariantType                     => flattenVariant(t)
-      case _: wit.FlagsType                       => List(watpe.Int32)
-      case _: wit.ResourceType                    => List(watpe.Int32)
+      case wit.TupleType(fields)                  => fields.flatMap(flattenType)
+      case t: wit.RecordTypeRef                   => flattenRecord(t)
+      case t: wit.VariantTypeRef                  => flattenVariant(t)
+      case wit.ResultType(ok, err)                => flattenVariantCases(resultCases(ok, err))
+      case wit.EnumTypeRef(className)             =>
+        val WitTypeDef.Enum(_, _, _, cases) = ctx.getWitTypeDef(className): @unchecked
+        flattenVariantCases(cases)
+      case wit.OptionType(t)   => List(watpe.Int32) ++ flattenVariants(List(t))
+      case _: wit.FlagsTypeRef => List(watpe.Int32)
+      case _: wit.ResourceType => List(watpe.Int32)
     }
   }
 
-  private def flattenList(t: wit.ListType): List[watpe.Type] = {
+  private def flattenList(t: wit.ListType)(implicit ctx: WasmContext): List[watpe.Type] = {
     t.length match {
       case Some(length) => List.fill(length)(flattenType(t.elemType)).flatten
       case None         => List(watpe.Int32, watpe.Int32)
     }
   }
 
-  private def flattenRecord(t: wit.RecordType): List[watpe.Type] =
-    t.fields.flatMap(f => flattenType(f.tpe))
+  private def flattenRecord(t: wit.RecordTypeRef)(
+      implicit ctx: WasmContext): List[watpe.Type] = {
+    val WitTypeDef.Record(_, _, _, fields) = ctx.getWitTypeDef(t.className): @unchecked
+    fields.flatMap(f => flattenType(f.tpe))
+  }
 
-  def flattenVariant(t: wit.VariantType): List[watpe.Type] = {
-    val variantTypes = t.cases.flatMap { case wit.CaseType(_, tpe) => tpe }
+  def flattenVariant(t: wit.VariantTypeRef)(
+      implicit ctx: WasmContext): List[watpe.Type] = {
+    val WitTypeDef.Variant(_, _, _, cases) = ctx.getWitTypeDef(t.className): @unchecked
+    flattenVariantCases(cases)
+  }
+
+  private def flattenVariantCases(cases: List[wit.CaseType])(
+      implicit ctx: WasmContext): List[watpe.Type] = {
+    val variantTypes = cases.flatMap { case wit.CaseType(_, _, tpe) => tpe }
     List(watpe.Int32) ++ flattenVariants(variantTypes)
   }
 
-  def flattenVariants(variants: List[wit.ValType]): List[watpe.Type] = {
+  private def resultCases(ok: Option[wit.ValType],
+      err: Option[wit.ValType]): List[wit.CaseType] = {
+    List(
+      wit.CaseType(ComponentResultOkClass, "ok", ok),
+      wit.CaseType(ComponentResultErrClass, "err", err)
+    )
+  }
+
+  def flattenVariants(variants: List[wit.ValType])(
+      implicit ctx: WasmContext): List[watpe.Type] = {
     variants.foldLeft(List.empty[watpe.Type]) { case (acc, variant) =>
       val flattened = flattenType(variant)
       val joined = acc.zip(flattened).map { case (a, b) => join(a, b) }

--- a/linker/shared/src/main/scala/org/scalajs/linker/checker/ClassDefChecker.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/checker/ClassDefChecker.scala
@@ -1270,6 +1270,7 @@ object ClassDefChecker {
       jsConstructorDef,
       exportedMembers,
       jsNativeMembers,
+      witTypeDef,
       witNativeMembers,
       topLevelExportDefs = Nil
     )(optimizerHints)

--- a/linker/shared/src/main/scala/org/scalajs/linker/frontend/BaseLinker.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/frontend/BaseLinker.scala
@@ -194,6 +194,7 @@ private[frontend] object BaseLinker {
         jsConstructor,
         jsMethodProps,
         jsNativeMembers,
+        classDef.witTypeDef,
         wasmwitNativeMembers,
         classDef.optimizerHints,
         classDef.pos,

--- a/linker/shared/src/main/scala/org/scalajs/linker/frontend/Desugarer.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/frontend/Desugarer.scala
@@ -94,6 +94,7 @@ final class Desugarer(config: CommonPhaseConfig, checkIR: Boolean) {
         jsConstructorDef = newJSConstructorDef,
         exportedMembers = newExportedMembers,
         jsNativeMembers,
+        witTypeDef,
         witNativeMembers,
         optimizerHints,
         pos,

--- a/linker/shared/src/main/scala/org/scalajs/linker/frontend/LambdaSynthesizer.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/frontend/LambdaSynthesizer.scala
@@ -138,7 +138,7 @@ private[linker] object LambdaSynthesizer {
     new ClassInfo(className, ClassKind.Class, Some(SyntheticClassKind.Lambda(descriptor)),
         nonExistent = false, Some(descriptor.superClass), descriptor.interfaces,
         jsNativeLoadSpec = None, referencedFieldClasses = Map.empty, methodInfos,
-        jsNativeMembers = Map.empty, witNativeMembers = Map.empty,
+        jsNativeMembers = Map.empty, witTypeDef = None, witNativeMembers = Map.empty,
         jsMethodProps = Nil, topLevelExports = Nil)
   }
 
@@ -204,6 +204,7 @@ private[linker] object LambdaSynthesizer {
       jsConstructor = None,
       jsMethodProps = Nil,
       jsNativeMembers = Nil,
+      witTypeDef = None,
       witNativeMembers = Nil,
       topLevelExportDefs = Nil
     )(OptimizerHints.empty.withInline(true))

--- a/linker/shared/src/main/scala/org/scalajs/linker/frontend/optimizer/IncOptimizer.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/frontend/optimizer/IncOptimizer.scala
@@ -189,6 +189,7 @@ final class IncOptimizer private[optimizer] (config: CommonPhaseConfig, collOps:
       interface.optimizedJSConstructorDef(),
       interface.optimizedExportedMembers(),
       linkedClass.jsNativeMembers,
+      linkedClass.witTypeDef,
       linkedClass.witNativeMembers,
       newTopLevelExports
     )(linkedClass.optimizerHints)(linkedClass.pos)

--- a/linker/shared/src/main/scala/org/scalajs/linker/standard/LinkedClass.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/standard/LinkedClass.scala
@@ -13,7 +13,7 @@
 package org.scalajs.linker.standard
 
 import org.scalajs.ir.Trees._
-import org.scalajs.ir.{ClassKind, Position, Version}
+import org.scalajs.ir.{ClassKind, Position, Version, WitTypeDef}
 import org.scalajs.ir.Names.{ClassName, FieldName, MethodName}
 
 /** A ClassDef after linking.
@@ -49,6 +49,7 @@ final class LinkedClass(
     val jsConstructorDef: Option[JSConstructorDef],
     val exportedMembers: List[JSMethodPropDef],
     val jsNativeMembers: List[JSNativeMemberDef],
+    val witTypeDef: Option[WitTypeDef],
     val witNativeMembers: List[WitNativeMemberDef],
     val optimizerHints: OptimizerHints,
     val pos: Position,

--- a/linker/shared/src/test/scala/org/scalajs/linker/testutils/TestIRBuilder.scala
+++ b/linker/shared/src/test/scala/org/scalajs/linker/testutils/TestIRBuilder.scala
@@ -22,6 +22,7 @@ import org.scalajs.ir.OriginalName
 import org.scalajs.ir.OriginalName.NoOriginalName
 import org.scalajs.ir.Trees._
 import org.scalajs.ir.Types._
+import org.scalajs.ir.WitTypeDef
 import org.scalajs.ir.WellKnownNames._
 
 import org.scalajs.linker.interface.ModuleInitializer
@@ -60,6 +61,7 @@ object TestIRBuilder {
       jsConstructor: Option[JSConstructorDef] = None,
       jsMethodProps: List[JSMethodPropDef] = Nil,
       jsNativeMembers: List[JSNativeMemberDef] = Nil,
+      witTypeDef: Option[WitTypeDef] = None,
       witNativeMembers: List[WitNativeMemberDef] = Nil,
       topLevelExportDefs: List[TopLevelExportDef] = Nil,
       optimizerHints: OptimizerHints = EOH
@@ -67,7 +69,8 @@ object TestIRBuilder {
     val notHashed = ClassDef(ClassIdent(className), NON, kind, jsClassCaptures,
         superClass.map(ClassIdent(_)), interfaces.map(ClassIdent(_)),
         jsSuperClass, jsNativeLoadSpec, fields, methods, jsConstructor,
-        jsMethodProps, jsNativeMembers, witNativeMembers, topLevelExportDefs)(
+        jsMethodProps, jsNativeMembers, witTypeDef, witNativeMembers,
+        topLevelExportDefs)(
         optimizerHints)
     Hashers.hashClassDef(notHashed)
   }

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -408,7 +408,8 @@ object Build {
 
   private val WasiCliRunModuleInitializerExport =
     WasmComponentModuleInitializerExport(
-        "wasi:cli/run@0.2.0",
+        org.scalajs.ir.WitScope.Interface(
+            "wasi", "cli", "run", Some("0.2.0")),
         "run",
         WasmComponentModuleInitializerExport.ResultType.ResultUnitUnit)
 

--- a/project/JavaLangObject.scala
+++ b/project/JavaLangObject.scala
@@ -185,6 +185,7 @@ object JavaLangObject {
           })(OptimizerHints.empty, Unversioned)
       ),
       jsNativeMembers = Nil,
+      witTypeDef = None,
       witNativeMembers = Nil,
       topLevelExportDefs = Nil)(OptimizerHints.empty)
 

--- a/project/JavalibIRCleaner.scala
+++ b/project/JavalibIRCleaner.scala
@@ -191,7 +191,7 @@ final class JavalibIRCleaner(baseDirectoryURI: URI) {
       val preprocessedTree = ClassDef(name, originalName, kind, jsClassCaptures,
           superClass, newInterfaces, jsSuperClass, jsNativeLoadSpec, fields,
           newMethods, jsConstructor, jsMethodProps, jsNativeMembers,
-          witNativeMembers, topLevelExportDefs)(
+          witTypeDef, witNativeMembers, topLevelExportDefs)(
           optimizerHints)(pos)
 
       // Only validate the hierarchy; do not transform
@@ -329,6 +329,7 @@ final class JavalibIRCleaner(baseDirectoryURI: URI) {
         classDef.jsConstructor,
         classDef.jsMethodProps,
         classDef.jsNativeMembers,
+        classDef.witTypeDef,
         classDef.witNativeMembers,
         classDef.topLevelExportDefs
       )(classDef.optimizerHints)(classDef.pos)

--- a/sbt-plugin/src/main/scala/org/scalajs/sbtplugin/ScalaJSPluginInternal.scala
+++ b/sbt-plugin/src/main/scala/org/scalajs/sbtplugin/ScalaJSPluginInternal.scala
@@ -98,7 +98,8 @@ private[sbtplugin] object ScalaJSPluginInternal {
 
     private final val TestBridgeModuleInitializerExport = {
       WasmComponentModuleInitializerExport(
-          "wasi:cli/run@0.2.0",
+          org.scalajs.ir.WitScope.Interface(
+              "wasi", "cli", "run", Some("0.2.0")),
           "run",
           WasmComponentModuleInitializerExport.ResultType.ResultUnitUnit)
     }

--- a/sbt-plugin/src/sbt-test/settings/wasm-component-jsenv/build.sbt
+++ b/sbt-plugin/src/sbt-test/settings/wasm-component-jsenv/build.sbt
@@ -56,7 +56,8 @@ lazy val testComponent = project
               .withWitDirectory(Some((baseDirectory.value / "wit").getAbsolutePath))
               .withWitWorld(Some("test"))
               .withModuleInitializerExport(Some(WasmComponentModuleInitializerExport(
-                  "wasi:cli/run@0.2.0",
+                  org.scalajs.ir.WitScope.Interface(
+                      "wasi", "cli", "run", Some("0.2.0")),
                   "run",
                   WasmComponentModuleInitializerExport.ResultType.ResultUnitUnit)))
           }

--- a/sbt-plugin/src/sbt-test/settings/wasm-component-jsenv/run-component/src/main/scala/wasmcomponent/Main.scala
+++ b/sbt-plugin/src/sbt-test/settings/wasm-component-jsenv/run-component/src/main/scala/wasmcomponent/Main.scala
@@ -4,7 +4,7 @@ import scala.scalajs.wit
 import scala.scalajs.wit.annotation._
 
 object Main {
-  @WitExport("wasi:cli/run@0.2.0", "run")
+  @WitExport(WitScope("wasi", "cli", "run", "0.2.0"), "run")
   def run(): wit.Result[Unit, Unit] = {
     Console.println("WasmComponent run")
     new wit.Ok(())

--- a/sbt-plugin/src/sbt-test/settings/wasm-component-jsenv/run-component/src/main/scala/wasmcomponent/wasi/cli/stdout.scala
+++ b/sbt-plugin/src/sbt-test/settings/wasm-component-jsenv/run-component/src/main/scala/wasmcomponent/wasi/cli/stdout.scala
@@ -6,7 +6,9 @@ package object stdout {
   type OutputStream = wasmcomponent.wasi.io.streams.OutputStream
 
   // Functions
-  @scala.scalajs.wit.annotation.WitImport("wasi:cli/stdout@0.2.0", "get-stdout")
+  @scala.scalajs.wit.annotation.WitImport(
+      scala.scalajs.wit.annotation.WitScope("wasi", "cli", "stdout", "0.2.0"),
+      "get-stdout")
   def getStdout(): OutputStream = scala.scalajs.wit.native
 
 }

--- a/sbt-plugin/src/sbt-test/settings/wasm-component-jsenv/run-component/src/main/scala/wasmcomponent/wasi/io/error.scala
+++ b/sbt-plugin/src/sbt-test/settings/wasm-component-jsenv/run-component/src/main/scala/wasmcomponent/wasi/io/error.scala
@@ -3,7 +3,9 @@ package wasmcomponent.wasi.io
 package object error {
 
   // Resources
-  @scala.scalajs.wit.annotation.WitResourceImport("wasi:io/error@0.2.0", "error")
+  @scala.scalajs.wit.annotation.WitResourceImport(
+      scala.scalajs.wit.annotation.WitScope("wasi", "io", "error", "0.2.0"),
+      "error")
   final class Error private () extends Object {
     @scala.scalajs.wit.annotation.WitResourceMethod("to-debug-string")
     def toDebugString(): String = scala.scalajs.wit.native

--- a/sbt-plugin/src/sbt-test/settings/wasm-component-jsenv/run-component/src/main/scala/wasmcomponent/wasi/io/poll.scala
+++ b/sbt-plugin/src/sbt-test/settings/wasm-component-jsenv/run-component/src/main/scala/wasmcomponent/wasi/io/poll.scala
@@ -3,7 +3,9 @@ package wasmcomponent.wasi.io
 package object poll {
 
   // Resources
-  @scala.scalajs.wit.annotation.WitResourceImport("wasi:io/poll@0.2.0", "pollable")
+  @scala.scalajs.wit.annotation.WitResourceImport(
+      scala.scalajs.wit.annotation.WitScope("wasi", "io", "poll", "0.2.0"),
+      "pollable")
   final class Pollable private () extends Object {
     @scala.scalajs.wit.annotation.WitResourceMethod("ready")
     def ready(): Boolean = scala.scalajs.wit.native
@@ -16,7 +18,11 @@ package object poll {
   }
 
   // Functions
-  @scala.scalajs.wit.annotation.WitImport("wasi:io/poll@0.2.0", "poll")
-  def poll(in: Array[Pollable]): Array[scala.scalajs.wit.unsigned.UInt] = scala.scalajs.wit.native
+  @scala.scalajs.wit.annotation.WitImport(
+      scala.scalajs.wit.annotation.WitScope("wasi", "io", "poll", "0.2.0"),
+      "poll")
+  def poll(
+      @scala.scalajs.wit.annotation.WitName("in") in: Array[Pollable]
+  ): Array[scala.scalajs.wit.unsigned.UInt] = scala.scalajs.wit.native
 
 }

--- a/sbt-plugin/src/sbt-test/settings/wasm-component-jsenv/run-component/src/main/scala/wasmcomponent/wasi/io/streams.scala
+++ b/sbt-plugin/src/sbt-test/settings/wasm-component-jsenv/run-component/src/main/scala/wasmcomponent/wasi/io/streams.scala
@@ -7,10 +7,15 @@ package object streams {
 
   type Pollable = wasmcomponent.wasi.io.poll.Pollable
 
-  @scala.scalajs.wit.annotation.WitVariant
+  @scala.scalajs.wit.annotation.WitVariant(
+      scala.scalajs.wit.annotation.WitScope("wasi", "io", "streams", "0.2.0"),
+      "stream-error")
   sealed trait StreamError
   object StreamError {
-    final class LastOperationFailed(val value: Error) extends StreamError {
+    @scala.scalajs.wit.annotation.WitName("last-operation-failed")
+    final class LastOperationFailed(
+        @scala.scalajs.wit.annotation.WitName("value") val value: Error)
+        extends StreamError {
       override def equals(other: Any): Boolean = other match {
         case that: LastOperationFailed => this.value == that.value
         case _ => false
@@ -24,16 +29,22 @@ package object streams {
       def apply(value: Error): LastOperationFailed = new LastOperationFailed(value)
       def unapply(arg: LastOperationFailed): Some[Error] = Some(arg.value)
     }
+    @scala.scalajs.wit.annotation.WitName("closed")
     object Closed extends StreamError {
       override def toString(): String = "Closed"
     }
   }
 
   // Resources
-  @scala.scalajs.wit.annotation.WitResourceImport("wasi:io/streams@0.2.0", "output-stream")
+  @scala.scalajs.wit.annotation.WitResourceImport(
+      scala.scalajs.wit.annotation.WitScope("wasi", "io", "streams", "0.2.0"),
+      "output-stream")
   final class OutputStream private () extends Object {
     @scala.scalajs.wit.annotation.WitResourceMethod("blocking-write-and-flush")
-    def blockingWriteAndFlush(contents: Array[scala.scalajs.wit.unsigned.UByte]): scala.scalajs.wit.Result[Unit, StreamError] = scala.scalajs.wit.native
+    def blockingWriteAndFlush(
+        @scala.scalajs.wit.annotation.WitName("contents")
+        contents: Array[scala.scalajs.wit.unsigned.UByte]): scala.scalajs.wit.Result[Unit, StreamError] =
+      scala.scalajs.wit.native
     @scala.scalajs.wit.annotation.WitResourceDrop
     def close(): Unit = scala.scalajs.wit.native
   }

--- a/test-bridge/src/main/scala/org/scalajs/testing/bridge/TestRpcTransport.scala
+++ b/test-bridge/src/main/scala/org/scalajs/testing/bridge/TestRpcTransport.scala
@@ -13,17 +13,17 @@
 package org.scalajs.testing.bridge
 
 import scalajs.wit
-import scalajs.wit.annotation.WitImport
+import scalajs.wit.annotation.{WitImport, WitName, WitScope}
 
 import java.util.Optional
 
 object TestRpcTransport {
-  @WitImport("scalajs:test-rpc/rpc", "init")
+  @WitImport(WitScope.unversioned("scalajs", "test-rpc", "rpc"), "init")
   def init(): Unit = wit.native
 
-  @WitImport("scalajs:test-rpc/rpc", "send")
-  def send(msg: String): Unit = wit.native
+  @WitImport(WitScope.unversioned("scalajs", "test-rpc", "rpc"), "send")
+  def send(@WitName("msg") msg: String): Unit = wit.native
 
-  @WitImport("scalajs:test-rpc/rpc", "poll")
+  @WitImport(WitScope.unversioned("scalajs", "test-rpc", "rpc"), "poll")
   def poll(): Optional[String] = wit.native
 }


### PR DESCRIPTION
towards https://github.com/scala-wasm/scala-wasm/issues/224 In later commit, we'll reconstruct WIT metadata component binary from SJSIR.
I'll merge this PR once CI passed, let's do a proper review when we upstream to Scala.js.

Previously, the annotations and IR had at least information for lowering to component-model interop. However, we could not reconstruct the original WIT metadata because

- Named types did not have information where those types are defined (which namespace:package/interface?).
- WIT types, parameters, and fields did not have reliable WIT names. (We could recover names from Scala name by converting CamelCase to kebab-case, but it's not reliable).
- There was no resource handle ownership information (own or borrow)
- (optionla) WIT interface annotations were just strings, there was no structured `namespace:package/interface` constraint, so the linker had to parse them to know which package are they defined.

This commit adds those missing information to annotation and IR so a later commit can rebuild WIT world metadata from linked IR.

**Annotations take an explicit `WitScope` instead of a module-id string.**

```scala
// wasi:cli/stdout@0.2.0
// for unversioned, `WitScope.unversioned("wasi", "cli", "stdout")`
@WitImport(WitScope("wasi", "cli", "stdout", "0.2.0"), "get-stdout")
def getStdout(): OutputStream = native
```

At SJSIR

```scala
WitNativeMemberDef(
  scope = WitScope.Interface("wasi", "cli", "stdout", Some("0.2.0")),
  name = WitFunctionName.Function("get-stdout"),
  ...)

WitExportDef(
  scope = WitScope.Interface("wasi", "cli", "run", Some("0.2.0")),
  name = WitFunctionName.Function("run"),
  ...)
```

**Named WIT types, cases, parameters, and fields requires WIT names (`@WitName`, scoped `@WitRecord` / `@WitVariant` / ...).**

```scala
// record datetime {
//      seconds: u64,
//      nanoseconds: u32,
//  }
@WitRecord(WitScope("wasi", "clocks", "wall-clock", "0.2.0"), "datetime")
final class Datetime(
    @WitName("seconds") val seconds: ULong,
    @WitName("nanoseconds") val nanoseconds: UInt
)
```


**IR stores named types as `ClassDef.witTypeDef`, and `ValType`s refer to them via `*TypeRef` / `ResourceRef` instead of inlining their bodies.**

```scala
// on class Datetime
ClassDef(
  Datetime,
  ...
  witTypeDef = Some(WitTypeDef.Record(
    className = DatetimeClass,
    scope = WitScope.Interface("wasi", "clocks", "wall-clock", Some("0.2.0")),
    name = "datetime",
    fields = List(
      FieldType(..., "seconds", U64Type),
      FieldType(..., "nanoseconds", U32Type))
    )
  )
)

// named type references
RecordTypeRef(DatetimeClass)
```

When decoding SJSIR from scala-js, all `witTypeDef` fields would be filled with `None` as hack.

**Resource annotation IR has information about ownership**

```scala
@WitResourceImport(WitScope("wasi", "io", "streams", "0.2.0"), "input-stream")
final class InputStream private () {
  @WitResourceMethod("read")
  def read(@WitName("len") len: ULong): Result[Array[UByte], StreamError] = native
}

// own<input-stream>
def take(s: InputStream): Unit = native
// borrow<input-stream>
def read(s: Borrow[InputStream]): Unit = native

// at IR
// resource handle
ResourceType(InputStreamClass, ResourceOwnership.Own)
```

---


Note that, component linking still uses the existing `witDirectory` embed. Later commit will read IR and deprecate `witDirectory`.

