### PR TITLE
Release snapshot version for every push on scala-wasm branch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -229,21 +229,18 @@ jobs:
         run: sbt sbtPlugin3/scripted
 
   publish-snapshot:
-    # needs:
-    #   - test-suite-js
-    #   - test-suite-webassembly
-    #   - test-suite-pure-wasm
-    #   - test-suite-component
-    #   - test-suite-jvm
-    #   - ir-compiler-and-linker-tests
-    #   - sbt-plugin-scripted
-    # for testing, temporaly running on PR to scala-wasm
+    needs:
+      - test-suite-js
+      - test-suite-webassembly
+      - test-suite-pure-wasm
+      - test-suite-component
+      - test-suite-jvm
+      - ir-compiler-and-linker-tests
+      - sbt-plugin-scripted
     if: >
       github.repository == 'scala-wasm/scala-wasm' &&
-      (
-        (github.event_name == 'push' && github.ref == 'refs/heads/scala-wasm') ||
-        (github.event_name == 'pull_request' && github.base_ref == 'scala-wasm')
-      )
+      github.event_name == 'push' &&
+      github.ref == 'refs/heads/scala-wasm'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -227,3 +227,42 @@ jobs:
         run: sbt sbtPlugin2_12/scripted
       - name: sbtPlugin3/scripted
         run: sbt sbtPlugin3/scripted
+
+  publish-snapshot:
+    # needs:
+    #   - test-suite-js
+    #   - test-suite-webassembly
+    #   - test-suite-pure-wasm
+    #   - test-suite-component
+    #   - test-suite-jvm
+    #   - ir-compiler-and-linker-tests
+    #   - sbt-plugin-scripted
+    # for testing, temporaly running on PR to scala-wasm
+    if: >
+      github.repository == 'scala-wasm/scala-wasm' &&
+      (
+        (github.event_name == 'push' && github.ref == 'refs/heads/scala-wasm') ||
+        (github.event_name == 'pull_request' && github.base_ref == 'scala-wasm')
+      )
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-java@v4
+        with:
+          distribution: 'temurin'
+          java-version: '17'
+          cache: 'sbt'
+      - uses: sbt/setup-sbt@v1
+      - name: Set per-commit SNAPSHOT version
+        env:
+          GIT_SHA: ${{ github.sha }}
+        run: ./scripts/set-snapshot-version.sh
+      - name: Publish SNAPSHOT to Maven Central
+        env:
+          SONATYPE_USERNAME: ${{ secrets.SONATYPE_USERNAME }}
+          SONATYPE_PASSWORD: ${{ secrets.SONATYPE_PASSWORD }}
+          PGP_PASSPHRASE: ${{ secrets.PGP_PASSPHRASE }}
+          PGP_SECRET: ${{ secrets.PGP_SECRET }}
+        run: |
+          echo "$PGP_SECRET" | base64 --decode | gpg --batch --import
+          ./scripts/publish.sh -x

--- a/scripts/set-snapshot-version.sh
+++ b/scripts/set-snapshot-version.sh
@@ -1,0 +1,42 @@
+#! /bin/sh
+# Rewrite ScalaJSVersions.current with commit-hash version
+#
+#   1.22.1-wasm.4-SNAPSHOT  ->  1.22.1-wasm.4-<7-char-sha>-SNAPSHOT
+#
+# Usage:
+#   ./scripts/set-snapshot-version.sh
+#
+# Optional env: `GIT_SHA`
+
+set -e
+
+# Use gsed on mac
+if command -v gsed >/dev/null 2>&1; then
+  SED=gsed
+else
+  SED=sed
+fi
+
+VERSIONS_FILE=ir/shared/src/main/scala/org/scalajs/ir/ScalaJSVersions.scala
+
+BASE_VERSION=$($SED -n 's/.*current = "\([^"]*\)".*/\1/p' "$VERSIONS_FILE" | head -1)
+case "$BASE_VERSION" in
+  *-SNAPSHOT) ;;
+  *)
+    echo "Can't rewrite non-SNAPSHOT version: $BASE_VERSION" >&2
+    exit 1
+    ;;
+esac
+
+RAW_SHA=${GIT_SHA:-$(git rev-parse HEAD)}
+SHORT_SHA=$(echo "$RAW_SHA" | cut -c1-7)
+PUBLISH_VERSION=$(echo "$BASE_VERSION" | $SED "s/-SNAPSHOT\$/-${SHORT_SHA}-SNAPSHOT/")
+
+echo "Base version:    $BASE_VERSION" >&2
+echo "Publish version: $PUBLISH_VERSION" >&2
+echo "Commit:          $RAW_SHA" >&2
+
+$SED -i "s/current = \"$BASE_VERSION\"/current = \"$PUBLISH_VERSION\"/" "$VERSIONS_FILE"
+echo "Rewrote $VERSIONS_FILE" >&2
+
+echo "$PUBLISH_VERSION"


### PR DESCRIPTION
The downstream ecosystem of scala-wasm (such as `wit-bindgen-scala`) depends on scala-wasm releases.

Before releasing scala-wasm, it would be nice to be able to test downstream tools and examples against changes on a every commits.

This commit releases a snapshot with the version suffix ``<commit hash>-SNAPSHOT` when we push to the scala-wasm branch and all other CI checks passed.