### PR TITLE
Support WIT named type alias in component binary using @WitAlias

### DIFF
--- a/compiler/src/main/scala/org/scalajs/nscplugin/GenJSCode.scala
+++ b/compiler/src/main/scala/org/scalajs/nscplugin/GenJSCode.scala
@@ -847,6 +847,7 @@ abstract class GenJSCode[G <: Global with Singleton](val global: G)
           memberExports,
           jsNativeMembers,
           witTypeDef = genWitTypeDef(sym),
+          witAliases = genWitAliasDefs(sym),
           witNativeMembers = witNativeMembersBuilder.result(),
           topLevelExportDefs ++ witExportDefsBuilder.result())(
           optimizerHints)
@@ -982,6 +983,7 @@ abstract class GenJSCode[G <: Global with Singleton](val global: G)
           jsMethodProps,
           jsNativeMembers = Nil,
           witTypeDef = None,
+          witAliases = Nil,
           witNativeMembers = Nil,
           topLevelExports)(
           OptimizerHints.empty)
@@ -1211,7 +1213,7 @@ abstract class GenJSCode[G <: Global with Singleton](val global: G)
 
       js.ClassDef(classIdent, originalNameOfClass(sym), kind, None, superClass,
           genClassInterfaces(sym, forJSClass = true), None, jsNativeLoadSpec,
-          Nil, Nil, None, Nil, Nil, None, Nil, Nil)(
+          Nil, Nil, None, Nil, Nil, None, Nil, Nil, Nil)(
           OptimizerHints.empty)
     }
 
@@ -1233,7 +1235,7 @@ abstract class GenJSCode[G <: Global with Singleton](val global: G)
 
       js.ClassDef(classIdent, originalNameOfClass(sym), ClassKind.Interface,
           None, None, interfaces, None, None, fields = Nil, methods = allMemberDefs,
-          None, Nil, Nil, genWitTypeDef(sym), Nil, Nil)(
+          None, Nil, Nil, genWitTypeDef(sym), genWitAliasDefs(sym), Nil, Nil)(
           OptimizerHints.empty)
     }
 
@@ -6910,6 +6912,7 @@ abstract class GenJSCode[G <: Global with Singleton](val global: G)
           Nil,
           Nil,
           None,
+          Nil,
           Nil,
           Nil)(
           js.OptimizerHints.empty.withInline(true))

--- a/compiler/src/main/scala/org/scalajs/nscplugin/GenWitInterop.scala
+++ b/compiler/src/main/scala/org/scalajs/nscplugin/GenWitInterop.scala
@@ -14,8 +14,6 @@ package org.scalajs.nscplugin
 
 import scala.tools.nsc._
 
-import scala.collection.mutable
-
 import org.scalajs.ir.{
   Names,
   Trees => js,
@@ -24,6 +22,7 @@ import org.scalajs.ir.{
   WitScope,
   ResourceOwnership,
   WitTypeDef,
+  WitAliasDef,
   ClassKind,
   Position
 }
@@ -235,6 +234,21 @@ trait GenWitInterop[G <: Global with Singleton] extends SubComponent {
     }
   }
 
+  /** Collect `@WitAlias` type aliases owned by this class/module. */
+  def genWitAliasDefs(owner: Symbol): List[WitAliasDef] = {
+    val aliases = exitingPhase(currentRun.typerPhase) {
+      owner.info.decls.toList.collect {
+        case tsym if tsym.isAliasType && tsym.hasAnnotation(WitAliasAnnotation) =>
+          val (scope, name) = witIdOf(tsym, WitAliasAnnotation)
+          (scope, name, tsym.info.dealias)
+      }
+    }
+    aliases.map {
+      case (scope, name, targetTpe) =>
+        WitAliasDef(scope, name, toWIT(targetTpe))
+    }
+  }
+
   private def witVariantValueTypeOf(sym: Symbol): Type = {
     exitingPhase(currentRun.typerPhase) {
       if (sym.isModuleClass) {
@@ -262,7 +276,14 @@ trait GenWitInterop[G <: Global with Singleton] extends SubComponent {
       val arg = tpe.typeArgs.headOption.getOrElse {
         throw new AssertionError(s"Borrow without a type argument in $tpe")
       }
-      toWIT(arg) match {
+      val resourceTpe = { // dealias @WitAlias type alias
+        val argSym = exitingPhase(currentRun.typerPhase)(arg.typeSymbolDirect)
+        if (argSym.hasAnnotation(WitAliasAnnotation))
+          exitingPhase(currentRun.typerPhase)(argSym.info.dealias)
+        else
+          arg
+      }
+      toWIT(resourceTpe) match {
         case res: wit.ResourceType =>
           Some(res.copy(ownership = ResourceOwnership.Borrow))
         case other =>
@@ -274,6 +295,12 @@ trait GenWitInterop[G <: Global with Singleton] extends SubComponent {
 
   private def toWIT(tpe: Type): wit.ValType = {
     val directTpe = exitingPhase(currentRun.typerPhase)(tpe)
+    val directSym = exitingPhase(currentRun.typerPhase)(directTpe.typeSymbolDirect)
+    if (directSym.hasAnnotation(WitAliasAnnotation)) {
+      val (scope, name) = witIdOf(directSym, WitAliasAnnotation)
+      return wit.AliasTypeRef(scope, name, encodeClassName(directSym.owner))
+    }
+
     val dealiasedTpe = exitingPhase(currentRun.typerPhase)(directTpe.dealias)
 
     unsigned2WIT.get(directTpe.typeSymbolDirect).orElse {

--- a/compiler/src/main/scala/org/scalajs/nscplugin/JSDefinitions.scala
+++ b/compiler/src/main/scala/org/scalajs/nscplugin/JSDefinitions.scala
@@ -84,6 +84,7 @@ trait JSDefinitions {
     lazy val WitVariantAnnotation = getRequiredClass("scala.scalajs.wit.annotation.WitVariant")
     lazy val WitFlagsAnnotation  = getRequiredClass("scala.scalajs.wit.annotation.WitFlags")
     lazy val WitEnumAnnotation   = getRequiredClass("scala.scalajs.wit.annotation.WitEnum")
+    lazy val WitAliasAnnotation  = getRequiredClass("scala.scalajs.wit.annotation.WitAlias")
     lazy val WitNameAnnotation   = getRequiredClass("scala.scalajs.wit.annotation.WitName")
 
     lazy val WitBorrowAlias = getTypeMember(ScalaJSWitPackageModule, newTermName("Borrow"))

--- a/compiler/src/main/scala/org/scalajs/nscplugin/PrepJSInterop.scala
+++ b/compiler/src/main/scala/org/scalajs/nscplugin/PrepJSInterop.scala
@@ -175,6 +175,8 @@ abstract class PrepJSInterop[G <: Global with Singleton](val global: G)
         checkWitRecord(sym)
       else if (sym.hasAnnotation(WitFlagsAnnotation))
         checkWitFlags(sym)
+      else if (sym.hasAnnotation(WitAliasAnnotation))
+        checkWitAlias(sym)
       else if (WasmComponentResourceAnnots.exists(sym.hasAnnotation(_)))
         checkWasmComponentResourceAnnotationContext(tree.pos, sym)
       else if (WasmComponentFunctionAnnots.exists(sym.hasAnnotation(_)))
@@ -233,7 +235,12 @@ abstract class PrepJSInterop[G <: Global with Singleton](val global: G)
             transformScalaValOrDefDef(tree)
           }
 
-        case _:TypeDef | _:PackageDef =>
+        case td: TypeDef =>
+          if (td.symbol.hasAnnotation(WitAliasAnnotation))
+            checkWitAlias(td.symbol)
+          super.transform(tree)
+
+        case _: PackageDef =>
           super.transform(tree)
       }
 
@@ -1093,8 +1100,9 @@ abstract class PrepJSInterop[G <: Global with Singleton](val global: G)
       val sym = dealiased.typeSymbol
       val fullName = sym.fullName
 
-      // Check primitives
-      if (sym == UnitClass || sym == ByteClass || sym == ShortClass || sym == IntClass || sym == LongClass ||
+      if (tpe.typeSymbolDirect.hasAnnotation(WitAliasAnnotation)) {
+        true
+      } else if (sym == UnitClass || sym == ByteClass || sym == ShortClass || sym == IntClass || sym == LongClass ||
           sym == FloatClass || sym == DoubleClass || sym == CharClass || sym == BooleanClass) {
         true
       } else if (sym.fullName == "java.lang.String") {
@@ -1118,10 +1126,27 @@ abstract class PrepJSInterop[G <: Global with Singleton](val global: G)
           sym.hasAnnotation(WitVariantAnnotation) ||
           sym.hasAnnotation(WitEnumAnnotation) ||
           sym.hasAnnotation(WitFlagsAnnotation) ||
+          sym.hasAnnotation(WitAliasAnnotation) ||
           sym.hasAnnotation(WitResourceImportAnnotation)) {
         true
       } else {
         false
+      }
+    }
+
+    private def checkWitAlias(sym: Symbol): Unit = {
+      if (!sym.isAliasType) {
+        reporter.error(sym.pos,
+            "@WitAlias can only be used on type aliases")
+      } else if (!isComponentModelCompatible(sym.info)) {
+        reporter.error(sym.pos,
+            s"@WitAlias target type '${sym.info}' is not compatible with Component Model")
+      } else {
+        val annot = sym.getAnnotation(WitAliasAnnotation).get
+        if (jsInterop.witScopeArg(annot, 0).isEmpty || annot.stringArg(1).isEmpty) {
+          reporter.error(sym.pos,
+              "@WitAlias requires a literal WitScope and a literal name")
+        }
       }
     }
 

--- a/examples/test-component-model/rust-exports/src/lib.rs
+++ b/examples/test-component-model/rust-exports/src/lib.rs
@@ -132,6 +132,7 @@ impl Tests for Component {
   fn roundtrip_tuple2(a: (i32, String)) -> (i32, String) { a }
   fn roundtrip_tuple3(a: (i32, String, bool)) -> (i32, String, bool) { a }
   fn roundtrip_named_r(a: NamedR) -> NamedR { a }
+  fn roundtrip_option_u32(a: OptionU32) -> OptionU32 { a }
 }
 
 bindings::export!(Component with_types_in bindings);

--- a/examples/test-component-model/rust-run/src/lib.rs
+++ b/examples/test-component-model/rust-run/src/lib.rs
@@ -105,8 +105,16 @@ impl Run for Component {
       assert_eq!(roundtrip_tuple2((111, "hello")), (111, "hello".to_string()));
       assert_eq!(roundtrip_tuple3((111, "hello", false)), (111, "hello".to_string(), false));
 
+      // Named WIT type alias, Scala should export named type alias in Component binary.
+      test_wit_type_alias();
+
       return Ok(());
     }
+}
+
+fn test_wit_type_alias() {
+    assert_eq!(roundtrip_option_u32(Some(42)), Some(42));
+    assert_eq!(roundtrip_option_u32(None), None);
 }
 
 bindings::export!(Component with_types_in bindings);

--- a/examples/test-component-model/src/main/scala/componentmodel/TestImportsImpl.scala
+++ b/examples/test-component-model/src/main/scala/componentmodel/TestImportsImpl.scala
@@ -172,8 +172,16 @@ object TestImportsImpl {
     // Test Object methods on imported resources
     TestFunctions.testResourceObjectMethods()
 
+    testWitTypeAlias()
+
     val end = Console.currentTimeMillis()
     Console.println(s"elapsed: ${(end - start).toInt} ms")
+  }
+
+  def testWitTypeAlias(): Unit = {
+    assert(Optional.of(7.asInstanceOf[UInt]) ==
+      roundtripOptionU32(Optional.of(7.asInstanceOf[UInt])))
+    assert(Optional.empty[UInt]() == roundtripOptionU32(Optional.empty[UInt]()))
   }
 }
 

--- a/examples/test-component-model/src/main/scala/componentmodel/TestsImpl.scala
+++ b/examples/test-component-model/src/main/scala/componentmodel/TestsImpl.scala
@@ -97,4 +97,7 @@ object TestsImpl {
   @WitExport(WitScope.unversioned("component", "testing", "tests"), "roundtrip-named-r")
   def roundtripNamedR(@WitName("a") a: NamedR): NamedR = roundtrip(a)
 
+  @WitExport(WitScope.unversioned("component", "testing", "tests"), "roundtrip-option-u32")
+  def roundtripOptionU32(@WitName("a") a: OptionU32): OptionU32 = roundtrip(a)
+
 }

--- a/examples/test-component-model/src/main/scala/componentmodel/component/testing/tests.scala
+++ b/examples/test-component-model/src/main/scala/componentmodel/component/testing/tests.scala
@@ -366,7 +366,8 @@ package object tests {
   @WitImport(WitScope.unversioned("component", "testing", "tests"), "roundtrip-named-r")
   def roundtripNamedR(@WitName("a") a: NamedR): NamedR = wit.native
 
-  // Named WIT type alias, Scala should export named type alias in Component binary.
+  // Named WIT type alias
+  @WitAlias(WitScope.unversioned("component", "testing", "tests"), "option-u32")
   type OptionU32 = java.util.Optional[wit.unsigned.UInt]
 
   @WitImport(WitScope.unversioned("component", "testing", "tests"), "roundtrip-option-u32")

--- a/examples/test-component-model/src/main/scala/componentmodel/component/testing/tests.scala
+++ b/examples/test-component-model/src/main/scala/componentmodel/component/testing/tests.scala
@@ -366,4 +366,10 @@ package object tests {
   @WitImport(WitScope.unversioned("component", "testing", "tests"), "roundtrip-named-r")
   def roundtripNamedR(@WitName("a") a: NamedR): NamedR = wit.native
 
+  // Named WIT type alias, Scala should export named type alias in Component binary.
+  type OptionU32 = java.util.Optional[wit.unsigned.UInt]
+
+  @WitImport(WitScope.unversioned("component", "testing", "tests"), "roundtrip-option-u32")
+  def roundtripOptionU32(@WitName("a") a: OptionU32): OptionU32 = wit.native
+
 }

--- a/examples/test-component-model/wit/world.wit
+++ b/examples/test-component-model/wit/world.wit
@@ -133,6 +133,10 @@ interface tests {
   record named-r { b: named-f }
   flags named-f { b0 }
   roundtrip-named-r: func(a: named-r) -> named-r;
+
+  // Named type alias must appear as an interface type export.
+  type option-u32 = option<u32>;
+  roundtrip-option-u32: func(a: option-u32) -> option-u32;
 }
 
 interface test-imports {

--- a/ir/shared/src/main/scala/org/scalajs/ir/Hashers.scala
+++ b/ir/shared/src/main/scala/org/scalajs/ir/Hashers.scala
@@ -134,7 +134,7 @@ object Hashers {
     val newTopLevelExportDefs = topLevelExportDefs.map(hashTopLevelExportDef(_))
     ClassDef(name, originalName, kind, jsClassCaptures, superClass, interfaces,
         jsSuperClass, jsNativeLoadSpec, fields, newMethods, newJSConstructorDef,
-        newExportedMembers, jsNativeMembers, witTypeDef, witNativeMembers,
+        newExportedMembers, jsNativeMembers, witTypeDef, witAliases, witNativeMembers,
         newTopLevelExportDefs)(
         optimizerHints)
   }

--- a/ir/shared/src/main/scala/org/scalajs/ir/Serializers.scala
+++ b/ir/shared/src/main/scala/org/scalajs/ir/Serializers.scala
@@ -681,11 +681,20 @@ object Serializers {
       writeJSNativeLoadSpec(jsNativeLoadSpec)
       writeBoolean(witTypeDef.isDefined)
       witTypeDef.foreach(writeWITTypeDef)
+      writeInt(witAliases.size)
+      witAliases.foreach(writeWitAliasDef)
       writeMemberDefs(
           fields ::: methods ::: jsConstructor.toList ::: jsMethodProps ::: jsNativeMembers
           ::: witNativeMembers)
       writeTopLevelExportDefs(topLevelExportDefs)
       writeInt(OptimizerHints.toBits(optimizerHints))
+    }
+
+    def writeWitAliasDef(alias: WitAliasDef): Unit = {
+      buffer.writeByte(TagWITAliasDef)
+      writeWitScope(alias.scope)
+      writeString(alias.name)
+      writeWITType(alias.target)
     }
 
     def writeMemberDef(memberDef: MemberDef): Unit = {
@@ -1061,6 +1070,11 @@ object Serializers {
           case ResourceOwnership.Own    => 0
           case ResourceOwnership.Borrow => 1
         })
+      case wit.AliasTypeRef(scope, name, owner) =>
+        buffer.writeByte(TagWITAliasTypeRef)
+        writeWitScope(scope)
+        writeString(name)
+        writeName(owner)
       case wit.FuncType(params, result) =>
         buffer.writeByte(TagWITFuncType)
         buffer.writeInt(params.length)
@@ -1965,6 +1979,10 @@ object Serializers {
         else if (readBoolean()) Some(readWITTypeDef())
         else None
       }
+      val witAliases = {
+        if (!hacks.isWasmIR) Nil
+        else List.fill(readInt())(readWitAliasDef())
+      }
 
       // Read member defs
       val fieldsBuilder = List.newBuilder[AnyFieldDef]
@@ -2021,7 +2039,8 @@ object Serializers {
 
       val classDef = ClassDef(name, originalName, kind, jsClassCaptures, superClass, parents,
           jsSuperClass, jsNativeLoadSpec, fields, methods, jsConstructor,
-          jsMethodProps, jsNativeMembers, witTypeDef, witNativeMembers, topLevelExportDefs)(
+          jsMethodProps, jsNativeMembers, witTypeDef, witAliases, witNativeMembers,
+          topLevelExportDefs)(
           optimizerHints)
 
       if (hacks.useBelow(19))
@@ -2398,6 +2417,7 @@ object Serializers {
           jsMethodProps,
           jsNativeMembers,
           witTypeDef,
+          witAliases,
           witNativeMembers,
           topLevelExportDefs
         )(OptimizerHints.empty)(pos) // throws away the `@inline`
@@ -2867,6 +2887,8 @@ object Serializers {
             case 1 => ResourceOwnership.Borrow
           }
           wit.ResourceType(className, ownership)
+        case TagWITAliasTypeRef =>
+          wit.AliasTypeRef(readWitScope(), readString(), readClassName())
       }
     }
 
@@ -2920,6 +2942,11 @@ object Serializers {
           val name = readString()
           WitTypeDef.Resource(wit.ResourceRef(className, scope, name))
       }
+    }
+
+    private def readWitAliasDef(): WitAliasDef = {
+      assert(readByte() == TagWITAliasDef)
+      WitAliasDef(readWitScope(), readString(), readWITType())
     }
 
     def readType(): Type = {

--- a/ir/shared/src/main/scala/org/scalajs/ir/Tags.scala
+++ b/ir/shared/src/main/scala/org/scalajs/ir/Tags.scala
@@ -271,6 +271,8 @@ private[ir] object Tags {
   final val TagWITEnumTypeDef = TagWITVariantTypeDef + 1
   final val TagWITFlagsTypeDef = TagWITEnumTypeDef + 1
   final val TagWITResourceTypeDef = TagWITFlagsTypeDef + 1
+  final val TagWITAliasTypeRef = TagWITResourceTypeDef + 1
+  final val TagWITAliasDef = TagWITAliasTypeRef + 1
 
   // Tags for wasm Component Function kind
 

--- a/ir/shared/src/main/scala/org/scalajs/ir/Transformers.scala
+++ b/ir/shared/src/main/scala/org/scalajs/ir/Transformers.scala
@@ -234,6 +234,7 @@ object Transformers {
         jsMethodProps.map(transformJSMethodPropDef),
         jsNativeMembers,
         witTypeDef,
+        witAliases,
         witNativeMembers,
         topLevelExportDefs.map(transformTopLevelExportDef)
       )(

--- a/ir/shared/src/main/scala/org/scalajs/ir/Trees.scala
+++ b/ir/shared/src/main/scala/org/scalajs/ir/Trees.scala
@@ -1497,6 +1497,8 @@ object Trees {
        *  Currently, only relevant for WIT record, variant, enum, flags and resource.
        */
       val witTypeDef: Option[WitTypeDef],
+      /** WIT named type aliases whose Scala definition is owned by this class. */
+      val witAliases: List[WitAliasDef],
       val witNativeMembers: List[WitNativeMemberDef],
       val topLevelExportDefs: List[TopLevelExportDef]
   )(
@@ -1522,6 +1524,7 @@ object Trees {
         jsMethodProps: List[JSMethodPropDef],
         jsNativeMembers: List[JSNativeMemberDef],
         witTypeDef: Option[WitTypeDef],
+        witAliases: List[WitAliasDef] = Nil,
         witNativeMembers: List[WitNativeMemberDef],
         topLevelExportDefs: List[TopLevelExportDef]
     )(
@@ -1529,7 +1532,7 @@ object Trees {
         implicit pos: Position): ClassDef = {
       new ClassDef(name, originalName, kind, jsClassCaptures, superClass,
           interfaces, jsSuperClass, jsNativeLoadSpec, fields, methods,
-          jsConstructor, jsMethodProps, jsNativeMembers, witTypeDef,
+          jsConstructor, jsMethodProps, jsNativeMembers, witTypeDef, witAliases,
           witNativeMembers, topLevelExportDefs)(
           optimizerHints)
     }

--- a/ir/shared/src/main/scala/org/scalajs/ir/WasmInterfaceTypes.scala
+++ b/ir/shared/src/main/scala/org/scalajs/ir/WasmInterfaceTypes.scala
@@ -141,6 +141,14 @@ object WasmInterfaceTypes {
     def toIRType(): jstpe.Type = jstpe.ClassType(className, nullable = true, exact = false)
   }
 
+  /** Named WIT type alias reference (`type name = ...`). */
+  final case class AliasTypeRef(scope: WitScope, name: String, owner: ClassName) extends ValType {
+    def toIRType(): jstpe.Type = {
+      throw new AssertionError(
+          s"AliasTypeRef($scope, $name, $owner) must be dealiased first")
+    }
+  }
+
   /** A WIT resource declaration, without handle ownership.
    *
    *  For example, `streams/input-stream` in:
@@ -193,7 +201,28 @@ object WasmInterfaceTypes {
     case EnumTypeRef(className)    => jstpe.ClassRef(className)
     case OptionType(tpe)           => jstpe.ClassRef(ClassName("java.util.Optional"))
     case FlagsTypeRef(className)   => jstpe.ClassRef(className)
-    case ResourceType(className, _) => jstpe.ClassRef(className)
+    case ResourceType(className, _)       => jstpe.ClassRef(className)
+    case AliasTypeRef(scope, name, owner) =>
+      throw new AssertionError(
+          s"AliasTypeRef($scope, $name, $owner) must be dealiased first")
+  }
+
+  def dealias(tpe: ValType, resolve: (WitScope, String) => ValType): ValType = {
+    def loop(t: ValType): ValType = t match {
+      case AliasTypeRef(scope, name, _) =>
+        loop(resolve(scope, name))
+      case ListType(elem, len) =>
+        ListType(loop(elem), len)
+      case TupleType(ts) =>
+        TupleType(ts.map(loop))
+      case OptionType(inner) =>
+        OptionType(loop(inner))
+      case ResultType(ok, err) =>
+        ResultType(ok.map(loop), err.map(loop))
+      case other =>
+        other
+    }
+    loop(tpe)
   }
 
   def makeCtorName(tpe: Option[ValType]): MethodName = {

--- a/ir/shared/src/main/scala/org/scalajs/ir/WitTypeDef.scala
+++ b/ir/shared/src/main/scala/org/scalajs/ir/WitTypeDef.scala
@@ -50,3 +50,7 @@ object WitTypeDef {
     def name: String = resource.name
   }
 }
+
+/** Named WIT `type name = target`, stored on the enclosing module ClassDef. */
+final case class WitAliasDef(scope: WitScope, name: String,
+    target: WasmInterfaceTypes.ValType)

--- a/ir/shared/src/test/scala/org/scalajs/ir/PrintersTest.scala
+++ b/ir/shared/src/test/scala/org/scalajs/ir/PrintersTest.scala
@@ -1132,7 +1132,7 @@ class PrintersTest {
 
     def makeForKind(kind: ClassKind): ClassDef = {
       ClassDef("Test", NON, kind, None, Some(ObjectClass), Nil, None, None, Nil,
-          Nil, None, Nil, Nil, None, Nil, Nil)(
+          Nil, None, Nil, Nil, None, Nil, Nil, Nil)(
           NoOptHints)
     }
 
@@ -1204,7 +1204,7 @@ class PrintersTest {
     def makeForParents(superClass: Option[ClassIdent],
         interfaces: List[ClassIdent]): ClassDef = {
       ClassDef("Test", NON, ClassKind.Class, None, superClass, interfaces, None,
-          None, Nil, Nil, None, Nil, Nil, None, Nil, Nil)(
+          None, Nil, Nil, None, Nil, Nil, None, Nil, Nil, Nil)(
           NoOptHints)
     }
 
@@ -1238,7 +1238,7 @@ class PrintersTest {
         """,
         ClassDef("Test", NON, ClassKind.NativeJSClass, None, Some(ObjectClass), Nil,
             None, Some(JSNativeLoadSpec.Global("Foo", List("Bar"))), Nil, Nil, None,
-            Nil, Nil, None, Nil, Nil)(
+            Nil, Nil, None, Nil, Nil, Nil)(
             NoOptHints))
 
     assertPrintEquals(
@@ -1248,7 +1248,7 @@ class PrintersTest {
         """,
         ClassDef("Test", NON, ClassKind.NativeJSClass, None, Some(ObjectClass), Nil,
             None, Some(JSNativeLoadSpec.Import("foo", List("Bar"))), Nil, Nil, None,
-            Nil, Nil, None, Nil, Nil)(
+            Nil, Nil, None, Nil, Nil, Nil)(
             NoOptHints))
 
     assertPrintEquals(
@@ -1262,7 +1262,7 @@ class PrintersTest {
                 JSNativeLoadSpec.Import("foo", List("Bar")),
                 JSNativeLoadSpec.Global("Baz", List("Foobar")))),
             Nil, Nil, None,
-            Nil, Nil, None, Nil, Nil)(
+            Nil, Nil, None, Nil, Nil, Nil)(
             NoOptHints))
   }
 
@@ -1274,7 +1274,7 @@ class PrintersTest {
           |}
         """,
         ClassDef("Test", NON, ClassKind.JSClass, Some(Nil), Some(ObjectClass), Nil,
-            None, None, Nil, Nil, None, Nil, Nil, None, Nil, Nil)(
+            None, None, Nil, Nil, None, Nil, Nil, None, Nil, Nil, Nil)(
             NoOptHints))
 
     assertPrintEquals(
@@ -1288,7 +1288,7 @@ class PrintersTest {
               ParamDef("x", NON, IntType, mutable = false),
               ParamDef("y", TestON, StringType, mutable = false)
             )),
-            Some(ObjectClass), Nil, None, None, Nil, Nil, None, Nil, Nil, None, Nil, Nil)(
+            Some(ObjectClass), Nil, None, None, Nil, Nil, None, Nil, Nil, None, Nil, Nil, Nil)(
             NoOptHints))
   }
 
@@ -1302,7 +1302,7 @@ class PrintersTest {
         ClassDef("Test", NON, ClassKind.JSClass,
             Some(List(ParamDef("sup", NON, AnyType, mutable = false))),
             Some("Bar"), Nil, Some(ref("sup", AnyType)), None, Nil, Nil, None,
-            Nil, Nil, None, Nil, Nil)(
+            Nil, Nil, None, Nil, Nil, Nil)(
             NoOptHints))
   }
 
@@ -1313,7 +1313,7 @@ class PrintersTest {
           |}
         """,
         ClassDef("Test", NON, ClassKind.Class, None, Some(ObjectClass), Nil,
-            None, None, Nil, Nil, None, Nil, Nil, None, Nil, Nil)(
+            None, None, Nil, Nil, None, Nil, Nil, None, Nil, Nil, Nil)(
             NoOptHints.withInline(true)))
   }
 
@@ -1324,7 +1324,7 @@ class PrintersTest {
           |}
         """,
         ClassDef("Test", TestON, ClassKind.ModuleClass, None, Some(ObjectClass),
-            Nil, None, None, Nil, Nil, None, Nil, Nil, None, Nil, Nil)(
+            Nil, None, None, Nil, Nil, None, Nil, Nil, None, Nil, Nil, Nil)(
             NoOptHints))
   }
 
@@ -1356,6 +1356,7 @@ class PrintersTest {
             List(JSNativeMemberDef(MemberFlags.empty.withNamespace(Static), MethodName("p", Nil, O),
                 JSNativeLoadSpec.Global("foo", Nil))),
             None,
+            Nil,
             List(WitNativeMemberDef(MemberFlags.empty.withNamespace(Static),
                 WitScope.Interface("wasi", "io", "streams", None),
                 WitFunctionName.Function("get-stdout"),

--- a/library/src/main/scala/scala/scalajs/wit/annotation/WitAlias.scala
+++ b/library/src/main/scala/scala/scalajs/wit/annotation/WitAlias.scala
@@ -1,0 +1,18 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
+package scala.scalajs.wit.annotation
+
+/** Marks a Scala type alias as a named WIT `type` alias. */
+class WitAlias private () extends scala.annotation.StaticAnnotation {
+  def this(scope: WitScope, name: String) = this()
+}

--- a/linker/shared/src/main/scala/org/scalajs/linker/analyzer/Analyzer.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/analyzer/Analyzer.scala
@@ -734,6 +734,14 @@ private class AnalyzerRun(config: CommonPhaseConfig, initial: Boolean,
       }
     }
 
+    private[this] val isWitAliasesUsed = new AtomicBoolean(false)
+
+    def useWitAliases(moduleUnit: ModuleUnit)(implicit from: From): Unit = {
+      if (isWitAliasesUsed.compareAndSet(false, true)) {
+        data.witAliases.foreach(followReachabilityInfo(_, moduleUnit))
+      }
+    }
+
     val jsNativeLoadSpec: Option[JSNativeLoadSpec] = data.jsNativeLoadSpec
 
     private[this] val _staticDependencies: mutable.Map[ClassName, Unit] = emptyThreadSafeMap
@@ -1565,6 +1573,7 @@ private class AnalyzerRun(config: CommonPhaseConfig, initial: Boolean,
       lookupClass(dataInClass.className) { clazz =>
         val className = dataInClass.className
         clazz.useWitTypeDef(moduleUnit)
+        clazz.useWitAliases(moduleUnit)
 
         val flags = dataInClass.flags
         if (flags != 0) {
@@ -1733,7 +1742,8 @@ private class AnalyzerRun(config: CommonPhaseConfig, initial: Boolean,
     new Infos.ClassInfo(className, ClassKind.Class, syntheticKind = None, nonExistent = true,
         superClass = superClass, interfaces = Nil, jsNativeLoadSpec = None,
         referencedFieldClasses = Map.empty, methods = methods,
-        jsNativeMembers = Map.empty, witTypeDef = None, witNativeMembers = Map.empty,
+        jsNativeMembers = Map.empty, witTypeDef = None, witAliases = None,
+        witNativeMembers = Map.empty,
         jsMethodProps = Nil, topLevelExports = Nil)
   }
 

--- a/linker/shared/src/main/scala/org/scalajs/linker/analyzer/InfoLoader.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/analyzer/InfoLoader.scala
@@ -128,7 +128,13 @@ private[analyzer] object InfoLoader {
       val jsNativeMembers = classDef.jsNativeMembers
         .map(m => m.name.name -> m.jsNativeLoadSpec).toMap
 
-      val witTypeDef = classDef.witTypeDef.map(generator.generateWitTypeDef(_))
+      val witTypeDef =
+        if (classDef.witTypeDef.isEmpty) None
+        else Some(generator.generateWitTypeDef(classDef))
+
+      val witAliases =
+        if (classDef.witAliases.isEmpty) None
+        else Some(generator.generateWitAliases(classDef.witAliases))
 
       val witNativeMembers = classDef.witNativeMembers
         .map(m => m.method.name -> generator.generateWitNativeMember(m)).toMap
@@ -137,7 +143,7 @@ private[analyzer] object InfoLoader {
           nonExistent = false, classDef.superClass.map(_.name),
           classDef.interfaces.map(_.name), classDef.jsNativeLoadSpec,
           referencedFieldClasses, prevMethodInfos, jsNativeMembers,
-          witTypeDef, witNativeMembers, exportedMembers, topLevelExports)
+          witTypeDef, witAliases, witNativeMembers, exportedMembers, topLevelExports)
     }
 
     /** Returns true if the cache has been used and should be kept. */

--- a/linker/shared/src/main/scala/org/scalajs/linker/analyzer/Infos.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/analyzer/Infos.scala
@@ -23,6 +23,7 @@ import org.scalajs.ir.Types._
 import org.scalajs.ir.Version
 import org.scalajs.ir.WellKnownNames._
 import org.scalajs.ir.WitTypeDef
+import org.scalajs.ir.WitAliasDef
 import org.scalajs.ir.{WasmInterfaceTypes => wit}
 
 import org.scalajs.linker.frontend.{LinkTimeEvaluator, LinkTimeProperties, SyntheticClassKind}
@@ -69,6 +70,7 @@ object Infos {
       val methods: Array[Map[MethodName, MethodInfo]],
       val jsNativeMembers: Map[MethodName, JSNativeLoadSpec],
       val witTypeDef: Option[ReachabilityInfo],
+      val witAliases: Option[ReachabilityInfo],
       val witNativeMembers: Map[MethodName, ReachabilityInfo],
       val jsMethodProps: List[ReachabilityInfo],
       val topLevelExports: List[TopLevelExportInfo]
@@ -641,9 +643,14 @@ object Infos {
         .generateWitNativeMember(member)
     }
 
-    def generateWitTypeDef(typeDef: WitTypeDef): ReachabilityInfo = {
+    def generateWitTypeDef(classDef: ClassDef): ReachabilityInfo = {
       new GenInfoTraverser(Version.Unversioned, linkTimeProperties, registerJSInterop)
-        .generateWitTypeDef(typeDef)
+        .generateWitTypeDef(classDef)
+    }
+
+    def generateWitAliases(aliases: List[WitAliasDef]): ReachabilityInfo = {
+      new GenInfoTraverser(Version.Unversioned, linkTimeProperties, registerJSInterop)
+        .generateWitAliases(aliases)
     }
   }
 
@@ -679,8 +686,14 @@ object Infos {
       MethodInfo(true, reachabilityInfo)
     }
 
-    def generateWitTypeDef(typeDef: WitTypeDef): ReachabilityInfo = {
-      generateForWITTypeDef(typeDef)
+    def generateWitTypeDef(classDef: ClassDef): ReachabilityInfo = {
+      generateForWITTypeDef(classDef)
+      builder.result()
+    }
+
+    def generateWitAliases(aliases: List[WitAliasDef]): ReachabilityInfo = {
+      for (alias <- aliases)
+        generateForWIT(alias.target)
       builder.result()
     }
 
@@ -822,16 +835,19 @@ object Infos {
         case wit.ResourceType(className, _) =>
           builder.maybeAddReferencedClass(ClassRef(className))
 
+        case wit.AliasTypeRef(_, _, owner) =>
+          builder.addReferencedClass(owner)
+
         case _ =>
       }
 
     }
 
-    private def generateForWITTypeDef(typeDef: WitTypeDef): Unit = {
-      typeDef match {
+    private def generateForWITTypeDef(classDef: ClassDef): Unit = {
+      classDef.witTypeDef.get match {
         case WitTypeDef.Record(className, _, _, fields) =>
-          val ctor = MethodName.constructor(fields.map(f => wit.toTypeRef(f.tpe)))
-          builder.addInstantiatedClass(className, ctor)
+          for (m <- classDef.methods if m.flags.namespace == MemberNamespace.Constructor)
+            builder.addInstantiatedClass(className, m.methodName)
           for (f <- fields) {
             builder.addFieldRead(f.label)
             generateForWIT(f.tpe)

--- a/linker/shared/src/main/scala/org/scalajs/linker/backend/wasmemitter/DerivedClasses.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/backend/wasmemitter/DerivedClasses.scala
@@ -148,6 +148,7 @@ object DerivedClasses {
       exportedMembers = Nil,
       jsNativeMembers = Nil,
       witTypeDef = None,
+      witAliases = Nil,
       witNativeMembers = Nil,
       EOH,
       pos,

--- a/linker/shared/src/main/scala/org/scalajs/linker/backend/wasmemitter/Preprocessor.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/backend/wasmemitter/Preprocessor.scala
@@ -39,6 +39,8 @@ object Preprocessor {
     val (itableBucketCount, itableBucketAssignments) =
       computeItableBuckets(classes)
 
+    val aliasMap = WitAliasResolution.collectAliases(classes)
+
     val classInfosBuilder = mutable.HashMap.empty[ClassName, ClassInfo]
     val definedReflectiveProxyNames = mutable.HashSet.empty[MethodName]
 
@@ -66,7 +68,7 @@ object Preprocessor {
     val reflectiveProxyIDs = definedReflectiveProxyNames.toList.sorted.zipWithIndex.toMap
 
     new WasmContext(coreSpec, coreLib, classInfos, reflectiveProxyIDs,
-        privateJSFields, itableBucketCount)
+        privateJSFields, itableBucketCount, aliasMap)
   }
 
   private def computeStaticFieldMirrors(

--- a/linker/shared/src/main/scala/org/scalajs/linker/backend/wasmemitter/WasmContext.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/backend/wasmemitter/WasmContext.scala
@@ -24,6 +24,8 @@ import org.scalajs.ir.OriginalName
 import org.scalajs.ir.OriginalName.NoOriginalName
 import org.scalajs.ir.Trees.{FieldDef, ParamDef, JSNativeLoadSpec}
 import org.scalajs.ir.Types._
+import org.scalajs.ir.WitScope
+import org.scalajs.ir.WasmInterfaceTypes.{ValType => WitValType}
 import org.scalajs.ir.WellKnownNames._
 
 import org.scalajs.linker.interface.ModuleKind
@@ -48,7 +50,8 @@ final class WasmContext(
     classInfo: Map[ClassName, WasmContext.ClassInfo],
     reflectiveProxies: Map[MethodName, Int],
     val privateJSFields: Map[FieldName, String],
-    val itablesLength: Int
+    val itablesLength: Int,
+    val witAliases: Map[(WitScope, String), WitValType]
 ) {
   import WasmContext._
 
@@ -125,6 +128,9 @@ final class WasmContext(
     getClassInfo(name).witTypeDef.getOrElse(
         throw new Error(s"WIT type definition not found for ${name.nameString}"))
   }
+
+  def dealiasWit(tpe: WitValType): WitValType =
+    WitAliasResolution.dealiasVal(tpe, witAliases)
 
   def inferTypeFromTypeRef(typeRef: TypeRef): Type = typeRef match {
     case PrimRef(tpe) =>

--- a/linker/shared/src/main/scala/org/scalajs/linker/backend/wasmemitter/WitAliasResolution.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/backend/wasmemitter/WitAliasResolution.scala
@@ -1,0 +1,43 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
+package org.scalajs.linker.backend.wasmemitter
+
+import scala.collection.mutable
+
+import org.scalajs.ir.WitScope
+import org.scalajs.ir.WasmInterfaceTypes._
+import org.scalajs.linker.standard.LinkedClass
+
+/** Resolve `AliasTypeRef`s using `WitAliasDef`s from linked classes. */
+private[wasmemitter] object WitAliasResolution {
+
+  def collectAliases(
+      classes: List[LinkedClass]): Map[(WitScope, String), ValType] = {
+    val m = mutable.Map.empty[(WitScope, String), ValType]
+    for {
+      clazz <- classes
+      alias <- clazz.witAliases
+    } {
+      m.getOrElseUpdate((alias.scope, alias.name), alias.target)
+    }
+    m.toMap
+  }
+
+  def dealiasVal(tpe: ValType,
+      aliases: Map[(WitScope, String), ValType]): ValType = {
+    dealias(tpe,
+        (scope, name) =>
+          aliases.getOrElse((scope, name),
+              throw new Error(s"WIT alias not found: $scope/$name")))
+  }
+}

--- a/linker/shared/src/main/scala/org/scalajs/linker/backend/wasmemitter/canonicalabi/CABIToScalaJS.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/backend/wasmemitter/canonicalabi/CABIToScalaJS.scala
@@ -114,7 +114,7 @@ object CABIToScalaJS {
 
       case wit.RecordTypeRef(className) =>
         val fields = WitTypeOps.recordFields(className)
-        val typeRefs = fields.map(f => wit.toTypeRef(f.tpe))
+        val typeRefs = fields.map(f => wit.toTypeRef(ctx.dealiasWit(f.tpe)))
         val ctor = MethodName.constructor(typeRefs)
         val ptr = fb.addLocal(NoOriginalName, watpe.Int32)
         fb += wa.LocalSet(ptr)
@@ -138,7 +138,7 @@ object CABIToScalaJS {
             genAlignTo(fb, WitTypeOps.alignment(f), ptr)
             fb += wa.LocalGet(ptr)
             genLoadMemory(fb, f)
-            f.toIRType() match {
+            ctx.dealiasWit(f).toIRType() match {
               case t: PrimTypeWithRef => genBox(fb, t)
               case _                  =>
             }
@@ -165,6 +165,9 @@ object CABIToScalaJS {
         val cases = WitTypeOps.getVariantCases(tpe)
         genLoadVariantMemory(fb, cases, false)
 
+      case a: wit.AliasTypeRef =>
+        genLoadMemory(fb, ctx.dealiasWit(a))
+
       case wit.OptionType(t) =>
         val optionType = watpe.RefType.nullable(genTypeID.forClass(juOptionalClass))
         val maxCaseAlignment = WitTypeOps.alignment(t)
@@ -185,7 +188,7 @@ object CABIToScalaJS {
           genNewScalaClass(fb, juOptionalClass, ctorID) {
             fb += wa.LocalGet(ptr)
             genLoadMemory(fb, t)
-            t.toIRType() match {
+            ctx.dealiasWit(t).toIRType() match {
               case t: PrimTypeWithRef => genBox(fb, t)
               case _                  =>
             }
@@ -249,7 +252,7 @@ object CABIToScalaJS {
           for (f <- fields) {
             val fieldType = Flatten.flattenType(f)
             genLoadStack(fb, f, vi)
-            f.toIRType() match {
+            ctx.dealiasWit(f).toIRType() match {
               case t: PrimTypeWithRef => genBox(fb, t)
               case _                  =>
             }
@@ -287,7 +290,7 @@ object CABIToScalaJS {
 
       case wit.RecordTypeRef(className) =>
         val fields = WitTypeOps.recordFields(className)
-        val typeRefs = fields.map(f => wit.toTypeRef(f.tpe))
+        val typeRefs = fields.map(f => wit.toTypeRef(ctx.dealiasWit(f.tpe)))
         val ctor = MethodName.constructor(typeRefs)
         genNewScalaClass(fb, className, ctor) {
           for (f <- fields) {
@@ -309,6 +312,9 @@ object CABIToScalaJS {
         val cases = WitTypeOps.getVariantCases(tpe)
         genLoadVariantStack(fb, cases, vi, boxValue = false)
 
+      case a: wit.AliasTypeRef =>
+        genLoadStack(fb, ctx.dealiasWit(a), vi)
+
       case wit.OptionType(t) =>
         val optionType = watpe.RefType(genTypeID.forClass(juOptionalClass))
         val ctorID = MethodName.constructor(List(ClassRef(ObjectClass)))
@@ -318,7 +324,7 @@ object CABIToScalaJS {
           // non-null
           genNewScalaClass(fb, juOptionalClass, ctorID) {
             genLoadStack(fb, t, vi)
-            t.toIRType() match {
+            ctx.dealiasWit(t).toIRType() match {
               case t: PrimTypeWithRef => genBox(fb, t)
               case _                  =>
             }
@@ -349,7 +355,7 @@ object CABIToScalaJS {
   )(implicit ctx: WasmContext): Unit = {
     val wit.ListType(elemType, maybeLength) = listType
     assert(maybeLength.isEmpty)
-    val arrayTypeRef = ArrayTypeRef.of(wit.toTypeRef(elemType))
+    val arrayTypeRef = ArrayTypeRef.of(wit.toTypeRef(ctx.dealiasWit(elemType)))
     val arrayUnderlyingID = genTypeID.underlyingOf(arrayTypeRef)
     val arrayStructTypeID = genTypeID.forArrayClass(arrayTypeRef)
     val elemSize = WitTypeOps.elemSize(elemType)
@@ -430,7 +436,7 @@ object CABIToScalaJS {
           } else {
             val ctorID =
               if (boxValue) MethodName.constructor(List(ClassRef(ObjectClass)))
-              else wit.makeCtorName(c.tpe)
+              else wit.makeCtorName(c.tpe.map(ctx.dealiasWit))
             genNewScalaClass(fb, c.className, ctorID) {
               c.tpe match {
                 case None =>
@@ -439,7 +445,7 @@ object CABIToScalaJS {
                   fb += wa.LocalGet(ptr)
                   genLoadMemory(fb, tpe)
                   if (boxValue) {
-                    tpe.toIRType() match {
+                    ctx.dealiasWit(tpe).toIRType() match {
                       case t: PrimTypeWithRef => genBox(fb, t)
                       case _                  =>
                     }
@@ -477,7 +483,7 @@ object CABIToScalaJS {
           } else {
             val ctorID =
               if (boxValue) MethodName.constructor(List(ClassRef(ObjectClass)))
-              else wit.makeCtorName(c.tpe)
+              else wit.makeCtorName(c.tpe.map(ctx.dealiasWit))
             genNewScalaClass(fb, c.className, ctorID) {
               c.tpe match {
                 case None =>
@@ -487,7 +493,7 @@ object CABIToScalaJS {
                   genCoerceValues(fb, vi.copy(), flattened, expect)
                   genLoadStack(fb, tpe, ValueIterator(fb, expect))
                   if (boxValue) {
-                    tpe.toIRType() match {
+                    ctx.dealiasWit(tpe).toIRType() match {
                       case t: PrimTypeWithRef => genBox(fb, t)
                       case _                  =>
                     }

--- a/linker/shared/src/main/scala/org/scalajs/linker/backend/wasmemitter/canonicalabi/InteropEmitter.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/backend/wasmemitter/canonicalabi/InteropEmitter.scala
@@ -12,7 +12,7 @@
 
 package org.scalajs.linker.backend.wasmemitter.canonicalabi
 
-import org.scalajs.ir.{Names, OriginalName, Trees => js, WasmInterfaceTypes => wit}
+import org.scalajs.ir.{Names, OriginalName, Trees => js}
 import org.scalajs.ir.WitScope
 import org.scalajs.ir.OriginalName.NoOriginalName
 
@@ -85,16 +85,15 @@ object InteropEmitter {
     fb += wa.LocalSet(savedStackPointer)
 
     val params = member.signature.paramTypes.map { p =>
-      val irType = p.toIRType()
       val localID = fb.addParam(
         NoOriginalName,
-        transformParamType(p.toIRType())
+        transformParamType(ctx.dealiasWit(p).toIRType())
       )
       (localID, p)
     }
     val resultType = member.signature.resultType match {
       case None        => Nil
-      case Some(value) => List(value.toIRType())
+      case Some(value) => List(ctx.dealiasWit(value).toIRType())
     }
     fb.setResultTypes(resultType.flatMap(transformResultType(_)))
 

--- a/linker/shared/src/main/scala/org/scalajs/linker/backend/wasmemitter/canonicalabi/ScalaJSToCABI.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/backend/wasmemitter/canonicalabi/ScalaJSToCABI.scala
@@ -110,7 +110,7 @@ object ScalaJSToCABI {
             genTypeID.forClass(className),
             genFieldID.forClassInstanceField(FieldName(className, SimpleFieldName(s"_${i + 1}")))
           )
-          f.toIRType() match {
+          ctx.dealiasWit(f).toIRType() match {
             case t: PrimTypeWithRef => genUnbox(fb, t)
             case _                  =>
           }
@@ -159,6 +159,9 @@ object ScalaJSToCABI {
       case tpe: wit.EnumTypeRef =>
         val cases = WitTypeOps.getVariantCases(tpe)
         genStoreVariantMemory(fb, cases, (_) => {})
+
+      case a: wit.AliasTypeRef =>
+        genStoreMemory(fb, ctx.dealiasWit(a))
 
       case wit.OptionType(t) =>
         val flattened = Flatten.flattenVariants(List(t))
@@ -266,7 +269,7 @@ object ScalaJSToCABI {
             genTypeID.forClass(className),
             genFieldID.forClassInstanceField(FieldName(className, SimpleFieldName(s"_${i + 1}")))
           )
-          f.toIRType() match {
+          ctx.dealiasWit(f).toIRType() match {
             case t: PrimTypeWithRef => genUnbox(fb, t)
             case _                  =>
           }
@@ -295,6 +298,9 @@ object ScalaJSToCABI {
       case tpe: wit.EnumTypeRef =>
         val cases = WitTypeOps.getVariantCases(tpe)
         genStoreVariantStack(fb, cases, (_) => {})
+
+      case a: wit.AliasTypeRef =>
+        genStoreStack(fb, ctx.dealiasWit(a))
 
       case wit.OptionType(t) =>
         val optionType = watpe.RefType.nullable(genTypeID.forClass(juOptionalClass))
@@ -347,7 +353,7 @@ object ScalaJSToCABI {
     maybeLength match {
       case None =>
         // array
-        val arrayTypeRef = ArrayTypeRef.of(wit.toTypeRef(elemType))
+        val arrayTypeRef = ArrayTypeRef.of(wit.toTypeRef(ctx.dealiasWit(elemType)))
         val arrayStructTypeID = genTypeID.forArrayClass(arrayTypeRef)
         val arrType = watpe.RefType.nullable(arrayStructTypeID)
 
@@ -391,7 +397,7 @@ object ScalaJSToCABI {
             fb += wa.LocalGet(arr)
             fb += wa.StructGet(arrayStructTypeID, genFieldID.objStruct.arrayUnderlying)
             fb += wa.LocalGet(iLocal)
-            wit.toTypeRef(elemType) match {
+            wit.toTypeRef(ctx.dealiasWit(elemType)) match {
               case BooleanRef | CharRef =>
                 fb += wa.ArrayGetU(genTypeID.underlyingOf(arrayTypeRef))
               case ByteRef | ShortRef =>
@@ -625,7 +631,7 @@ object ScalaJSToCABI {
         val resourceStructType = watpe.RefType(genTypeID.forClass(className))
         fb += wa.RefCast(resourceStructType)
       case _ =>
-        targetTpe.toIRType() match {
+        ctx.dealiasWit(targetTpe).toIRType() match {
           case t: PrimTypeWithRef => genUnbox(fb, t)
           case _                  =>
         }

--- a/linker/shared/src/main/scala/org/scalajs/linker/backend/wasmemitter/canonicalabi/WitTypeOps.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/backend/wasmemitter/canonicalabi/WitTypeOps.scala
@@ -53,6 +53,8 @@ private[canonicalabi] object WitTypeOps {
       elemSizeVariant(getVariantCases(tpe))
     case FlagsTypeRef(className) =>
       flagsSize(flagNames(className))
+    case a: AliasTypeRef =>
+      elemSize(ctx.dealiasWit(a))
     case ResourceType(_, _) =>
       4
   }
@@ -83,6 +85,8 @@ private[canonicalabi] object WitTypeOps {
       alignmentVariant(getVariantCases(tpe))
     case FlagsTypeRef(className) =>
       flagsSize(flagNames(className))
+    case a: AliasTypeRef =>
+      alignment(ctx.dealiasWit(a))
     case ResourceType(_, _) =>
       4
   }

--- a/linker/shared/src/main/scala/org/scalajs/linker/backend/webassembly/component/ComponentBinaryWriter.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/backend/webassembly/component/ComponentBinaryWriter.scala
@@ -213,6 +213,11 @@ private sealed class ComponentBinaryWriter(component: Component) {
         buf.byte(0x68)
         buf.u32(typeIdx(resource))
 
+      // defvaltype ::= pvt:<primvaltype> => pvt  (and other valtypes already covered)
+      case Decl.ValTypeDef(_, v) =>
+        buf.byte(0x01)
+        writeValRef(v, typeIdx)
+
       case Decl.AliasExport(_, instance, name) =>
         buf.byte(0x02)
         buf.byte(SortType) // sort ::= 0x03 type

--- a/linker/shared/src/main/scala/org/scalajs/linker/backend/webassembly/component/ComponentBuilder.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/backend/webassembly/component/ComponentBuilder.scala
@@ -17,13 +17,13 @@ import scala.collection.mutable
 import org.scalajs.ir.Names.ClassName
 import org.scalajs.ir.ResourceOwnership
 import org.scalajs.ir.Trees.WitFunctionName
-import org.scalajs.ir.{WitScope, WitTypeDef}
+import org.scalajs.ir.{WitScope, WitTypeDef, WitAliasDef}
 import org.scalajs.ir.WasmInterfaceTypes.{ExternType => _, _}
 
 import Components._
-import ComponentWorld.{endpointTypeRefs, namedTypeRefs}
+import ComponentWorld._
 
-private[backend] final class ComponentBuilder {
+final class ComponentBuilder {
   private val declBuf = mutable.ListBuffer.empty[Decl]
 
   private def addType(mk: TypeID => TypeDecl): TypeID = {
@@ -76,6 +76,9 @@ private[backend] final class ComponentBuilder {
   def addBorrow(resource: TypeID): TypeID =
     addType(Decl.Borrow(_, resource))
 
+  def addValTypeDef(v: ValRef): TypeID =
+    addType(Decl.ValTypeDef(_, v))
+
   def addAliasExport(instance: InstanceID, name: String): TypeID =
     addType(Decl.AliasExport(_, instance, name))
 
@@ -121,10 +124,10 @@ private[backend] final class ComponentBuilder {
   def build(packageName: String, worldName: String): Component =
     Component(packageName, worldName, decls())
 
-  private def decls(): List[Decl] = declBuf.toList
+  private[component] def decls(): List[Decl] = declBuf.toList
 }
 
-private[backend] object ComponentBuilder {
+object ComponentBuilder {
 
   /** Encode wit-component metadata from a reachable WIT world.
    *
@@ -172,340 +175,34 @@ private[backend] object ComponentBuilder {
   private def encodeWorld(world: ComponentWorld): List[Decl] =
     new WorldEncoder(world).encode()
 
-  /** Encode one WIT world into componenttype decls. */
-  private final class WorldEncoder(world: ComponentWorld) {
-    private val builder = new ComponentBuilder
-    private val typeDefByClass = world.typeDefByClass
-    private val emittedAliases = mutable.Set.empty[ClassName]
-
-    private val instanceIds: Map[WitScope.Interface, InstanceID] = {
-      world.imports.collect {
-        // We don't pre-allocate instance IDs for inline blocks or funcs, because WIT cannot
-        // import types/functions defined in inline interface.
-        case ComponentWorld.WorldItem.Interface(iface) =>
-          iface -> new InstanceID
-      }.toMap
-    }
-
-    private val typeIds: Map[(WitScope, String), TypeID] = {
-      // World-level named types and types imported from other interfaces.
-      val fromWorldTypes = world.imports.collect {
-        case ComponentWorld.WorldItem.Type(td) => (td.scope, td.name)
-      }
-      val uses = (world.imports ++ world.exports).flatMap(foreignClassNamesUsedBy).map {
-        className =>
-          val td = typeDefByClass(className)
-          (td.scope, td.name)
-      }
-      (fromWorldTypes ++ uses).distinct.map(k => k -> new TypeID).toMap
-    }
-
-    private val typeIdsByClass: Map[ClassName, TypeID] = {
-      typeDefByClass.flatMap { case (className, td) =>
-        typeIds.get((td.scope, td.name)).map(className -> _)
-      }
-    }
-
-    def encode(): List[Decl] = {
-      // Write each world import, then each world export.
-      //
-      // When an import/export item uses a type defined in another interface (via `use`),
-      // bring the type onto the world first with `(alias export ...)`, then encode
-      // the item (which pulls it in via `alias outer`).
-      //
-      // For example, wasi:io/streams uses a type from wasi:io/error:
-      //
-      // {{{
-      // interface streams {
-      //   use wasi:io/error.{error};
-      //   write: func(e: error);
-      // }
-      //
-      // (import "wasi:io/error" (instance $error ...))
-      // (alias export $error "error" (type $t)) ;; $t = type from $error's exports
-      // (import "wasi:io/streams" (instance (type (instance
-      //   (alias outer 1 $t (type $error))  ;; $error = $t from 1 outer scope
-      //   (export "error" (type $error))
-      //   ...))))
-      // }}}
-      emitImports()
-      emitExports()
-      builder.decls()
-    }
-
-    /** Encode WIT `import` items into world componenttype import decls. */
-    private def emitImports(): Unit = {
-      for (item <- topologicalSortWorldItems(world.imports)) {
-        item match {
-          case ComponentWorld.WorldItem.Type(named) =>
-            encodeWorldType(named)
-            // `(import "ns:pkg/iface" (instance $id ...))`
-          case ComponentWorld.WorldItem.Interface(iface) =>
-            // alias export imported types
-            // e.g. (alias export $error "error" (type $t))
-            aliasExports(foreignClassNamesUsedBy(item))
-            builder.addInstanceImport(iface.witId, instanceType(iface), instanceIds(iface))
-            // `(import "name" (instance ...))`
-          case ComponentWorld.WorldItem.Inline(inline) =>
-            aliasExports(foreignClassNamesUsedBy(item))
-            builder.addInstanceImport(inline.name, instanceType(inline))
-            // `(import "f" (func ...))`
-          case ComponentWorld.WorldItem.Func(func) =>
-            aliasExports(foreignClassNamesUsedBy(item))
-            builder.addImport(WitFunctionName.wasmName(func.name),
-                ExternType.Func(bareFunc(func)))
-        }
-      }
-    }
-
-    private def emitExports(): Unit = {
-      for (item <- topologicalSortWorldItems(world.exports)) {
-        item match {
-          // `(export "ns:pkg/iface" (instance ...))`
-          case ComponentWorld.WorldItem.Interface(iface) =>
-            aliasExports(foreignClassNamesUsedBy(item))
-            builder.addExport(iface.witId, ExternType.Instance(instanceType(iface)))
-            // `(export "name" (instance ...))`
-          case ComponentWorld.WorldItem.Inline(inline) =>
-            aliasExports(foreignClassNamesUsedBy(item))
-            builder.addExport(inline.name, ExternType.Instance(instanceType(inline)))
-            // `(export "f" (func ...))`
-          case ComponentWorld.WorldItem.Func(func) =>
-            aliasExports(foreignClassNamesUsedBy(item))
-            builder.addExport(WitFunctionName.wasmName(func.name),
-                ExternType.Func(bareFunc(func)))
-          case _: ComponentWorld.WorldItem.Type =>
-            throw new AssertionError("world types are encoded as imports")
-        }
-      }
-    }
-
-    /** World-level named type: Root typedef or `use iface.{T}`. */
-    private def encodeWorldType(named: WitTypeDef): Unit = {
-      val id = typeIdsByClass.getOrElse(named.className,
-          throw new AssertionError(
-              s"missing world type ${WitScope.importModuleName(named.scope)}/${named.name}"))
-      named.scope match {
-        case WitScope.Root =>
-          named match {
-            case _: WitTypeDef.Resource =>
-              // `(import "$name" (type $id (sub resource)))`
-              builder.addImportTypeResource(id, named.name)
-            case other =>
-              val body = addNamedTypeBody(builder, other, typeIdsByClass)
-              // `(import "$name" (type $id (eq $body)))`
-              builder.addImportTypeEq(id, other.name, body)
-          }
-        case _: WitScope.Interface =>
-          encodeWorldUse(named, id)
-        case _: WitScope.Inline =>
-          throw new AssertionError(
-              s"inline type ${named.name} cannot be a world-level type")
-      }
-    }
-
-    // `(alias export $inst "T" $alias)` then `(import "T" (type $id (eq $alias)))`.
-    private def encodeWorldUse(named: WitTypeDef, id: TypeID): Unit = {
-      val owner = interfaceOf(named.className).getOrElse(
-          throw new AssertionError(
-              s"world use ${named.name} is not from a package interface"))
-      val inst = instanceIds.getOrElse(owner,
-          throw new AssertionError(
-              s"missing imported dependency interface ${owner.witId} " +
-              s"before aliasing ${named.name}"))
-      val aliased = builder.addAliasExport(inst, named.name)
-      emittedAliases += named.className
-      builder.addImportTypeEq(id, named.name, aliased)
-    }
-
-    private def topologicalSortWorldItems(
-        items: List[ComponentWorld.WorldItem]): List[ComponentWorld.WorldItem] = {
-      val interfaceItems = items.collect {
-        case i @ ComponentWorld.WorldItem.Interface(iface) => iface -> i
-      }.toMap
-      val typeItems = items.collect {
-        case t @ ComponentWorld.WorldItem.Type(named) => named.className -> t
-      }.toMap
-      val ordered = mutable.LinkedHashSet.empty[ComponentWorld.WorldItem]
-      val visiting = mutable.Set.empty[ComponentWorld.WorldItem]
-
-      def visit(item: ComponentWorld.WorldItem): Unit = {
-        if (ordered.contains(item)) {
-          // skip
-        } else if (!visiting.add(item)) {
-          throw new AssertionError("cyclic world item dependency")
-        } else {
-          item match {
-            case ComponentWorld.WorldItem.Type(named) =>
-              named.scope match {
-                case iface: WitScope.Interface =>
-                  interfaceItems.get(iface).foreach(visit)
-                case _ =>
-              }
-              for (className <- namedTypeRefs(named) if className != named.className) {
-                typeItems.get(className).foreach(visit)
-                interfaceOf(className).flatMap(interfaceItems.get).foreach(visit)
-              }
-            case _ =>
-              for (className <- foreignClassNamesUsedBy(item)) {
-                typeItems.get(className).foreach(visit)
-                interfaceOf(className).flatMap(interfaceItems.get).foreach(visit)
-              }
-          }
-          visiting -= item
-          ordered += item
-        }
-      }
-
-      items.foreach(visit)
-      ordered.toList
-    }
-
-    // `(alias export $id "T" $inst)` for each first-seen `use ns:pkg/iface.{T}`.
-    private def aliasExports(classNames: Iterable[ClassName]): Unit = {
-      for (className <- classNames if emittedAliases.add(className)) {
-        val td = typeDefByClass(className)
-        val owner = interfaceOf(className).getOrElse(
-            throw new AssertionError(
-                s"foreign type ${className.nameString} is not from a package interface"))
-        val inst = instanceIds.getOrElse(owner,
-            throw new AssertionError(
-                s"missing imported dependency interface ${owner.witId} " +
-                s"before aliasing ${td.name}"))
-        builder.addAliasExport(typeIdsByClass(className), inst, td.name)
-      }
-    }
-
-    /** `ClassName`s of types from other interfaces that `item` references. */
-    private def foreignClassNamesUsedBy(item: ComponentWorld.WorldItem): List[ClassName] = {
-      item match {
-        case ComponentWorld.WorldItem.Interface(iface) =>
-          filterForeignClassNames(iface, scopeTypeRefs(iface))
-        case ComponentWorld.WorldItem.Inline(inline) =>
-          filterForeignClassNames(inline, scopeTypeRefs(inline))
-        case ComponentWorld.WorldItem.Func(func) =>
-          filterForeignClassNames(func.scope, endpointTypeRefs(func))
-        case ComponentWorld.WorldItem.Type(named) =>
-          filterForeignClassNames(named.scope, namedTypeRefs(named))
-      }
-    }
-
-    /** Collect referenced types from the given scope. */
-    private def scopeTypeRefs(scope: WitScope): List[ClassName] = {
-      world.typesFor(scope).flatMap(namedTypeRefs) ++
-      world.endpointsFor(scope).flatMap(endpointTypeRefs)
-    }
-
-    /** Filter out classes defined in this scope */
-    private def filterForeignClassNames(scope: WitScope,
-        classNames: Iterable[ClassName]): List[ClassName] = {
-      classNames.filter { className =>
-        interfaceOf(className).exists(_ != scope)
-      }.toList.distinct
-    }
-
-    private def interfaceOf(className: ClassName): Option[WitScope.Interface] = {
-      typeDefByClass(className).scope match {
-        case iface: WitScope.Interface => Some(iface)
-        case _                         => None
-      }
-    }
-
-    private def bareFunc(func: ComponentWorld.Endpoint): TypeID = {
-      val params = func.signature.params.map { p =>
-        p.name -> resolveValRef(builder, p.tpe, typeIdsByClass)
-      }
-      val result = func.signature.resultType.map(resolveValRef(builder, _, typeIdsByClass))
-      builder.addFuncType(params, result)
-    }
-
-    private def instanceType(scope: WitScope): TypeID = {
-      builder.addInstanceType(encodeInstanceType(
-          scope, world.endpointsFor(scope), world.typesFor(scope), typeIdsByClass,
-          typeDefByClass))
-    }
-  }
-
   /** Build decls for one WIT interface/inline as a component instance type.
    *
    *  Emits, in order:
-   *   1. Types defined in another interfaces: `(alias outer ...)` + `(export "T" (type ...))`
-   *   2. Named types defined in this scope in topological order.
+   *   1. `use` of types/aliases from other interfaces: `(alias outer ...)` + `(export "T" (type ...))`
+   *   2. Export local named types and aliases
    *   3. Exported funcs.
    *
    *  @param scope This interface or inline scope
    *  @param endpoints Functions belong to this `scope`
    *  @param namedTypes Named types defined in `scope`
-   *  @param worldTypeIds World-referencable types keyed by IR class
+   *  @param worldTypeIds World-referencable types/aliases keyed by `(scope, name)`
    *  @param typeDefByClass All named types in the world, for resolving type refs
    */
   private[component] def encodeInstanceType(scope: WitScope,
       endpoints: List[ComponentWorld.Endpoint],
       namedTypes: List[WitTypeDef],
-      worldTypeIds: Map[ClassName, TypeID],
+      definedAliases: List[WitAliasDef],
+      worldTypeIds: Map[(WitScope, String), TypeID],
       typeDefByClass: Map[ClassName, WitTypeDef]): List[Decl] = {
-    val builder = new ComponentBuilder
-    var localTypeIdx = Map.empty[ClassName, TypeID]
-
-    // Step 1: Index WIT `use other.{T}`. Pull world's
-    // `(alias export ...)` from `worldTypeIds` using `alias outer`.
-    // `alias outer`, then export the local name `typeName`.
-    //   (alias outer 1 $t (type $error))
-    //   (export "error" (type $error))
-    val usedFromOtherIfaces = (
-      namedTypes.flatMap(namedTypeRefs) ++ endpoints.flatMap(endpointTypeRefs)
-    ).distinct.filter { className =>
-      typeDefByClass(className).scope != scope
-    }
-    for (className <- usedFromOtherIfaces) {
-      val outerId = worldTypeIds.getOrElse(className,
-          throw new AssertionError(
-              s"missing aliased foreign type for ${className.nameString}"))
-      val aliased = builder.addAliasOuter(outerId)
-      localTypeIdx = localTypeIdx + (className ->
-        builder.addExportTypeEq(typeDefByClass(className).name, aliased))
-    }
-
-    // Step 2: Index named types defined in this interface (record, variant, resouce, and etc)
-    // Topological sort so field referencess can resolve when bodies are encoded.
-    for (named <- topologicalSortNamedTypes(namedTypes)) {
-      named match {
-        case _: WitTypeDef.Resource =>
-          localTypeIdx = localTypeIdx + (named.className -> builder.addExportResource(named.name))
-        case other =>
-          val defId = addNamedTypeBody(builder, other, localTypeIdx)
-          localTypeIdx =
-            localTypeIdx + (other.className -> builder.addExportTypeEq(other.name, defId))
-      }
-    }
-
-    // Step 3: Export funcs
-    val resourceOrder = namedTypes.collect { case r: WitTypeDef.Resource => r.name }
-    val resourceFuncs = endpoints.filter(_.name.isResourceMethod).sortBy { func =>
-      val ord = resourceOrder.indexOf(func.name.resourceName.get)
-      if (ord < 0) resourceOrder.size else ord
-    }
-    val plainFuncs = endpoints.filter(_.name.isFunction)
-
-    val seenNames = mutable.Set.empty[String]
-    for (func <- resourceFuncs ::: plainFuncs) {
-      val exportName = WitFunctionName.wasmName(func.name)
-      if (seenNames.add(exportName)) {
-        val params = func.signature.params.map { p =>
-          p.name -> resolveValRef(builder, p.tpe, localTypeIdx)
-        }
-        val result = func.signature.resultType.map(resolveValRef(builder, _, localTypeIdx))
-        val ty = builder.addFuncType(params, result)
-        builder.addExport(exportName, ExternType.Func(ty))
-      }
-    }
-
-    builder.decls()
+    new InstanceTypeEncoder(scope, endpoints, namedTypes, definedAliases,
+        worldTypeIds, typeDefByClass).encode()
   }
 
   /** Local named types in dependency order. */
-  private def topologicalSortNamedTypes(namedTypes: List[WitTypeDef]): List[WitTypeDef] = {
+  private[component] def topologicalSortNamedTypes(namedTypes: List[WitTypeDef],
+      localAliases: List[WitAliasDef] = Nil): List[WitTypeDef] = {
     val byClass = namedTypes.map(t => t.className -> t).toMap
+    val aliasByName = localAliases.map(a => a.name -> a).toMap
     val ordered = mutable.LinkedHashSet.empty[ClassName]
     val visiting = mutable.Set.empty[ClassName]
 
@@ -516,8 +213,13 @@ private[backend] object ComponentBuilder {
         throw new AssertionError(
             s"cyclic dependency ${className.nameString}")
       } else {
-        for (dep <- namedTypeRefs(byClass(className))) {
+        val td = byClass(className)
+        for (dep <- namedTypeRefs(td)) {
           if (byClass.contains(dep))
+            visit(dep)
+        }
+        for (a <- namedTypeAliasRefs(td) if a.scope == td.scope) {
+          for (dep <- valTypeRefs(aliasByName(a.name).target) if byClass.contains(dep))
             visit(dep)
         }
         visiting -= className
@@ -529,16 +231,22 @@ private[backend] object ComponentBuilder {
     ordered.iterator.map(byClass).toList
   }
 
-  private def addNamedTypeBody(builder: ComponentBuilder, named: WitTypeDef,
-      localTypeIdx: Map[ClassName, TypeID]): TypeID = {
+  /** Encode record/variant/enum/flags body.
+   *
+   *  Field/case types must be TypeIDs already in the caller's table (world imports
+   *  vs instance exports). WorldEncoder and InstanceTypeEncoder each pass their
+   *  own `resolve` for that.
+   */
+  private[component] def addNamedTypeBody(builder: ComponentBuilder, named: WitTypeDef,
+      resolve: ValType => ValRef): TypeID = {
     named match {
       case WitTypeDef.Record(_, _, _, fields) =>
         builder.addRecord(fields.map { f =>
-          f.name -> resolveValRef(builder, f.tpe, localTypeIdx)
+          f.name -> resolve(f.tpe)
         })
       case WitTypeDef.Variant(_, _, _, cases) =>
         builder.addVariant(cases.map { c =>
-          c.name -> c.tpe.map(resolveValRef(builder, _, localTypeIdx))
+          c.name -> c.tpe.map(resolve)
         })
       case WitTypeDef.Enum(_, _, _, cases) =>
         builder.addEnum(cases.map(_.name))
@@ -549,8 +257,10 @@ private[backend] object ComponentBuilder {
     }
   }
 
-  private def resolveValRef(builder: ComponentBuilder, tpe: ValType,
-      localTypeIdx: Map[ClassName, TypeID]): ValRef = {
+  /** Convert IR `ValType` to component-model encoding (`ValRef`). */
+  private[component] def resolveValRef(builder: ComponentBuilder, tpe: ValType,
+      localTypeIdx: Map[ClassName, TypeID],
+      alias: (WitScope, String) => ValRef): ValRef = {
     tpe match {
       case BoolType   => ValRef.Bool
       case S8Type     => ValRef.S8
@@ -567,23 +277,23 @@ private[backend] object ComponentBuilder {
       case StringType => ValRef.String
 
       case ListType(elem, None) =>
-        ValRef.Type(builder.addList(resolveValRef(builder, elem, localTypeIdx)))
+        ValRef.Type(builder.addList(resolveValRef(builder, elem, localTypeIdx, alias)))
       case ListType(elem, Some(len)) =>
         ValRef.Type(builder.addFixedList(
-            resolveValRef(builder, elem, localTypeIdx), len))
+            resolveValRef(builder, elem, localTypeIdx, alias), len))
 
       case TupleType(ts) =>
         ValRef.Type(builder.addTuple(
-            ts.map(resolveValRef(builder, _, localTypeIdx))))
+            ts.map(resolveValRef(builder, _, localTypeIdx, alias))))
 
       case OptionType(inner) =>
         ValRef.Type(builder.addOption(
-            resolveValRef(builder, inner, localTypeIdx)))
+            resolveValRef(builder, inner, localTypeIdx, alias)))
 
       case ResultType(ok, err) =>
         ValRef.Type(builder.addResult(
-            ok.map(resolveValRef(builder, _, localTypeIdx)),
-            err.map(resolveValRef(builder, _, localTypeIdx))))
+            ok.map(resolveValRef(builder, _, localTypeIdx, alias)),
+            err.map(resolveValRef(builder, _, localTypeIdx, alias))))
 
       case RecordTypeRef(className) =>
         ValRef.Type(localTypeIdx(className))
@@ -593,6 +303,8 @@ private[backend] object ComponentBuilder {
         ValRef.Type(localTypeIdx(className))
       case FlagsTypeRef(className) =>
         ValRef.Type(localTypeIdx(className))
+      case AliasTypeRef(scope, name, _) =>
+        alias(scope, name)
 
       case ResourceType(className, ownership) =>
         val resId = localTypeIdx(className)

--- a/linker/shared/src/main/scala/org/scalajs/linker/backend/webassembly/component/ComponentWorld.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/backend/webassembly/component/ComponentWorld.scala
@@ -16,7 +16,7 @@ import scala.collection.mutable
 
 import org.scalajs.ir.Names.ClassName
 import org.scalajs.ir.Trees.{WitExportDef, WitFunctionName}
-import org.scalajs.ir.{WitScope, WitTypeDef}
+import org.scalajs.ir.{WitScope, WitTypeDef, WitAliasDef}
 import org.scalajs.ir.WasmInterfaceTypes._
 import org.scalajs.linker.interface.WasmComponentModuleInitializerExport
 import org.scalajs.linker.standard.ModuleSet
@@ -28,7 +28,8 @@ private[backend] final case class ComponentWorld(
     imports: List[ComponentWorld.WorldItem],
     exports: List[ComponentWorld.WorldItem],
     endpoints: List[ComponentWorld.Endpoint],
-    typeDefs: List[WitTypeDef]
+    typeDefs: List[WitTypeDef],
+    aliases: List[WitAliasDef]
 ) {
   def endpointsFor(scope: WitScope): List[ComponentWorld.Endpoint] =
     endpoints.filter(_.scope == scope)
@@ -36,8 +37,14 @@ private[backend] final case class ComponentWorld(
   def typesFor(scope: WitScope): List[WitTypeDef] =
     typeDefs.filter(_.scope == scope)
 
+  def aliasesFor(scope: WitScope): List[WitAliasDef] =
+    aliases.filter(_.scope == scope)
+
   def typeDefByClass: Map[ClassName, WitTypeDef] =
     typeDefs.map(td => td.className -> td).toMap
+
+  def aliasMap: Map[(WitScope, String), ValType] =
+    aliases.map(a => (a.scope, a.name) -> a.target).toMap
 }
 
 private[backend] object ComponentWorld {
@@ -59,8 +66,11 @@ private[backend] object ComponentWorld {
     final case class Inline(scope: WitScope.Inline) extends WorldItem
     final case class Func(func: Endpoint) extends WorldItem
 
-    /** World-level named type: a Root typedef or `use iface.{T}`. */
+    /** World-level named type: Root typedef or `use iface.{T}`. */
     final case class Type(named: WitTypeDef) extends WorldItem
+
+    /** World-level `type foo = ...` or `use iface.{T as Z}`. */
+    final case class Alias(alias: WitAliasDef) extends WorldItem
   }
 
   final case class Endpoint(
@@ -75,6 +85,7 @@ private[backend] object ComponentWorld {
     // correct all Wasm Component imports/exports and type definitions from IR
     val allEndpoints: List[Endpoint] = collectEndpoints(module, moduleInitializerExport)
     val allTypeDefs: List[WitTypeDef] = collectTypeDefs(module)
+    val allAliases: List[WitAliasDef] = collectAliasDefs(module)
 
     val importInterfaces = mutable.LinkedHashSet.empty[WitScope.Interface]
     val importInlines = mutable.LinkedHashSet.empty[WitScope.Inline]
@@ -99,6 +110,7 @@ private[backend] object ComponentWorld {
     }
     val typesByScope = allTypeDefs.groupBy(_.scope)
     val endpointsByScope = allEndpoints.groupBy(_.scope)
+    val aliasesByScope = allAliases.groupBy(_.scope)
     val typeDefByClass = allTypeDefs.map(td => td.className -> td).toMap
 
     // World-level named types: Root typedefs and `use` of types referenced by Root funcs.
@@ -120,7 +132,16 @@ private[backend] object ComponentWorld {
     for {
       ep <- importRoots.iterator ++ exportRoots.iterator
       className <- endpointTypeRefs(ep)
-    } addWorldType(typeDefByClass(className))
+    } {
+      typeDefByClass.get(className).foreach(addWorldType)
+    }
+    // Root `use other.{T}` aliases (no ClassName on the alias itself).
+    for {
+      alias <- aliasesByScope.getOrElse(WitScope.Root, Nil)
+      className <- valTypeRefs(alias.target)
+    } {
+      typeDefByClass.get(className).foreach(addWorldType)
+    }
 
     // Interfaces referenced only from Root bare funcs still need a world import
     // so `(alias export ...)` can bring those types into scope.
@@ -135,13 +156,14 @@ private[backend] object ComponentWorld {
     val interfacesToImport = {
       transitiveInterfaceDeps(
           importInterfaces ++ exportInterfaces ++ rootIfaceDeps, endpointsByScope,
-          typesByScope, typeDefByClass) ++ importInterfaces ++ rootIfaceDeps
+          typesByScope, aliasesByScope, typeDefByClass) ++ importInterfaces ++ rootIfaceDeps
     }
 
     val imports: List[WorldItem] = {
       val b = List.newBuilder[WorldItem]
       interfacesToImport.foreach(i => b += WorldItem.Interface(i))
       worldTypes.values.foreach(td => b += WorldItem.Type(td))
+      aliasesByScope.getOrElse(WitScope.Root, Nil).foreach(a => b += WorldItem.Alias(a))
       importInlines.foreach(i => b += WorldItem.Inline(i))
       importRoots.foreach(i => b += WorldItem.Func(i))
       b.result()
@@ -154,7 +176,8 @@ private[backend] object ComponentWorld {
       b.result()
     }
 
-    ComponentWorld(RootPackage, WorldName, imports, exports, allEndpoints, allTypeDefs)
+    ComponentWorld(RootPackage, WorldName, imports, exports, allEndpoints, allTypeDefs,
+        allAliases)
   }
 
   private def collectEndpoints(module: ModuleSet.Module,
@@ -198,25 +221,51 @@ private[backend] object ComponentWorld {
     byKey.values.toList
   }
 
+  private def collectAliasDefs(module: ModuleSet.Module): List[WitAliasDef] = {
+    val byKey = mutable.Map.empty[(WitScope, String), WitAliasDef]
+    for {
+      classDef <- module.classDefs
+      alias <- classDef.witAliases
+    } {
+      byKey.getOrElseUpdate((alias.scope, alias.name), alias)
+    }
+    byKey.values.toList
+  }
+
   /** Interfaces transitively referenced by `roots` via `use`. */
   private def transitiveInterfaceDeps(
       roots: Iterable[WitScope.Interface],
       endpointsByScope: Map[WitScope, List[Endpoint]],
       typesByScope: Map[WitScope, List[WitTypeDef]],
+      aliasesByScope: Map[WitScope, List[WitAliasDef]],
       typeDefByClass: Map[ClassName, WitTypeDef]): mutable.LinkedHashSet[WitScope.Interface] = {
     def depsOf(iface: WitScope.Interface): Iterable[WitScope.Interface] = {
       val deps = mutable.HashSet.empty[WitScope.Interface]
-      val refs = {
-        typesByScope.getOrElse(iface, Nil).flatMap(namedTypeRefs) ++
-        endpointsByScope.getOrElse(iface, Nil).flatMap(endpointTypeRefs)
+      def addIfForeign(scope: WitScope): Unit = scope match {
+        case dep: WitScope.Interface if dep != iface => deps += dep
+        case _                                       =>
       }
-      refs.foreach { className =>
-        // Only named package interfaces need a world import for `use`
-        typeDefByClass(className).scope match {
-          case dep: WitScope.Interface if dep != iface => deps += dep
-          case _                                       =>
+      def visit(tpe: ValType): Unit = {
+        for (className <- valTypeRefs(tpe))
+          typeDefByClass.get(className).foreach(td => addIfForeign(td.scope))
+        for (a <- aliasTypeRefs(tpe))
+          addIfForeign(a.scope)
+      }
+
+      for (named <- typesByScope.getOrElse(iface, Nil)) {
+        named match {
+          case WitTypeDef.Record(_, _, _, fields) =>
+            fields.foreach(f => visit(f.tpe))
+          case WitTypeDef.Variant(_, _, _, cases) =>
+            cases.foreach(_.tpe.foreach(visit))
+          case _ =>
         }
       }
+      for (ep <- endpointsByScope.getOrElse(iface, Nil)) {
+        ep.signature.params.foreach(p => visit(p.tpe))
+        ep.signature.resultType.foreach(visit)
+      }
+      aliasesByScope.getOrElse(iface, Nil).foreach(a => visit(a.target))
       deps
     }
 
@@ -263,6 +312,8 @@ private[backend] object ComponentWorld {
         className :: Nil
       case ResourceType(className, _) =>
         className :: Nil
+      case AliasTypeRef(_, _, _) =>
+        Nil // named types come from WitAliasDef targets
       case TupleType(ts) =>
         ts.flatMap(valTypeRefs(_))
       case ResultType(ok, err) =>
@@ -273,5 +324,57 @@ private[backend] object ComponentWorld {
       case _: PrimValType =>
         Nil
     }
+  }
+
+  /** Collect named WIT aliases referenced from a value type. */
+  private[component] def aliasTypeRefs(tpe: ValType): List[AliasTypeRef] = {
+    tpe match {
+      case a @ AliasTypeRef(_, _, _) =>
+        a :: Nil
+      case ListType(elem, _) =>
+        aliasTypeRefs(elem)
+      case TupleType(ts) =>
+        ts.flatMap(aliasTypeRefs(_))
+      case ResultType(ok, err) =>
+        ok.toList.flatMap(aliasTypeRefs(_)) ++
+        err.toList.flatMap(aliasTypeRefs(_))
+      case OptionType(inner) =>
+        aliasTypeRefs(inner)
+      case _ =>
+        Nil
+    }
+  }
+
+  private[component] def endpointAliasRefs(func: Endpoint): List[AliasTypeRef] = {
+    val tpes = func.signature.params.map(_.tpe) ++ func.signature.resultType
+    tpes.flatMap(aliasTypeRefs)
+  }
+
+  private[component] def namedTypeAliasRefs(named: WitTypeDef): List[AliasTypeRef] = {
+    named match {
+      case WitTypeDef.Record(_, _, _, fields) =>
+        fields.flatMap(f => aliasTypeRefs(f.tpe))
+      case WitTypeDef.Variant(_, _, _, cases) =>
+        cases.flatMap(_.tpe.toList.flatMap(aliasTypeRefs(_)))
+      case _ =>
+        Nil
+    }
+  }
+
+  private[component] def collectAliasesForScope(scope: WitScope,
+      defined: List[WitAliasDef],
+      endpoints: List[Endpoint], namedTypes: List[WitTypeDef]): List[WitAliasDef] = {
+    val byKey = mutable.Map.empty[(WitScope, String), WitAliasDef]
+    for (a <- defined if a.scope == scope)
+      byKey.getOrElseUpdate((a.scope, a.name), a)
+
+    for (ref <- endpoints.flatMap(endpointAliasRefs) ++ namedTypes.flatMap(namedTypeAliasRefs)
+        if ref.scope == scope) {
+      if (!byKey.contains((ref.scope, ref.name))) {
+        throw new AssertionError(
+            s"missing WitAliasDef for ${ref.scope}/${ref.name}")
+      }
+    }
+    byKey.values.toList
   }
 }

--- a/linker/shared/src/main/scala/org/scalajs/linker/backend/webassembly/component/Components.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/backend/webassembly/component/Components.scala
@@ -20,7 +20,7 @@ package org.scalajs.linker.backend.webassembly.component
  *  @see
  *    [[https://github.com/bytecodealliance/wasm-tools/blob/main/crates/wit-component/src/metadata.rs]]
  */
-private[backend] object Components {
+object Components {
 
   final class TypeID
   final class InstanceID
@@ -87,6 +87,9 @@ private[backend] object Components {
 
     final case class Own(id: TypeID, resource: TypeID) extends TypeDecl
     final case class Borrow(id: TypeID, resource: TypeID) extends TypeDecl
+
+    /** `(type $id <valtype>)` */
+    final case class ValTypeDef(id: TypeID, v: ValRef) extends TypeDecl
 
     /** `(alias export $instance "name" (type ...))` */
     final case class AliasExport(id: TypeID, instance: InstanceID, name: String) extends TypeDecl

--- a/linker/shared/src/main/scala/org/scalajs/linker/backend/webassembly/component/Flatten.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/backend/webassembly/component/Flatten.scala
@@ -107,6 +107,7 @@ object Flatten {
         flattenVariantCases(cases)
       case wit.OptionType(t)   => List(watpe.Int32) ++ flattenVariants(List(t))
       case _: wit.FlagsTypeRef => List(watpe.Int32)
+      case a: wit.AliasTypeRef => flattenType(ctx.dealiasWit(a))
       case _: wit.ResourceType => List(watpe.Int32)
     }
   }

--- a/linker/shared/src/main/scala/org/scalajs/linker/backend/webassembly/component/InstanceTypeEncoder.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/backend/webassembly/component/InstanceTypeEncoder.scala
@@ -1,0 +1,174 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
+package org.scalajs.linker.backend.webassembly.component
+
+import scala.collection.mutable
+
+import org.scalajs.ir.Names.ClassName
+import org.scalajs.ir.Trees.WitFunctionName
+import org.scalajs.ir.{WitScope, WitTypeDef, WitAliasDef}
+import org.scalajs.ir.WasmInterfaceTypes.{ExternType => _, _}
+
+import Components._
+import ComponentWorld._
+
+private[component] final class InstanceTypeEncoder(
+    scope: WitScope,
+    endpoints: List[ComponentWorld.Endpoint],
+    namedTypes: List[WitTypeDef],
+    definedAliases: List[WitAliasDef],
+    worldTypeIds: Map[(WitScope, String), TypeID],
+    typeDefByClass: Map[ClassName, WitTypeDef]
+) {
+  private val builder = new ComponentBuilder
+  private var localTypeIdx = Map.empty[ClassName, TypeID]
+  private var aliasIdx = Map.empty[String, TypeID]
+  private val resourceAliasNames = mutable.Set.empty[String]
+
+  private val localAliases =
+    collectAliasesForScope(scope, definedAliases, endpoints, namedTypes)
+
+  private val byAliasName = localAliases.map(a => a.name -> a).toMap
+  private val visitingAliases = mutable.Set.empty[String]
+
+  def encode(): List[Decl] = {
+    // Step 1: `use other.{T}` (named type or alias). `alias outer` the
+    // world's TypeID, then export unless a local WitAlias covers the name.
+    //   (alias outer 1 $t (type $error))
+    //   (export "error" (type $error))
+    importForeignUses()
+
+    // Step 2: Export local named types and aliases. Named types first
+    // then remaining aliases (`type foo = ...` only used by funcs).
+    //   record r1 { a: u8 }
+    //     (type $r1 (record (field "a" u8)))
+    //     (export "r1" (type $r1))
+    //   type option-u32 = option<u32>
+    //     (type $t (option u32))
+    //     (export "option-u32" (type $t))
+    exportLocalTypes()
+
+    // Step 3: Export funcs.
+    //   f: func(a: option-u32) -> option-u32
+    //     (export "f" (func (param "a" (type $t)) (result (type $t))))
+    exportFuncs()
+    builder.decls()
+  }
+
+  private def resolve(tpe: ValType): ValRef = {
+    // Alias ref -> alias definition (not dealias).
+    def lookupAlias(scope: WitScope, name: String): ValRef = {
+      val id = aliasIdx.getOrElse(name,
+          emitAlias(byAliasName.getOrElse(name,
+              throw new AssertionError(s"missing local WitAlias export `$name`"))))
+      if (resourceAliasNames.contains(name))
+        ValRef.Type(builder.addOwn(id))
+      else
+        ValRef.Type(id)
+    }
+    ComponentBuilder.resolveValRef(builder, tpe, localTypeIdx, lookupAlias)
+  }
+
+  private def importForeignUses(): Unit = {
+    def aliasOuter(owner: WitScope, name: String, exportType: Boolean): TypeID = {
+      val outerId = worldTypeIds.getOrElse((owner, name),
+          throw new AssertionError(
+              s"missing aliased foreign type for $owner/$name"))
+      val aliased = builder.addAliasOuter(outerId)
+      if (exportType) builder.addExportTypeEq(name, aliased) else aliased
+    }
+
+    val usedFromOtherIfaces = (
+      namedTypes.flatMap(namedTypeRefs) ++ endpoints.flatMap(endpointTypeRefs) ++
+        localAliases.flatMap(a => valTypeRefs(a.target))
+    ).distinct.filter { className =>
+      typeDefByClass(className).scope != scope
+    }
+    for (className <- usedFromOtherIfaces) {
+      val td = typeDefByClass(className)
+      val covered = localAliases.exists { a =>
+        a.name == td.name || valTypeRefs(a.target).contains(className)
+      }
+      localTypeIdx += className -> aliasOuter(td.scope, td.name, exportType = !covered)
+    }
+
+    val foreignAliases = (
+      endpoints.flatMap(endpointAliasRefs) ++
+        namedTypes.flatMap(namedTypeAliasRefs) ++
+        localAliases.flatMap(a => aliasTypeRefs(a.target))
+    ).filter(_.scope != scope).distinct
+    for (a <- foreignAliases)
+      aliasIdx += a.name -> aliasOuter(a.scope, a.name, exportType = true)
+  }
+
+  private def exportLocalTypes(): Unit = {
+    // Topo-sort so field typeidxs exist when bodies are encoded.
+    for (named <- ComponentBuilder.topologicalSortNamedTypes(namedTypes, localAliases)) {
+      named match {
+        case _: WitTypeDef.Resource =>
+          localTypeIdx += named.className -> builder.addExportResource(named.name)
+        case other =>
+          val defId = ComponentBuilder.addNamedTypeBody(builder, other, resolve)
+          localTypeIdx += other.className -> builder.addExportTypeEq(other.name, defId)
+      }
+    }
+    localAliases.foreach(emitAlias)
+  }
+
+  private def emitAlias(alias: WitAliasDef): TypeID = {
+    aliasIdx.get(alias.name) match {
+      case Some(id) => id
+      case None     =>
+        if (!visitingAliases.add(alias.name))
+          throw new AssertionError(s"cyclic WitAlias dependency ${alias.name}")
+        val defId = alias.target match {
+          case ResourceType(className, _) =>
+            resourceAliasNames += alias.name
+            localTypeIdx.getOrElse(className,
+                throw new AssertionError(
+                    s"missing foreign resource for WitAlias ${alias.name}"))
+          case other =>
+            resolve(other) match {
+              case ValRef.Type(id) => id
+              case prim            => builder.addValTypeDef(prim)
+            }
+        }
+        visitingAliases -= alias.name
+        val id = builder.addExportTypeEq(alias.name, defId)
+        aliasIdx += alias.name -> id
+        id
+    }
+  }
+
+  private def exportFuncs(): Unit = {
+    val resourceOrder = namedTypes.collect { case r: WitTypeDef.Resource => r.name }
+    val resourceFuncs = endpoints.filter(_.name.isResourceMethod).sortBy { func =>
+      val ord = resourceOrder.indexOf(func.name.resourceName.get)
+      if (ord < 0) resourceOrder.size else ord
+    }
+    val plainFuncs = endpoints.filter(_.name.isFunction)
+
+    val seenNames = mutable.Set.empty[String]
+    for (func <- resourceFuncs ::: plainFuncs) {
+      val exportName = WitFunctionName.wasmName(func.name)
+      if (seenNames.add(exportName)) {
+        val params = func.signature.params.map { p =>
+          p.name -> resolve(p.tpe)
+        }
+        val result = func.signature.resultType.map(resolve)
+        val ty = builder.addFuncType(params, result)
+        builder.addExport(exportName, ExternType.Func(ty))
+      }
+    }
+  }
+}

--- a/linker/shared/src/main/scala/org/scalajs/linker/backend/webassembly/component/WorldEncoder.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/backend/webassembly/component/WorldEncoder.scala
@@ -1,0 +1,376 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
+package org.scalajs.linker.backend.webassembly.component
+
+import scala.collection.mutable
+
+import org.scalajs.ir.Names.ClassName
+import org.scalajs.ir.Trees.WitFunctionName
+import org.scalajs.ir.{WitScope, WitTypeDef, WitAliasDef, ResourceOwnership}
+import org.scalajs.ir.WasmInterfaceTypes.{ExternType => _, _}
+
+import Components._
+import ComponentWorld._
+
+/** Encode one WIT world into componenttype decls. */
+private[component] final class WorldEncoder(world: ComponentWorld) {
+  private val builder = new ComponentBuilder
+  private val typeDefByClass = world.typeDefByClass
+
+  private val instanceIds: Map[WitScope.Interface, InstanceID] = {
+    world.imports.collect {
+      // We don't pre-allocate instance IDs for inline blocks or funcs, because WIT cannot
+      // import types/functions defined in inline interface.
+      case ComponentWorld.WorldItem.Interface(iface) =>
+        iface -> new InstanceID
+    }.toMap
+  }
+
+  private val typeIds: Map[(WitScope, String), TypeID] = {
+    val buf = mutable.Map.empty[(WitScope, String), TypeID]
+    def alloc(key: (WitScope, String)): TypeID =
+      buf.getOrElseUpdate(key, new TypeID)
+
+    for (td <- world.imports.collect { case WorldItem.Type(t) => t })
+      alloc((td.scope, td.name))
+    for (a <- world.imports.collect { case WorldItem.Alias(a) => a })
+      alloc((a.scope, a.name))
+    for (key <- (world.imports ++ world.exports).flatMap(foreignUses))
+      alloc(key)
+
+    buf.toMap
+  }
+
+  private val typeIdsByClass: Map[ClassName, TypeID] = {
+    typeDefByClass.flatMap { case (className, td) =>
+      typeIds.get((td.scope, td.name)).map(className -> _)
+    }
+  }
+
+  private val emittedAliasExports = mutable.Set.empty[(WitScope, String)]
+
+  def encode(): List[Decl] = {
+    // Write each world import, then each world export.
+    //
+    // When an import/export item uses a type defined in another interface (via `use`),
+    // bring the type onto the world first with `(alias export ...)`, then encode
+    // the item (which pulls it in via `alias outer`).
+    //
+    // For example, wasi:io/streams uses a type from wasi:io/error:
+    //
+    // {{{
+    // interface streams {
+    //   use wasi:io/error.{error};
+    //   write: func(e: error);
+    // }
+    //
+    // (import "wasi:io/error" (instance $error ...))
+    // (alias export $error "error" (type $t)) ;; $t = type from $error's exports
+    // (import "wasi:io/streams" (instance (type (instance
+    //   (alias outer 1 $t (type $error))  ;; $error = $t from 1 outer scope
+    //   (export "error" (type $error))
+    //   ...))))
+    // }}}
+    emitImports()
+    emitExports()
+    builder.decls()
+  }
+
+  /** Encode WIT `import` items into world componenttype import decls. */
+  private def emitImports(): Unit = {
+    for (item <- topologicalSortWorldItems(world.imports)) {
+      item match {
+        case ComponentWorld.WorldItem.Type(named) =>
+          encodeWorldType(named)
+        case ComponentWorld.WorldItem.Alias(alias) =>
+          aliasExports(item)
+          encodeWorldAlias(alias)
+        case ComponentWorld.WorldItem.Interface(iface) =>
+          // alias export imported types
+          // e.g. (alias export $error "error" (type $t))
+          aliasExports(item)
+          builder.addInstanceImport(iface.witId, instanceType(iface), instanceIds(iface))
+          // `(import "name" (instance ...))`
+        case ComponentWorld.WorldItem.Inline(inline) =>
+          aliasExports(item)
+          builder.addInstanceImport(inline.name, instanceType(inline))
+          // `(import "f" (func ...))`
+        case ComponentWorld.WorldItem.Func(func) =>
+          aliasExports(item)
+          builder.addImport(WitFunctionName.wasmName(func.name),
+              ExternType.Func(bareFunc(func)))
+      }
+    }
+  }
+
+  private def emitExports(): Unit = {
+    for (item <- topologicalSortWorldItems(world.exports)) {
+      item match {
+        // `(export "ns:pkg/iface" (instance ...))`
+        case ComponentWorld.WorldItem.Interface(iface) =>
+          aliasExports(item)
+          builder.addExport(iface.witId, ExternType.Instance(instanceType(iface)))
+          // `(export "name" (instance ...))`
+        case ComponentWorld.WorldItem.Inline(inline) =>
+          aliasExports(item)
+          builder.addExport(inline.name, ExternType.Instance(instanceType(inline)))
+          // `(export "f" (func ...))`
+        case ComponentWorld.WorldItem.Func(func) =>
+          aliasExports(item)
+          builder.addExport(WitFunctionName.wasmName(func.name),
+              ExternType.Func(bareFunc(func)))
+        case _:ComponentWorld.WorldItem.Type | _:ComponentWorld.WorldItem.Alias =>
+          throw new AssertionError("world types are encoded as imports")
+      }
+    }
+  }
+
+  /** World-level named type: Root typedef or `use iface.{T}`. */
+  private def encodeWorldType(named: WitTypeDef): Unit = {
+    val id = typeIdsByClass.getOrElse(named.className,
+        throw new AssertionError(
+            s"missing world type ${WitScope.importModuleName(named.scope)}/${named.name}"))
+    named.scope match {
+      case WitScope.Root =>
+        named match {
+          case _: WitTypeDef.Resource =>
+            // `(import "$name" (type $id (sub resource)))`
+            builder.addImportTypeResource(id, named.name)
+          case other =>
+            val body = ComponentBuilder.addNamedTypeBody(builder, other, resolve)
+            // `(import "$name" (type $id (eq $body)))`
+            builder.addImportTypeEq(id, other.name, body)
+        }
+      case _: WitScope.Interface =>
+        encodeWorldUse(named, id)
+      case _: WitScope.Inline =>
+        throw new AssertionError(
+            s"inline type ${named.name} cannot be a world-level type")
+    }
+  }
+
+  // `(alias export $inst "T" $alias)` then `(import "T" (type $id (eq $alias)))`.
+  private def encodeWorldUse(named: WitTypeDef, id: TypeID): Unit = {
+    val owner = interfaceOf(named.className).getOrElse(
+        throw new AssertionError(
+            s"world use ${named.name} is not from a package interface"))
+    val inst = instanceIds.getOrElse(owner,
+        throw new AssertionError(
+            s"missing imported dependency interface ${owner.witId} " +
+            s"before aliasing ${named.name}"))
+    val aliased = builder.addAliasExport(inst, named.name)
+    emittedAliasExports += ((owner, named.name))
+    builder.addImportTypeEq(id, named.name, aliased)
+  }
+
+  private def encodeWorldAlias(alias: WitAliasDef): Unit = {
+    val id = typeIds.getOrElse((alias.scope, alias.name),
+        throw new AssertionError(
+            s"missing world type ${alias.scope}/${alias.name}"))
+    alias.scope match {
+      case WitScope.Root =>
+        val defId = alias.target match {
+          case ResourceType(className, _) =>
+            typeIdsByClass.getOrElse(className,
+                throw new AssertionError(
+                    s"missing foreign resource for WitAlias ${alias.name}"))
+          case other =>
+            resolve(other) match {
+              case ValRef.Type(tid) => tid
+              case prim             => builder.addValTypeDef(prim)
+            }
+        }
+        builder.addImportTypeEq(id, alias.name, defId)
+      case _:WitScope.Interface | _:WitScope.Inline =>
+        throw new AssertionError(
+            s"world-level WitAlias ${alias.name} must be Root, got ${alias.scope}")
+    }
+  }
+
+  private def topologicalSortWorldItems(
+      items: List[ComponentWorld.WorldItem]): List[ComponentWorld.WorldItem] = {
+    val interfaceItems = items.collect {
+      case i @ ComponentWorld.WorldItem.Interface(iface) => iface -> i
+    }.toMap
+    val namedItems = items.collect {
+      case t @ ComponentWorld.WorldItem.Type(named) => (named.scope, named.name) -> t
+      case a @ ComponentWorld.WorldItem.Alias(al)   => (al.scope, al.name) -> a
+    }.toMap
+    val ordered = mutable.LinkedHashSet.empty[ComponentWorld.WorldItem]
+    val visiting = mutable.Set.empty[ComponentWorld.WorldItem]
+
+    def visit(item: ComponentWorld.WorldItem): Unit = {
+      val self: Option[WitScope] = item match {
+        case ComponentWorld.WorldItem.Interface(iface) => Some(iface)
+        case ComponentWorld.WorldItem.Inline(inline)   => Some(inline)
+        case _                                         => None
+      }
+      if (ordered.contains(item)) {
+        // skip
+      } else if (!visiting.add(item)) {
+        throw new AssertionError("cyclic world item dependency")
+      } else {
+        item match {
+          case ComponentWorld.WorldItem.Type(named) =>
+            named.scope match {
+              case iface: WitScope.Interface =>
+                interfaceItems.get(iface).foreach { ifaceItem =>
+                  if (!visiting.contains(ifaceItem)) visit(ifaceItem)
+                }
+              case _ =>
+            }
+          case _ =>
+        }
+        for ((scope, name) <- namedKeysUsedBy(item)) {
+          if (self.forall(_ != scope)) {
+            namedItems.get((scope, name)).foreach { dep =>
+              if (dep != item) visit(dep)
+            }
+          }
+          scope match {
+            case iface: WitScope.Interface if self.forall(_ != iface) =>
+              interfaceItems.get(iface).foreach(visit)
+            case _ =>
+          }
+        }
+        visiting -= item
+        ordered += item
+      }
+    }
+
+    items.foreach(visit)
+    ordered.toList
+  }
+
+  // `(alias export $id "T" $inst)` for each first-seen `use ns:pkg/iface.{T}`.
+  private def aliasExports(item: ComponentWorld.WorldItem): Unit = {
+    for ((scope, name) <- foreignUses(item))
+      aliasExport(scope, name)
+  }
+
+  private def aliasExport(scope: WitScope, name: String): Unit = {
+    if (emittedAliasExports.add((scope, name))) {
+      val owner = scope match {
+        case iface: WitScope.Interface => iface
+        case other                     =>
+          throw new AssertionError(
+              s"foreign type $name is not from a package interface: $other")
+      }
+      val inst = instanceIds.getOrElse(owner,
+          throw new AssertionError(
+              s"missing imported dependency interface ${owner.witId} " +
+              s"before aliasing $name"))
+      val id = typeIds.getOrElse((scope, name),
+          throw new AssertionError(
+              s"missing world TypeID for $scope/$name"))
+      builder.addAliasExport(id, inst, name)
+    }
+  }
+
+  private def namedKey(className: ClassName): (WitScope, String) = {
+    val td = typeDefByClass(className)
+    (td.scope, td.name)
+  }
+
+  private def keysFromVal(tpe: ValType): List[(WitScope, String)] =
+    valTypeRefs(tpe).map(namedKey) ++ aliasTypeRefs(tpe).map(a => (a.scope, a.name))
+
+  private def namedKeysUsedBy(item: ComponentWorld.WorldItem): List[(WitScope, String)] = {
+    val keys = item match {
+      case ComponentWorld.WorldItem.Interface(iface) =>
+        keysFromScope(iface)
+      case ComponentWorld.WorldItem.Inline(inline) =>
+        keysFromScope(inline)
+      case ComponentWorld.WorldItem.Func(func) =>
+        endpointTypeRefs(func).map(namedKey) ++
+        endpointAliasRefs(func).map(a => (a.scope, a.name))
+      case ComponentWorld.WorldItem.Type(named) =>
+        namedTypeRefs(named).map(namedKey) ++
+        namedTypeAliasRefs(named).map(a => (a.scope, a.name))
+      case ComponentWorld.WorldItem.Alias(alias) =>
+        keysFromVal(alias.target)
+    }
+    keys.distinct
+  }
+
+  private def keysFromScope(scope: WitScope): List[(WitScope, String)] = {
+    world.typesFor(scope).flatMap { named =>
+      namedTypeRefs(named).map(namedKey) ++
+      namedTypeAliasRefs(named).map(a => (a.scope, a.name))
+    } ++
+    world.endpointsFor(scope).flatMap { func =>
+      endpointTypeRefs(func).map(namedKey) ++
+      endpointAliasRefs(func).map(a => (a.scope, a.name))
+    } ++
+    world.aliasesFor(scope).flatMap(a => keysFromVal(a.target))
+  }
+
+  /** Types/aliases from other interfaces that `item` references (`use`). */
+  private def foreignUses(item: ComponentWorld.WorldItem): List[(WitScope, String)] = {
+    val self = item match {
+      case ComponentWorld.WorldItem.Interface(iface) => iface
+      case ComponentWorld.WorldItem.Inline(inline)   => inline
+      case ComponentWorld.WorldItem.Func(func)       => func.scope
+      case ComponentWorld.WorldItem.Type(named)      => named.scope
+      case ComponentWorld.WorldItem.Alias(alias)     => alias.scope
+    }
+    namedKeysUsedBy(item).filter { case (scope, _) =>
+      scope != self && (scope match {
+        case _: WitScope.Interface => true
+        case _                     => false
+      })
+    }
+  }
+
+  private def interfaceOf(className: ClassName): Option[WitScope.Interface] = {
+    typeDefByClass(className).scope match {
+      case iface: WitScope.Interface => Some(iface)
+      case _                         => None
+    }
+  }
+
+  private def resolve(tpe: ValType): ValRef = {
+    def lookupAlias(scope: WitScope, name: String): ValRef = {
+      val id = typeIds.getOrElse((scope, name),
+          throw new AssertionError(s"missing world WitAlias for $scope/$name"))
+      world.aliasMap.get((scope, name)) match {
+        case Some(ResourceType(_, ownership)) =>
+          ownership match {
+            case ResourceOwnership.Own =>
+              ValRef.Type(builder.addOwn(id))
+            case ResourceOwnership.Borrow =>
+              ValRef.Type(builder.addBorrow(id))
+          }
+        case Some(target) =>
+          resolve(target)
+        case None =>
+          ValRef.Type(id)
+      }
+    }
+    ComponentBuilder.resolveValRef(builder, tpe, typeIdsByClass, lookupAlias)
+  }
+
+  private def bareFunc(func: ComponentWorld.Endpoint): TypeID = {
+    val params = func.signature.params.map { p =>
+      p.name -> resolve(p.tpe)
+    }
+    val result = func.signature.resultType.map(resolve)
+    builder.addFuncType(params, result)
+  }
+
+  private def instanceType(scope: WitScope): TypeID = {
+    builder.addInstanceType(ComponentBuilder.encodeInstanceType(
+        scope, world.endpointsFor(scope), world.typesFor(scope),
+        world.aliasesFor(scope), typeIds, typeDefByClass))
+  }
+}

--- a/linker/shared/src/main/scala/org/scalajs/linker/checker/ClassDefChecker.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/checker/ClassDefChecker.scala
@@ -1271,6 +1271,7 @@ object ClassDefChecker {
       exportedMembers,
       jsNativeMembers,
       witTypeDef,
+      witAliases,
       witNativeMembers,
       topLevelExportDefs = Nil
     )(optimizerHints)

--- a/linker/shared/src/main/scala/org/scalajs/linker/frontend/BaseLinker.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/frontend/BaseLinker.scala
@@ -195,6 +195,7 @@ private[frontend] object BaseLinker {
         jsMethodProps,
         jsNativeMembers,
         classDef.witTypeDef,
+        classDef.witAliases,
         wasmwitNativeMembers,
         classDef.optimizerHints,
         classDef.pos,

--- a/linker/shared/src/main/scala/org/scalajs/linker/frontend/Desugarer.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/frontend/Desugarer.scala
@@ -95,6 +95,7 @@ final class Desugarer(config: CommonPhaseConfig, checkIR: Boolean) {
         exportedMembers = newExportedMembers,
         jsNativeMembers,
         witTypeDef,
+        witAliases,
         witNativeMembers,
         optimizerHints,
         pos,

--- a/linker/shared/src/main/scala/org/scalajs/linker/frontend/LambdaSynthesizer.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/frontend/LambdaSynthesizer.scala
@@ -138,7 +138,8 @@ private[linker] object LambdaSynthesizer {
     new ClassInfo(className, ClassKind.Class, Some(SyntheticClassKind.Lambda(descriptor)),
         nonExistent = false, Some(descriptor.superClass), descriptor.interfaces,
         jsNativeLoadSpec = None, referencedFieldClasses = Map.empty, methodInfos,
-        jsNativeMembers = Map.empty, witTypeDef = None, witNativeMembers = Map.empty,
+        jsNativeMembers = Map.empty, witTypeDef = None, witAliases = None,
+        witNativeMembers = Map.empty,
         jsMethodProps = Nil, topLevelExports = Nil)
   }
 

--- a/linker/shared/src/main/scala/org/scalajs/linker/frontend/optimizer/IncOptimizer.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/frontend/optimizer/IncOptimizer.scala
@@ -190,6 +190,7 @@ final class IncOptimizer private[optimizer] (config: CommonPhaseConfig, collOps:
       interface.optimizedExportedMembers(),
       linkedClass.jsNativeMembers,
       linkedClass.witTypeDef,
+      linkedClass.witAliases,
       linkedClass.witNativeMembers,
       newTopLevelExports
     )(linkedClass.optimizerHints)(linkedClass.pos)

--- a/linker/shared/src/main/scala/org/scalajs/linker/standard/LinkedClass.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/standard/LinkedClass.scala
@@ -13,7 +13,7 @@
 package org.scalajs.linker.standard
 
 import org.scalajs.ir.Trees._
-import org.scalajs.ir.{ClassKind, Position, Version, WitTypeDef}
+import org.scalajs.ir.{ClassKind, Position, Version, WitTypeDef, WitAliasDef}
 import org.scalajs.ir.Names.{ClassName, FieldName, MethodName}
 
 /** A ClassDef after linking.
@@ -50,6 +50,7 @@ final class LinkedClass(
     val exportedMembers: List[JSMethodPropDef],
     val jsNativeMembers: List[JSNativeMemberDef],
     val witTypeDef: Option[WitTypeDef],
+    val witAliases: List[WitAliasDef],
     val witNativeMembers: List[WitNativeMemberDef],
     val optimizerHints: OptimizerHints,
     val pos: Position,

--- a/linker/shared/src/test/scala/org/scalajs/linker/backend/webassembly/component/ComponentBuilderTest.scala
+++ b/linker/shared/src/test/scala/org/scalajs/linker/backend/webassembly/component/ComponentBuilderTest.scala
@@ -40,7 +40,7 @@ class ComponentBuilderTest {
     val typeDefByClass = Map(f1Class -> f1, r1Class -> r1)
     // r1 depends on f1, but r1 comes first
     val decls = ComponentBuilder.encodeInstanceType(
-        scope, Nil, List(r1, f1), Map.empty, typeDefByClass)
+        scope, Nil, List(r1, f1), Nil, Map.empty, typeDefByClass)
 
     val exportedNames = decls.collect {
       case Decl.ExportTypeEq(_, name, _) => name

--- a/linker/shared/src/test/scala/org/scalajs/linker/testutils/TestIRBuilder.scala
+++ b/linker/shared/src/test/scala/org/scalajs/linker/testutils/TestIRBuilder.scala
@@ -69,7 +69,7 @@ object TestIRBuilder {
     val notHashed = ClassDef(ClassIdent(className), NON, kind, jsClassCaptures,
         superClass.map(ClassIdent(_)), interfaces.map(ClassIdent(_)),
         jsSuperClass, jsNativeLoadSpec, fields, methods, jsConstructor,
-        jsMethodProps, jsNativeMembers, witTypeDef, witNativeMembers,
+        jsMethodProps, jsNativeMembers, witTypeDef, witAliases = Nil, witNativeMembers,
         topLevelExportDefs)(
         optimizerHints)
     Hashers.hashClassDef(notHashed)

--- a/project/JavalibIRCleaner.scala
+++ b/project/JavalibIRCleaner.scala
@@ -191,7 +191,7 @@ final class JavalibIRCleaner(baseDirectoryURI: URI) {
       val preprocessedTree = ClassDef(name, originalName, kind, jsClassCaptures,
           superClass, newInterfaces, jsSuperClass, jsNativeLoadSpec, fields,
           newMethods, jsConstructor, jsMethodProps, jsNativeMembers,
-          witTypeDef, witNativeMembers, topLevelExportDefs)(
+          witTypeDef, witAliases, witNativeMembers, topLevelExportDefs)(
           optimizerHints)(pos)
 
       // Only validate the hierarchy; do not transform
@@ -330,6 +330,7 @@ final class JavalibIRCleaner(baseDirectoryURI: URI) {
         classDef.jsMethodProps,
         classDef.jsNativeMembers,
         classDef.witTypeDef,
+        classDef.witAliases,
         classDef.witNativeMembers,
         classDef.topLevelExportDefs
       )(classDef.optimizerHints)(classDef.pos)


### PR DESCRIPTION
Previously, scala-wasm didn't emit named alias types. For WIT functions that uses type aliases, Scala just dealias types at the boundary. In the example below, Scala emits `option<u32> -> option<u32>` instead of `option-u32 -> option-u32`.

```wit
type option-u32 = option<u32>;
roundtrip-option-u32: func(a: option-u32) -> option-u32;
```

At the canonical ABI, it's alright, ABI doesn't care type aliases.
However, at the component instance type checking, type aliases are one of the `type export` from instance type. We need to export those type aliases as a named type in order to linking with other components with type aliases.

**fix**

This commit introduces `@WitAlias` annotation for a type alias.
The Scala code corresponds to the WIT above looks like:

```scala
@Witalias(WitScope.unversioned("component", "testing", "tests"), "option-u32")
type OptionU32 = ju.OptionalUInt]

@WitImport(WitScope("component", "testing", "tests"), "roundtrip-option-u32")
def roundtripOptionU32(a: OptionU32): OptionU32 = wit.native
```

 Also, renamed imports `use test.{float as Foo}` is also expected to be bound as `@WitAlias type Foo = test.Float`.

At IR level, `ClassDef` has a new field `val witAliases: List[WitAliasDef]` which contains a list of WIT type aliases defined in the class.

At the linker,
- canonical ABI just dealias the type aliases
- component binary builder generates component binary that honors those type alias information.
 